### PR TITLE
Check the message body for sessionID, not the message JSON itself

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/EventBusBridge.java
@@ -374,7 +374,12 @@ public class EventBusBridge implements Handler<SockJSSocket> {
     }
     if (curMatch.doesMatch) {
       if (curMatch.requiresAuth) {
-        final String sessionID = message.getString("sessionID");
+        String sessionIdString = null;
+        JsonObject messageBody = message.getObject("body");
+        if (messageBody != null) {
+          sessionIdString = messageBody.getString("sessionID");
+        }
+        final String sessionID = sessionIdString;
         if (sessionID != null) {
           authorise(message, sessionID, new AsyncResultHandler<Boolean>() {
             public void handle(AsyncResult<Boolean> res) {


### PR DESCRIPTION
During message reply handling, vert.x Event bus bridge decides if the reply contains authentication data (sessionID) which it should cache and then keep using for that socket. The reply is stored as "sessionID" variable in the reply body JSON object.

The code however checks for presence of this property in the message itself (message contains properties such as "type":"send", "address":"xxxxx" etc, not the message body itself. Therefore, such session ID in a reply is never found.

This patch fixes the issue, so that vert.x searches for the session ID in the message body.

Signed-off-by: Michal Boska <michal@boska.me>