### PR TITLE
bz466228:  BlockedThreadChecker doesn't have a config value for the time until a stack trace is written

### DIFF
--- a/src/main/asciidoc/cheatsheet/VertxOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/VertxOptions.adoc
@@ -84,4 +84,9 @@ Set the HA group to be used when HA is enabled.+++
 |`link:MetricsOptions.html[MetricsOptions]`
 |+++
 Set the metrics options+++
+
+|[[warningExceptionTime]]`warningExceptionTime`
+|`Number`
+|+++
+Set the threshold value above this, the blocked warning contains a stack trace.+++
 |===

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -562,7 +562,7 @@ public class VertxOptions {
    * @return the warning exception time threshold
    */
   public long getWarningExceptionTime() {
-    return warningExceptionTime ;
+    return warningExceptionTime;
   }
 
   /**

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -572,6 +572,9 @@ public class VertxOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public VertxOptions setWarningExceptionTime(long warningExceptionTime) {
+    if (warningExceptionTime < 1) {
+      throw new IllegalArgumentException("warningExceptionTime must be > 0");
+    }
     this.warningExceptionTime = warningExceptionTime;
     return this;
   }

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -77,7 +77,7 @@ public class VertxOptions {
   /**
    * The default value of max event loop execute time = 2000000000 ns (2 seconds)
    */
-  public static final long DEFAULT_MAX_EVENT_LOOP_EXECUTE_TIME = 2000l * 1000000;
+  public static final long DEFAULT_MAX_EVENT_LOOP_EXECUTE_TIME = 2l * 1000 * 1000000;
 
   /**
    * The default value of max worker execute time = 60000000000 ns (60 seconds)
@@ -99,6 +99,13 @@ public class VertxOptions {
    */
   public static final boolean DEFAULT_METRICS_ENABLED = false;
 
+  /**
+   * The default value of warning exception time 5000000000 ns (5 seconds)
+   * If a thread is blocked longer than this threshold, the warning log
+   * contains a stack trace
+   */
+  private static final long DEFAULT_WARNING_EXECPTION_TIME = 5l * 1000 * 1000000;
+
   private int eventLoopPoolSize = DEFAULT_EVENT_LOOP_POOL_SIZE;
   private int workerPoolSize = DEFAULT_WORKER_POOL_SIZE;
   private int internalBlockingPoolSize = DEFAULT_INTERNAL_BLOCKING_POOL_SIZE;
@@ -115,6 +122,8 @@ public class VertxOptions {
   private int quorumSize = DEFAULT_QUORUM_SIZE;
   private String haGroup;
   private MetricsOptions metrics;
+
+  private long warningExceptionTime = DEFAULT_WARNING_EXECPTION_TIME;
 
   /**
    * Default constructor
@@ -144,6 +153,7 @@ public class VertxOptions {
     this.quorumSize = other.getQuorumSize();
     this.haGroup = other.getHAGroup();
     this.metrics = other.getMetricsOptions() != null ? new MetricsOptions(other.getMetricsOptions()) : null;
+    this.warningExceptionTime = other.warningExceptionTime;
   }
 
   /**
@@ -168,6 +178,7 @@ public class VertxOptions {
     this.haGroup = json.getString("haGroup", null);
     JsonObject metricsJson = json.getJsonObject("metricsOptions");
     this.metrics = metricsJson != null ? new MetricsOptions(metricsJson) : null;
+    this.warningExceptionTime = json.getLong("warningExceptionTime", DEFAULT_WARNING_EXECPTION_TIME);
   }
 
   /**
@@ -545,6 +556,26 @@ public class VertxOptions {
     return this;
   }
 
+  /**
+   * Get the threshold value above this, the blocked warning contains a stack trace.
+   *
+   * @return the warning exception time threshold
+   */
+  public long getWarningExceptionTime() {
+    return warningExceptionTime ;
+  }
+
+  /**
+   * Set the threshold value above this, the blocked warning contains a stack trace.
+   *
+   * @param warningExceptionTime
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setWarningExceptionTime(long warningExceptionTime) {
+    this.warningExceptionTime = warningExceptionTime;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -566,6 +597,7 @@ public class VertxOptions {
     if (clusterManager != null ? !clusterManager.equals(that.clusterManager) : that.clusterManager != null)
       return false;
     if (haGroup != null ? !haGroup.equals(that.haGroup) : that.haGroup != null) return false;
+    if (warningExceptionTime != that.warningExceptionTime) return false;
 
     return true;
   }
@@ -585,6 +617,7 @@ public class VertxOptions {
     result = 31 * result + (haEnabled ? 1 : 0);
     result = 31 * result + quorumSize;
     result = 31 * result + (haGroup != null ? haGroup.hashCode() : 0);
+    result = 31 * result + (int) (warningExceptionTime ^ (warningExceptionTime >>> 32));
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -16,6 +16,7 @@
 
 package io.vertx.core.impl;
 
+import io.vertx.core.VertxException;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.impl.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class BlockedThreadChecker {
   private Map<VertxThread, Object> threads = new WeakHashMap<>();
   private final Timer timer; // Need to use our own timer - can't use event loop for this
 
-  BlockedThreadChecker(long interval, long maxEventLoopExecTime, long maxWorkerExecTime) {
+  BlockedThreadChecker(long interval, long maxEventLoopExecTime, long maxWorkerExecTime, long warningExceptionTime) {
     timer = new Timer("vertx-blocked-thread-checker", true);
     timer.schedule(new TimerTask() {
       @Override
@@ -45,12 +46,14 @@ public class BlockedThreadChecker {
           long execStart = thread.startTime();
           long dur = now - execStart;
           if (execStart != 0 && dur > (thread.isWorker() ? maxWorkerExecTime : maxEventLoopExecTime)) {
-            log.warn("Thread " + thread + " has been blocked for " + (dur / 1000000) + " ms" + " time " + maxEventLoopExecTime);
-            if (dur/1000000 > 5000) {
-              StackTraceElement[] stack = thread.getStackTrace();
-              for (StackTraceElement elem: stack) {
-                System.out.println(elem);
-              }
+            long timeLimit = thread.isWorker() ? maxWorkerExecTime : maxEventLoopExecTime;
+            final String message = "Thread " + thread + " has been blocked for " + (dur / 1000000) + " ms, time limit is " + (timeLimit / 1000000);
+            if (dur <= warningExceptionTime) {
+              log.warn(message);
+            } else {
+              VertxException stackTrace = new VertxException("Thread blocked");
+              stackTrace.setStackTrace(thread.getStackTrace());
+              log.warn(message, stackTrace);
             }
           }
         }

--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -45,8 +45,8 @@ public class BlockedThreadChecker {
         for (VertxThread thread: threads.keySet()) {
           long execStart = thread.startTime();
           long dur = now - execStart;
-          if (execStart != 0 && dur > (thread.isWorker() ? maxWorkerExecTime : maxEventLoopExecTime)) {
-            long timeLimit = thread.isWorker() ? maxWorkerExecTime : maxEventLoopExecTime;
+          final long timeLimit = thread.isWorker() ? maxWorkerExecTime : maxEventLoopExecTime;
+          if (execStart != 0 && dur > timeLimit) {
             final String message = "Thread " + thread + " has been blocked for " + (dur / 1000000) + " ms, time limit is " + (timeLimit / 1000000);
             if (dur <= warningExceptionTime) {
               log.warn(message);

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -125,7 +125,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   VertxImpl(VertxOptions options, Handler<AsyncResult<Vertx>> resultHandler) {
     checker = new BlockedThreadChecker(options.getBlockedThreadCheckPeriod(), options.getMaxEventLoopExecuteTime(),
-                                       options.getMaxWorkerExecuteTime());
+                                       options.getMaxWorkerExecuteTime(), options.getWarningExceptionTime());
     eventLoopGroup = new NioEventLoopGroup(options.getEventLoopPoolSize(),
                                            new VertxThreadFactory("vert.x-eventloop-thread-", checker, false));
     workerPool = Executors.newFixedThreadPool(options.getWorkerPoolSize(),

--- a/src/test/java/io/vertx/test/core/BlockedThreadCheckerTest.java
+++ b/src/test/java/io/vertx/test/core/BlockedThreadCheckerTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Red Hat, Inc.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
- *
- * The Eclipse Public License is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * The Apache License v2.0 is available at
- * http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
- */
-
 package io.vertx.test.core;
 
 import io.vertx.core.AbstractVerticle;
@@ -25,7 +9,10 @@ import io.vertx.core.VertxOptions;
 import org.junit.Test;
 
 /**
- * @author <a href="http://tfox.org">Tim Fox</a>
+ * please note that this test class does not assert anything about the log output (this would require a kind of log
+ * mock), it just runs the different methods to get coverage
+ *
+ * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 public class BlockedThreadCheckerTest extends VertxTestBase {
 

--- a/src/test/java/io/vertx/test/core/BlockedThreadCheckerTest.java
+++ b/src/test/java/io/vertx/test/core/BlockedThreadCheckerTest.java
@@ -74,7 +74,7 @@ public class BlockedThreadCheckerTest extends VertxTestBase {
     vertxOptions.setMaxWorkerExecuteTime(1000000000);
     vertxOptions.setWarningExceptionTime(1000000000);
     Vertx newVertx = Vertx.vertx(vertxOptions);
-    DeploymentOptions depolymentOptions = new DeploymentOptions(); 
+    DeploymentOptions depolymentOptions = new DeploymentOptions();
     depolymentOptions.setWorker(true);
     newVertx.deployVerticle(verticle, depolymentOptions);
     await();

--- a/src/test/java/io/vertx/test/core/BlockedThreadCheckerTest.java
+++ b/src/test/java/io/vertx/test/core/BlockedThreadCheckerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+
+import org.junit.Test;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class BlockedThreadCheckerTest extends VertxTestBase {
+
+  @Test
+  public void testBlockCheckDefault() throws Exception {
+    Verticle verticle = new AbstractVerticle() {
+      @Override
+      public void start() throws InterruptedException {
+        Thread.sleep(6000);
+        testComplete();
+      }
+    };
+    vertx.deployVerticle(verticle);
+    await();
+  }
+
+  @Test
+  public void testBlockCheckExceptionTimeLimit() throws Exception {
+    Verticle verticle = new AbstractVerticle() {
+      @Override
+      public void start() throws InterruptedException {
+        Thread.sleep(2000);
+        testComplete();
+      }
+    };
+    // set warning threshold to 1s and the exception threshold as well
+    VertxOptions vertxOptions = new VertxOptions();
+    vertxOptions.setMaxEventLoopExecuteTime(1000000000);
+    vertxOptions.setWarningExceptionTime(1000000000);
+    Vertx newVertx = Vertx.vertx(vertxOptions);
+    newVertx.deployVerticle(verticle);
+    await();
+  }
+
+  @Test
+  public void testBlockCheckWorker() throws Exception {
+    Verticle verticle = new AbstractVerticle() {
+      @Override
+      public void start() throws InterruptedException {
+        Thread.sleep(2000);
+        testComplete();
+      }
+    };
+    // set warning threshold to 1s and the exception threshold as well
+    VertxOptions vertxOptions = new VertxOptions();
+    vertxOptions.setMaxWorkerExecuteTime(1000000000);
+    vertxOptions.setWarningExceptionTime(1000000000);
+    Vertx newVertx = Vertx.vertx(vertxOptions);
+    DeploymentOptions depolymentOptions = new DeploymentOptions(); 
+    depolymentOptions.setWorker(true);
+    newVertx.deployVerticle(verticle, depolymentOptions);
+    await();
+  }
+}

--- a/src/test/java/io/vertx/test/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/test/core/VertxOptionsTest.java
@@ -164,6 +164,15 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(randString, options.getHAGroup());
 
     assertNull(options.getMetricsOptions());
+
+    try {
+      options.setWarningExceptionTime(-1);
+      fail("Should throw exception");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
+    assertEquals(options, options.setWarningExceptionTime(1000000000l));
+    assertEquals(1000000000l, options.getWarningExceptionTime());
   }
 
   @Test
@@ -186,6 +195,7 @@ public class VertxOptionsTest extends VertxTestBase {
     boolean metricsEnabled = rand.nextBoolean();
     int quorumSize = 51214;
     String haGroup = TestUtils.randomAlphaString(100);
+    long warningExceptionTime = TestUtils.randomPositiveLong();
     options.setClusterPort(clusterPort);
     options.setEventLoopPoolSize(eventLoopPoolSize);
     options.setInternalBlockingPoolSize(internalBlockingPoolSize);
@@ -202,6 +212,7 @@ public class VertxOptionsTest extends VertxTestBase {
     options.setMetricsOptions(
         new MetricsOptions().
             setEnabled(metricsEnabled));
+    options.setWarningExceptionTime(warningExceptionTime);
     options = new VertxOptions(options);
     assertEquals(clusterPort, options.getClusterPort());
     assertEquals(clusterPingInterval, options.getClusterPingInterval());
@@ -219,6 +230,7 @@ public class VertxOptionsTest extends VertxTestBase {
     MetricsOptions metricsOptions = options.getMetricsOptions();
     assertNotNull(metricsOptions);
     assertEquals(metricsEnabled, metricsOptions.isEnabled());
+    assertEquals(warningExceptionTime, options.getWarningExceptionTime());
   }
 
   @Test
@@ -238,6 +250,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(def.isHAEnabled(), json.isHAEnabled());
     assertEquals(def.getQuorumSize(), json.getQuorumSize());
     assertEquals(def.getHAGroup(), json.getHAGroup());
+    assertEquals(def.getWarningExceptionTime(), json.getWarningExceptionTime());
   }
 
   @Test
@@ -259,6 +272,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(1, options.getQuorumSize());
     assertNull(options.getHAGroup());
     assertNull(options.getMetricsOptions());
+    assertEquals(5000000000l, options.getWarningExceptionTime());
     int clusterPort = TestUtils.randomPortInt();
     int eventLoopPoolSize = TestUtils.randomPositiveInt();
     int internalBlockingPoolSize = TestUtils.randomPositiveInt();
@@ -270,6 +284,7 @@ public class VertxOptionsTest extends VertxTestBase {
     int maxEventLoopExecuteTime = TestUtils.randomPositiveInt();
     int maxWorkerExecuteTime = TestUtils.randomPositiveInt();
     int proxyOperationTimeout = TestUtils.randomPositiveInt();
+    long warningExceptionTime = TestUtils.randomPositiveLong();
     Random rand = new Random();
     boolean haEnabled = rand.nextBoolean();
     int quorumSize = TestUtils.randomShort() + 1;
@@ -292,6 +307,7 @@ public class VertxOptionsTest extends VertxTestBase {
         put("haEnabled", haEnabled).
         put("quorumSize", quorumSize).
         put("haGroup", haGroup).
+        put("warningExceptionTime", warningExceptionTime).
         put("metricsOptions", new JsonObject().
             put("enabled", metricsEnabled).
             put("jmxEnabled", jmxEnabled).
@@ -313,5 +329,6 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(haGroup, options.getHAGroup());
     MetricsOptions metricsOptions = options.getMetricsOptions();
     assertEquals(metricsEnabled, metricsOptions.isEnabled());
+    assertEquals(warningExceptionTime, options.getWarningExceptionTime());
   }
 }


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=466228

added config value warningExceptionTime to VertxOptions to set the threshold value when a stack trace
is included in the blocking warning. changed the log code to put the stack trace into the log statement
so that it is output by the logger and not to stdout
added a unit test for the BlockChecker class
