### PR TITLE
HttpClientImpl.requestAbs() losing the query params

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -268,7 +268,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
   @Override
   public HttpClientRequest requestAbs(HttpMethod method, String absoluteURI) {
     URL url = parseUrl(absoluteURI);
-    return doRequest(method, url.getHost(), url.getPort(), url.getPath(), null);
+    return doRequest(method, url.getHost(), url.getPort(), url.getFile(), null);
   }
 
   @Override

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -1007,10 +1007,13 @@ public class HttpTest extends HttpTestBase {
   }
 
   private void testSimpleRequest(String uri, HttpMethod method, HttpClientRequest request) {
-    String path = uri.indexOf('?') == -1 ? uri : uri.substring(0, uri.indexOf('?'));
+    int index = uri.indexOf('?');
+    String path = index == -1 ? uri : uri.substring(0, index);
+    String query = index == -1 ? null : uri.substring(index + 1);
     server.requestHandler(req -> {
       assertEquals(path, req.path());
       assertEquals(method, req.method());
+      assertEquals(query, req.query());
       req.response().end();
     });
 


### PR DESCRIPTION
`HttpClientImpl.request()` was losing the query params if passing a string absoluteURI.  

From `URL getFile()` Java Docs:

_Gets the file name of this URL. The returned file portion will be the same as getPath(), plus the concatenation of the value of getQuery(), if any. If there is no query portion, this method and getPath() will return identical results._
