### PR TITLE
increase event bus bridge ping interval to 20s

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
@@ -47,7 +47,7 @@ public class EventBusBridge implements Handler<SockJSSocket> {
   private static final long DEFAULT_REPLY_TIMEOUT = 30 * 1000;
   private static final int DEFAULT_MAX_ADDRESS_LENGTH = 200;
   private static final int DEFAULT_MAX_HANDLERS_PER_SOCKET = 1000;
-  private static final long DEFAULT_PING_TIMEOUT = 10 * 1000;
+  private static final long DEFAULT_PING_TIMEOUT = 20 * 1000;
 
   private final Map<String, Auth> authCache = new HashMap<>();
   private final Map<SockJSSocket, SockInfo> sockInfos = new HashMap<>();


### PR DESCRIPTION
We noticed unexpected connections closed using Safari and Firefox + OS X

In order to save battery life, these browsers increase minimal setInterval to 1000ms (just like Chrome).
But in some case, this interval in increase to 10s. For instance, if your browser is not in your current desktop.

You can find an example that demonstrate the issue here: https://github.com/davidphan/js-interval