### PR TITLE
Update Jackson to 2.5.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,8 @@ group=io.vertx
 
 # dependency versions
 hazelcastVersion=3.2.3
-jacksonCoreVersion=2.2.2
-jacksonDatabindVersion=2.2.2
+jacksonCoreVersion=2.5.2
+jacksonDatabindVersion=2.5.2
 nettyVersion=4.0.21.Final
 log4jVersion=1.2.16
 slf4jVersion=1.6.2


### PR DESCRIPTION
From what we've seen module jars can not override the core runtime jars. We are using vertx-mod-jersey on top of Vertx, which uses jackson for serialization and deserialization. Unfortunately the 2.2 Version has some issues when it comes to polymorphic serialization.
It would be really great if we could have a 2.1.6 Version of Vertx with the updated libraries.