### PR TITLE
[2.x] Create parent dir(s) if necessary, do not try to create an existing dir (module unzip)

### DIFF
--- a/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
+++ b/vertx-platform/src/main/java/org/vertx/java/platform/impl/DefaultPlatformManager.java
@@ -1499,7 +1499,8 @@ public class DefaultPlatformManager implements PlatformManagerInternal, ModuleRe
         String entryName = zipinfo.oldStyle ? removeTopDir(entry.getName()) : entry.getName();
         if (!entryName.isEmpty()) {
           if (entry.isDirectory()) {
-            if (!new File(directory, entryName).mkdir()) {
+            File entryFile = new File(directory, entryName);
+            if (!entryFile.exists() && !entryFile.mkdirs()) {
               throw new PlatformManagerException("Failed to create directory");
             }
           } else {


### PR DESCRIPTION
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=466820