### PR TITLE
update to io.vertx~lang-scala_2.11~1.1.0-M1

### DIFF
--- a/vertx-platform/src/main/resources/default-langs.properties
+++ b/vertx-platform/src/main/resources/default-langs.properties
@@ -25,7 +25,7 @@ rhino=io.vertx~lang-rhino~2.1.1:org.vertx.java.platform.impl.RhinoVerticleFactor
 jruby=io.vertx~lang-jruby~2.1.0-final:org.vertx.java.platform.impl.JRubyVerticleFactory
 groovy=io.vertx~lang-groovy~2.1.1-final:org.vertx.groovy.platform.impl.GroovyVerticleFactory
 jython=io.vertx~lang-jython~2.1.1:org.vertx.java.platform.impl.JythonVerticleFactory
-scala=io.vertx~lang-scala~1.0.0:org.vertx.scala.platform.impl.ScalaVerticleFactory
+scala=io.vertx~lang-scala_2.11~1.1.0-M1:org.vertx.scala.platform.impl.ScalaVerticleFactory
 clojure=io.vertx~lang-clojure~1.0.4:io.vertx.lang.clojure.ClojureVerticleFactory
 ceylon=io.vertx~lang-ceylon~1.0.1:org.vertx.ceylon.platform.impl.CeylonVerticleFactory
 


### PR DESCRIPTION
Updating `scala` requirement to `io.vertx~lang-scala_2.11~1.1.0-M1:org.vertx.scala.platform.impl.ScalaVerticleFactory`. With the old default it seems there is no `mod-mysql-postgresql` version module that would work.
Reference: https://github.com/vert-x/mod-mysql-postgresql/issues/51