### PR TITLE
Fix sendHead() in http client request

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClientRequest.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClientRequest.java
@@ -189,8 +189,8 @@ public class DefaultHttpClientRequest implements HttpClientRequest {
         writeHead();
       }
     } else {
-      connect();
       writeHead = true;
+      connect();
     }
     return this;
   }


### PR DESCRIPTION
If the underlying connection is already establish (e.g. by a previous GET request with keep alive), the connected() callback is invoked in the very same thread as sendHead(). Since the writeHead flag is set after the connect the HTTP header is actually never written.
ATM the only workaround is to call sendHead() twice (which is very ugly).