### PR TITLE
BZ465510: new NetClientOptions() and new NetClientOptions(new JsonObject...

### DIFF
--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -106,7 +106,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     this.ssl = other.isSsl();
     this.keyCertOptions = other.getKeyCertOptions() != null ? other.getKeyCertOptions().clone() : null;
     this.trustOptions = other.getTrustOptions() != null ? other.getTrustOptions().clone() : null;
-    this.enabledCipherSuites = other.getEnabledCipherSuites() == null ? null : new HashSet<>(other.getEnabledCipherSuites());
+    this.enabledCipherSuites = other.getEnabledCipherSuites() == null ? new HashSet<>() : new HashSet<>(other.getEnabledCipherSuites());
     this.crlPaths = new ArrayList<>(other.getCrlPaths());
     this.crlValues = new ArrayList<>(other.getCrlValues());
   }
@@ -149,7 +149,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
       this.trustOptions = new PemTrustOptions(trustOptions);
     }
     JsonArray arr = json.getJsonArray("enabledCipherSuites");
-    this.enabledCipherSuites = arr == null ? null : new HashSet<>(arr.getList());
+    this.enabledCipherSuites = arr == null ? new HashSet<>() : new HashSet<>(arr.getList());
     arr = json.getJsonArray("crlPaths");
     this.crlPaths = arr == null ? new ArrayList<>() : new ArrayList<>(arr.getList());
     this.crlValues = new ArrayList<>();

--- a/src/test/java/io/vertx/test/core/NetClientOptionsTest.java
+++ b/src/test/java/io/vertx/test/core/NetClientOptionsTest.java
@@ -1,0 +1,34 @@
+package io.vertx.test.core;
+import static org.junit.Assert.assertEquals;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.NetClientOptions;
+
+import org.junit.Test;
+
+/**
+ * test that the default object of NetClientOptions equals to when creating
+ * a NetClientOptions object from an empty Json object. Previously the json constructor
+ * used null for the enabledCipherSuite property which breaks the addEnabledCipherSuite
+ * operation.
+ */
+
+/**
+ * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
+ *
+ */
+public class NetClientOptionsTest {
+
+  @Test
+  public final void testEquals() {
+    NetClientOptions options1 = new NetClientOptions();
+    NetClientOptions options2 = new NetClientOptions(new JsonObject("{}"));
+    assertEquals(options1, options2);
+  }
+
+  @Test
+  public final void testAdd() {
+    NetClientOptions options = new NetClientOptions(new JsonObject("{}"));
+    options.addEnabledCipherSuite("XXX");
+  }
+
+}


### PR DESCRIPTION
new NetClientOptions() and new NetClientOptions(new JsonObject("{}")) create objects that are not equal

When creating an NetClientOptions object from a JsonObject, the property for enabledCipherSuite is set to null if it is not set in the json. When creating an object with new NetClientOptions(), the property is intialized with an empty set. This means that the objects are not equal, but they behave almost completey the same and they have the same hashCode, since null and [] both give 0 as hash value.

In addition, you get a null pointer exception when trying to add to the cipher suite with an object created from Json.

I have created an unit test and fixed the json constructor (for TCPSSLOptions actually)
