### PR TITLE
more informative error message for ReplyException

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/ReplyException.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyException.java
@@ -81,7 +81,4 @@ public class ReplyException extends VertxException {
     return failureCode;
   }
 
-  private static String failure(ReplyFailure failureType, int failureCode, String message) {
-    return "(" + failureType + "," + failureCode + ") " + (message != null ? message : ""); 
-  }
 }

--- a/src/main/java/io/vertx/core/eventbus/ReplyException.java
+++ b/src/main/java/io/vertx/core/eventbus/ReplyException.java
@@ -39,9 +39,9 @@ public class ReplyException extends VertxException {
    * @param message  the failure message
    */
   public ReplyException(ReplyFailure failureType, int failureCode, String message) {
-    super(message);
-    this.failureType = failureType;
-    this.failureCode = failureCode;
+      super("(" + failureType + "," + failureCode + ") " + (message != null ? message : ""));
+      this.failureType = failureType;
+      this.failureCode = failureCode;
   }
 
   /**
@@ -51,9 +51,7 @@ public class ReplyException extends VertxException {
    * @param message  the failure message
    */
   public ReplyException(ReplyFailure failureType, String message) {
-    super(message);
-    this.failureType = failureType;
-    this.failureCode = -1;
+    this(failureType, -1, message);
   }
 
   /**
@@ -62,9 +60,7 @@ public class ReplyException extends VertxException {
    * @param failureType  the failure type
    */
   public ReplyException(ReplyFailure failureType) {
-    super((String)null);
-    this.failureType = failureType;
-    this.failureCode = -1;
+    this(failureType, -1, null);
   }
 
   /**
@@ -85,4 +81,7 @@ public class ReplyException extends VertxException {
     return failureCode;
   }
 
+  private static String failure(ReplyFailure failureType, int failureCode, String message) {
+    return "(" + failureType + "," + failureCode + ") " + (message != null ? message : ""); 
+  }
 }


### PR DESCRIPTION
Nice stack trace and error message. Makes it easier to spot the problem.
Example:
io.vertx.core.eventbus.ReplyException: (NO_HANDLERS,100) dang!
Signed-off-by: Jochen Bedersdorfer <beders@yahoo.com>