### PR TITLE
Resolved API/impl dependency for json module.

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonServices.java
+++ b/src/main/java/io/vertx/core/json/JsonServices.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.json;
+
+import io.vertx.core.ServiceHelper;
+
+import java.util.Objects;
+
+/**
+ * Abstraction for Json related functionality used by the API. Implementations must register using the
+ * {@link io.vertx.core.ServiceHelper} mechanism (by default based on {@link java.util.ServiceLoader}.
+ */
+public interface JsonServices {
+    /** The current instance loaded. */
+    static final JsonServices INSTANCE = ServiceHelper.loadFactory(JsonServices.class);
+
+    /**
+     * Accessor for getting the singleton instane.
+     * @return the services instance, not null.
+     */
+    public static JsonServices of(){
+        return Objects.requireNonNull(INSTANCE, "No JsonServices loaded.");
+    }
+
+    /**
+     * Checks the given object and optionally creates a copy of it.
+     * @param val the object to check.
+     * @param copy flag, if a copy should be created.
+     * @return the instance passed, or copied.
+     */
+    Object checkAndCopy(Object val, boolean copy);
+
+    /**
+     * Encodes the given object.
+     * @param obj the instance to encode, not null.
+     * @return the encoded value
+     * @throws io.vertx.core.json.EncodeException
+     */
+    String encode(Object obj) throws EncodeException;
+
+    /**
+     * Encodes the given object, prettifying the output for better readability.
+     * @param obj the instance to encode, not null.
+     * @return the encoded value
+     * @throws io.vertx.core.json.EncodeException
+     */
+    String encodePrettily(Object obj) throws EncodeException;
+
+    /**
+     * Decodes the given Json input into the required target type.
+     * @param json the JSON input
+     * @param clazz the target type
+     * @param <T> the type to be returned.
+     * @return the decoded instance, not null.
+     * @throws io.vertx.core.json.DecodeException
+     */
+    <T> T decodeValue(String json, Class<?> clazz) throws DecodeException;
+}

--- a/src/main/java/io/vertx/core/json/impl/JacksonJsonServices.java
+++ b/src/main/java/io/vertx/core/json/impl/JacksonJsonServices.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.json.impl;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.EncodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonServices;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author Anatole Tresch
+ */
+public class JacksonJsonServices implements JsonServices {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ObjectMapper prettyMapper = new ObjectMapper();
+
+    public JacksonJsonServices() {
+        // Non-standard JSON but we allow C style comments in our JSON
+        mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+
+        prettyMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        prettyMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(JsonObject.class, new JsonObjectSerializer());
+        module.addSerializer(JsonArray.class, new JsonArraySerializer());
+        mapper.registerModule(module);
+        prettyMapper.registerModule(module);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object checkAndCopy(Object val, boolean copy) {
+        if (val == null) {
+            // OK
+        } else if (val instanceof Number && !(val instanceof BigDecimal)) {
+            // OK
+        } else if (val instanceof Boolean) {
+            // OK
+        } else if (val instanceof String) {
+            // OK
+        } else if (val instanceof CharSequence) {
+            val = val.toString();
+        } else if (val instanceof JsonObject) {
+            if (copy) {
+                val = ((JsonObject) val).copy();
+            }
+        } else if (val instanceof JsonArray) {
+            if (copy) {
+                val = ((JsonArray) val).copy();
+            }
+        } else if (val instanceof Map) {
+            if (copy) {
+                val = (new JsonObject((Map) val)).copy();
+            } else {
+                val = new JsonObject((Map) val);
+            }
+        } else if (val instanceof List) {
+            if (copy) {
+                val = (new JsonArray((List) val)).copy();
+            } else {
+                val = new JsonArray((List) val);
+            }
+        } else if (val instanceof byte[]) {
+            val = Base64.getEncoder().encodeToString((byte[]) val);
+        } else {
+            throw new IllegalStateException("Illegal type in JsonObject: " + val.getClass());
+        }
+        return val;
+    }
+
+    @Override
+    public String encode(Object obj) throws EncodeException {
+        try {
+            return mapper.writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String encodePrettily(Object obj) throws EncodeException {
+        try {
+            return prettyMapper.writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T decodeValue(String str, Class<?> clazz) throws DecodeException {
+        try {
+            return (T) mapper.readValue(str, clazz);
+        } catch (Exception e) {
+            throw new DecodeException("Failed to decode:" + e.getMessage());
+        }
+    }
+
+    private static class JsonObjectSerializer extends JsonSerializer<JsonObject> {
+        @Override
+        public void serialize(JsonObject value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+            jgen.writeObject(value.getMap());
+        }
+    }
+
+    private static class JsonArraySerializer extends JsonSerializer<JsonArray> {
+        @Override
+        public void serialize(JsonArray value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+            jgen.writeObject(value.getList());
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/io.vertx.core.json.JsonServices
+++ b/src/main/resources/META-INF/services/io.vertx.core.json.JsonServices
@@ -1,0 +1,1 @@
+io.vertx.core.json.impl.JacksonJsonServices


### PR DESCRIPTION
Signed-off-by: atsticks <atsticks@gmail.com>
There were circular dependencies between the json's api part and its impl. In most other modules these deps are resolved, so I resolved it here similarly by adding a JSonServices interface, registered using the ServiceLoader component. As an alternative one could refactor the JSON package completely to a util module (with the disadvantage of a hardcoded dep to the Jackson framework, of course).
The change should be backward compatible (I deprecated the former impl/Json class because now the JSonServices should be used instead of, where needed).
Nevertheless the API is relatively weak from an API design perspective. Maybe we should think on changing method signatures on JSonServices to be more explicit (Object can be anything). Feel free to comment, adapt etc.