### PR TITLE
SockJS Session must call super.close()

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/Session.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/sockjs/impl/Session.java
@@ -166,6 +166,7 @@ class Session extends SockJSSocketBase implements Shareable {
   // Yes, SockJS is weird, but it's hard to work out expected server behaviour when there's no spec
   @Override
   public synchronized void close() {
+    super.close();
     if (endHandler != null) {
       endHandler.handle(null);
     }


### PR DESCRIPTION
Must call super.close or writeHandler is never unregistered from EventBus. This means the Session object cannot be garbage collected.