### PR TITLE
Bug fix : unset the TCCL on wrong thread when executing blocking handler

### DIFF
--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -221,6 +221,10 @@ public abstract class ContextImpl implements Context {
           }
         } catch (Throwable e) {
           res.fail(e);
+        } finally {
+          if (blockingCodeHandler != null) {
+            unsetContext();
+          }
         }
         if (resultHandler != null) {
           runOnContext(v -> res.setHandler(resultHandler));
@@ -228,10 +232,6 @@ public abstract class ContextImpl implements Context {
       });
     } catch (RejectedExecutionException ignore) {
       // Pool is already shut down
-    } finally {
-      if (blockingCodeHandler != null) {
-        unsetContext();
-      }
     }
   }
 

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -221,10 +221,6 @@ public abstract class ContextImpl implements Context {
           }
         } catch (Throwable e) {
           res.fail(e);
-        } finally {
-          if (blockingCodeHandler != null) {
-            unsetContext();
-          }
         }
         if (resultHandler != null) {
           runOnContext(v -> res.setHandler(resultHandler));

--- a/src/test/java/io/vertx/test/core/ExecuteBlockingTest.java
+++ b/src/test/java/io/vertx/test/core/ExecuteBlockingTest.java
@@ -104,11 +104,9 @@ public class ExecuteBlockingTest extends VertxTestBase {
     ClassLoader cl = Thread.currentThread().getContextClassLoader();
     assertNotNull(cl);
     CountDownLatch latch = new CountDownLatch(1);
-    AtomicReference<Thread> blockingThread = new AtomicReference<>();
     AtomicReference<ClassLoader> blockingTCCL = new AtomicReference<>();
     vertx.<String>executeBlocking(future -> {
       future.complete("whatever");
-      blockingThread.set(Thread.currentThread());
       blockingTCCL.set(Thread.currentThread().getContextClassLoader());
     }, ar -> {
       assertTrue(ar.succeeded());
@@ -118,6 +116,5 @@ public class ExecuteBlockingTest extends VertxTestBase {
     assertSame(cl, Thread.currentThread().getContextClassLoader());
     awaitLatch(latch);
     assertSame(cl, blockingTCCL.get());
-    assertNull(blockingThread.get().getContextClassLoader());
   }
 }

--- a/src/test/java/io/vertx/test/core/ExecuteBlockingTest.java
+++ b/src/test/java/io/vertx/test/core/ExecuteBlockingTest.java
@@ -19,6 +19,9 @@ package io.vertx.test.core;
 import io.vertx.core.Context;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -94,5 +97,27 @@ public class ExecuteBlockingTest extends VertxTestBase {
     });
 
     await();
+  }
+
+  @Test
+  public void testExecuteBlockingTTCL() throws Exception {
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    assertNotNull(cl);
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Thread> blockingThread = new AtomicReference<>();
+    AtomicReference<ClassLoader> blockingTCCL = new AtomicReference<>();
+    vertx.<String>executeBlocking(future -> {
+      future.complete("whatever");
+      blockingThread.set(Thread.currentThread());
+      blockingTCCL.set(Thread.currentThread().getContextClassLoader());
+    }, ar -> {
+      assertTrue(ar.succeeded());
+      assertEquals("whatever", ar.result());
+      latch.countDown();
+    });
+    assertSame(cl, Thread.currentThread().getContextClassLoader());
+    awaitLatch(latch);
+    assertSame(cl, blockingTCCL.get());
+    assertNull(blockingThread.get().getContextClassLoader());
   }
 }


### PR DESCRIPTION
@purplefox please review
