### PR TITLE
Metrics thread contexts fixes

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -80,7 +80,6 @@ class ClientConnection extends ConnectionBase {
   // Requests can be pipelined so we need a queue to keep track of requests
   private final Queue<HttpClientRequestImpl> requests = new ArrayDeque<>();
   private final Handler<Throwable> exceptionHandler;
-  private final Object metric;
   private final HttpClientMetrics metrics;
 
   private WebSocketClientHandshaker handshaker;
@@ -88,6 +87,7 @@ class ClientConnection extends ConnectionBase {
   private HttpClientResponseImpl currentResponse;
   private HttpClientRequestImpl requestForResponse;
   private WebSocketImpl ws;
+  private Object metric;
 
   ClientConnection(VertxInternal vertx, HttpClientImpl client, Handler<Throwable> exceptionHandler, Channel channel, boolean ssl, String host,
                    int port, ContextImpl context, ConnectionLifeCycleListener listener, HttpClientMetrics metrics) {
@@ -104,7 +104,10 @@ class ClientConnection extends ConnectionBase {
     this.listener = listener;
     this.exceptionHandler = exceptionHandler;
     this.metrics = metrics;
-    this.metric = metrics.connected(remoteAddress());
+  }
+
+  public void setMetric(Object metric) {
+    this.metric = metric;
   }
 
   @Override
@@ -361,6 +364,7 @@ class ClientConnection extends ConnectionBase {
   NetSocket createNetSocket() {
     // connection was upgraded to raw TCP socket
     NetSocketImpl socket = new NetSocketImpl(vertx, channel, context, client.getSslHelper(), true, metrics);
+    socket.setMetric(metrics.connected(socket.remoteAddress()));
     Map<Channel, NetSocketImpl> connectionMap = new HashMap<>(1);
     connectionMap.put(channel, socket);
 

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -149,6 +149,7 @@ class ClientConnection extends ConnectionBase {
       p.addBefore("handler", "handshakeCompleter", new HandshakeInboundHandler(wsConnect, version != WebSocketVersion.V00));
       handshaker.handshake(channel).addListener(future -> {
         if (!future.isSuccess() && exceptionHandler != null) {
+          // On good thread ?
           exceptionHandler.handle(future.cause());
         }
       });
@@ -186,46 +187,48 @@ class ClientConnection extends ConnectionBase {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-      context.executeFromIO(() -> {
-        synchronized (ClientConnection.this) {
-          if (handshaker != null && handshaking) {
-            if (msg instanceof HttpResponse) {
-              HttpResponse resp = (HttpResponse) msg;
-              if (resp.getStatus().code() != 101) {
+      synchronized (ClientConnection.this) {
+        if (handshaker != null && handshaking) {
+          if (msg instanceof HttpResponse) {
+            HttpResponse resp = (HttpResponse) msg;
+            if (resp.getStatus().code() != 101) {
+              context.executeFromIO(() -> {
                 handleException(new WebSocketHandshakeException("Websocket connection attempt returned HTTP status code " + resp.getStatus().code()));
-                return;
-              }
-              response = new DefaultFullHttpResponse(resp.getProtocolVersion(), resp.getStatus());
-              response.headers().add(resp.headers());
+              });
+              return;
             }
+            response = new DefaultFullHttpResponse(resp.getProtocolVersion(), resp.getStatus());
+            response.headers().add(resp.headers());
+          }
 
-            if (msg instanceof HttpContent) {
-              if (response != null) {
-                response.content().writeBytes(((HttpContent) msg).content());
-                if (msg instanceof LastHttpContent) {
-                  response.trailingHeaders().add(((LastHttpContent) msg).trailingHeaders());
-                  try {
-                    handshakeComplete(ctx, response);
-                    channel.pipeline().remove(HandshakeInboundHandler.this);
-                    for (; ; ) {
-                      Object m = buffered.poll();
-                      if (m == null) {
-                        break;
-                      }
-                      ctx.fireChannelRead(m);
+          if (msg instanceof HttpContent) {
+            if (response != null) {
+              response.content().writeBytes(((HttpContent) msg).content());
+              if (msg instanceof LastHttpContent) {
+                response.trailingHeaders().add(((LastHttpContent) msg).trailingHeaders());
+                try {
+                  handshakeComplete(ctx, response);
+                  channel.pipeline().remove(HandshakeInboundHandler.this);
+                  for (; ; ) {
+                    Object m = buffered.poll();
+                    if (m == null) {
+                      break;
                     }
-                  } catch (WebSocketHandshakeException e) {
-                    close();
-                    handleException(e);
+                    ctx.fireChannelRead(m);
                   }
+                } catch (WebSocketHandshakeException e) {
+                  close();
+                  context.executeFromIO(() -> {
+                    handleException(e);
+                  });
                 }
               }
             }
-          } else {
-            buffered.add(msg);
           }
+        } else {
+          buffered.add(msg);
         }
-      });
+      }
     }
 
     private void handleException(WebSocketHandshakeException e) {
@@ -245,8 +248,12 @@ class ClientConnection extends ConnectionBase {
       }
       ws = new WebSocketImpl(vertx, ClientConnection.this, supportsContinuation, client.getOptions().getMaxWebsocketFrameSize());
       handshaker.finishHandshake(channel, response);
+
       log.debug("WebSocket handshake complete");
-      wsConnect.handle(ws);
+      context.executeFromIO(() -> {
+        ws.metric = metrics().connected(metric(), ws);
+        wsConnect.handle(ws);
+      });
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -725,12 +725,6 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
   private void connected(ContextImpl context, int port, String host, Channel ch, Handler<ClientConnection> connectHandler,
                          Handler<Throwable> exceptionHandler,
                          ConnectionLifeCycleListener listener) {
-    context.executeFromIO(() -> createConn(context, port, host, ch, connectHandler, exceptionHandler, listener));
-  }
-
-  private void createConn(ContextImpl context, int port, String host, Channel ch, Handler<ClientConnection> connectHandler,
-                          Handler<Throwable> exceptionHandler,
-                          ConnectionLifeCycleListener listener) {
     ClientConnection conn = new ClientConnection(vertx, HttpClientImpl.this, exceptionHandler, ch,
         options.isSsl(), host, port, context, listener, metrics);
     conn.closeHandler(v -> {
@@ -740,7 +734,10 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       listener.connectionClosed(conn);
     });
     connectionMap.put(ch, conn);
-    connectHandler.handle(conn);
+    context.executeFromIO(() -> {
+      conn.setMetric(metrics.connected(conn.remoteAddress()));
+      connectHandler.handle(conn);
+    });
   }
 
   private void connectionFailed(ContextImpl context, Channel ch, Handler<Throwable> connectionExceptionHandler,

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -559,6 +559,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       conn.requestHandler(reqHandler.handler);
       connectionMap.put(ch, conn);
       reqHandler.context.executeFromIO(() -> {
+        conn.setMetric(metrics.connected(conn.remoteAddress()));
         conn.handleMessage(request);
       });
     }
@@ -584,6 +585,11 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
         }
       } else {
 
+        ServerConnection wsConn = new ServerConnection(vertx, HttpServerImpl.this, ch, wsHandler.context,
+            serverOrigin, shake, metrics);
+        wsConn.wsHandler(wsHandler.handler);
+        connectionMap.put(ch, wsConn);
+
         wsHandler.context.executeFromIO(() -> {
           URI theURI;
           try {
@@ -592,12 +598,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             throw new IllegalArgumentException("Invalid uri " + request.getUri()); //Should never happen
           }
 
-          ServerConnection wsConn = new ServerConnection(vertx, HttpServerImpl.this, ch, wsHandler.context,
-            serverOrigin, shake, metrics);
-          wsConn.wsHandler(wsHandler.handler);
-
           Runnable connectRunnable = () -> {
-            connectionMap.put(ch, wsConn);
             try {
               shake.handshake(ch, request);
             } catch (WebSocketHandshakeException e) {
@@ -610,6 +611,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
           ServerWebSocketImpl ws = new ServerWebSocketImpl(vertx, theURI.toString(), theURI.getPath(),
             theURI.getQuery(), new HeadersAdaptor(request.headers()), wsConn, shake.version() != WebSocketVersion.V00,
             connectRunnable, options.getMaxWebsocketFrameSize());
+          wsConn.setMetric(metrics.connected(wsConn.remoteAddress()));
           ws.metric = metrics.connected(wsConn.metric(), ws);
           wsConn.handleWebsocketConnect(ws);
           if (!ws.isRejected()) {

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -80,7 +80,6 @@ class ServerConnection extends ConnectionBase {
   private final HttpServerImpl server;
   private final WebSocketServerHandshaker handshaker;
   private final HttpServerMetrics metrics;
-  private final Object metric;
 
   private Object requestMetric;
   private Handler<HttpServerRequest> requestHandler;
@@ -94,6 +93,7 @@ class ServerConnection extends ConnectionBase {
   private boolean sentCheck;
   private long bytesRead;
   private long bytesWritten;
+  private Object metric;
 
   ServerConnection(VertxInternal vertx, HttpServerImpl server, Channel channel, ContextImpl context, String serverOrigin,
                    WebSocketServerHandshaker handshaker, HttpServerMetrics metrics) {
@@ -102,7 +102,10 @@ class ServerConnection extends ConnectionBase {
     this.server = server;
     this.handshaker = handshaker;
     this.metrics = metrics;
-    this.metric = metrics.connected(remoteAddress());
+  }
+
+  void setMetric(Object metric) {
+    this.metric = metric;
   }
 
   @Override
@@ -205,6 +208,7 @@ class ServerConnection extends ConnectionBase {
 
   NetSocket createNetSocket() {
     NetSocketImpl socket = new NetSocketImpl(vertx, channel, context, server.getSslHelper(), false, metrics);
+    socket.setMetric(metrics.connected(socket.remoteAddress()));
     Map<Channel, NetSocketImpl> connectionMap = new HashMap<Channel, NetSocketImpl>(1);
     connectionMap.put(channel, socket);
 

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -34,13 +34,12 @@ import io.vertx.core.spi.metrics.HttpClientMetrics;
  */
 public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
 
-  final Object metric;
+  Object metric;
 
   public WebSocketImpl(VertxInternal vertx,
                        ClientConnection conn, boolean supportsContinuation,
                        int maxWebSocketFrameSize) {
     super(vertx, conn, supportsContinuation, maxWebSocketFrameSize);
-    metric = conn.metrics().connected(conn.metric(), this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
+++ b/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
@@ -108,7 +108,7 @@ public class DummyVertxMetrics implements VertxMetrics {
     return false;
   }
 
-  class DummyEventBusMetrics implements EventBusMetrics<Void> {
+  protected class DummyEventBusMetrics implements EventBusMetrics<Void> {
 
     @Override
     public void messageWritten(String address, int numberOfBytes) {
@@ -157,7 +157,7 @@ public class DummyVertxMetrics implements VertxMetrics {
     }
   }
 
-  class DummyHttpServerMetrics implements HttpServerMetrics<Void, Void, Void> {
+  protected class DummyHttpServerMetrics implements HttpServerMetrics<Void, Void, Void> {
 
     @Override
     public Void requestBegin(Void socketMetric, HttpServerRequest request) {
@@ -208,7 +208,7 @@ public class DummyVertxMetrics implements VertxMetrics {
     }
   }
 
-  class DummyHttpClientMetrics implements HttpClientMetrics<Void, Void, Void> {
+  protected class DummyHttpClientMetrics implements HttpClientMetrics<Void, Void, Void> {
 
     @Override
     public Void requestBegin(Void socketMetric, SocketAddress localAddress, SocketAddress remoteAddress, HttpClientRequest request) {
@@ -259,7 +259,7 @@ public class DummyVertxMetrics implements VertxMetrics {
     }
   }
 
-  class DummyTCPMetrics implements TCPMetrics<Void> {
+  protected class DummyTCPMetrics implements TCPMetrics<Void> {
 
     @Override
     public Void connected(SocketAddress remoteAddress) {
@@ -292,7 +292,7 @@ public class DummyVertxMetrics implements VertxMetrics {
     }
   }
 
-  class DummyDatagramMetrics implements DatagramSocketMetrics {
+  protected class DummyDatagramMetrics implements DatagramSocketMetrics {
 
     @Override
     public void listening(SocketAddress localAddress) {

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -104,10 +104,10 @@ public class NetClientImpl implements NetClient, MetricsProvider {
       for (NetSocket sock : socketMap.values()) {
         sock.close();
       }
+      closed = true;
       if (creatingContext != null) {
         creatingContext.removeCloseHook(closeHook);
       }
-      closed = true;
       metrics.close();
     }
   }
@@ -220,6 +220,7 @@ public class NetClientImpl implements NetClient, MetricsProvider {
 
   private void doConnected(ContextImpl context, Channel ch, Handler<AsyncResult<NetSocket>> connectHandler) {
     NetSocketImpl sock = new NetSocketImpl(vertx, ch, context, sslHelper, true, metrics);
+    sock.setMetric(metrics.connected(sock.remoteAddress()));
     socketMap.put(ch, sock);
     connectHandler.handle(Future.succeededFuture(sock));
   }

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -433,13 +433,12 @@ public class NetServerImpl implements NetServer, Closeable, MetricsProvider {
     }
 
     private void connected(Channel ch, HandlerHolder<NetSocket> handler) {
-      handler.context.executeFromIO(() -> doConnected(ch, handler));
-    }
-
-    private void doConnected(Channel ch, HandlerHolder<NetSocket> handler) {
       NetSocketImpl sock = new NetSocketImpl(vertx, ch, handler.context, sslHelper, false, metrics);
       socketMap.put(ch, sock);
-      handler.handler.handle(sock);
+      handler.context.executeFromIO(() -> {
+        sock.setMetric(metrics.connected(sock.remoteAddress()));
+        handler.handler.handle(sock);
+      });
     }
   }
 

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -64,7 +64,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   private final MessageConsumer registration;
   private final SSLHelper helper;
   private final boolean client;
-  private final Object metric;
+  private Object metric;
   private Handler<Buffer> dataHandler;
   private Handler<Void> endHandler;
   private Handler<Void> drainHandler;
@@ -77,9 +77,12 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
     this.helper = helper;
     this.client = client;
     this.writeHandlerID = UUID.randomUUID().toString();
-    this.metric = metrics.connected(remoteAddress());
     Handler<Message<Buffer>> writeHandler = msg -> write(msg.body());
     registration = vertx.eventBus().<Buffer>localConsumer(writeHandlerID).handler(writeHandler);
+  }
+
+  public void setMetric(Object metric) {
+    this.metric = metric;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
+++ b/src/main/java/io/vertx/core/spi/VertxMetricsFactory.java
@@ -28,7 +28,9 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 public interface VertxMetricsFactory {
 
   /**
-   * Create a new {@link io.vertx.core.spi.metrics.VertxMetrics} object.
+   * Create a new {@link io.vertx.core.spi.metrics.VertxMetrics} object.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param vertx the vertx instance
    * @param options the metrics configuration option

--- a/src/main/java/io/vertx/core/spi/metrics/DatagramSocketMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/DatagramSocketMetrics.java
@@ -19,7 +19,21 @@ package io.vertx.core.spi.metrics;
 import io.vertx.core.net.SocketAddress;
 
 /**
- * The datagram/udp metrics SPI which Vert.x will use to call when each event occurs pertaining to datagram sockets.
+ * The datagram/udp metrics SPI which Vert.x will use to call when each event occurs pertaining to datagram sockets.<p/>
+ *
+ * The thread model for the datagram socket depends on the actual context thats started the server.<p/>
+ *
+ * <h3>Event loop context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with the thread of the http server and therefore are the same than the
+ * {@link io.vertx.core.spi.metrics.VertxMetrics} {@code createMetrics} method that created and returned
+ * this metrics object.
+ *
+ * <h3>Worker context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with a worker thread.
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */

--- a/src/main/java/io/vertx/core/spi/metrics/EventBusMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/EventBusMetrics.java
@@ -26,7 +26,10 @@ import io.vertx.core.eventbus.ReplyFailure;
 public interface EventBusMetrics<H> extends Metrics {
 
   /**
-   * Called when a handler is registered on the event bus.
+   * Called when a handler is registered on the event bus.<p/>
+   *
+   * This method is invoked with {@link io.vertx.core.Context} and thread of the message handler and therefore
+   * might be different on every invocation.
    *
    * @param address the address used to register the handler
    * @param replyHandler true when the handler is a reply handler
@@ -34,14 +37,34 @@ public interface EventBusMetrics<H> extends Metrics {
   H handlerRegistered(String address, boolean replyHandler);
 
   /**
-   * Called when a handler has been unregistered from the event bus.
+   * Called when a handler has been unregistered from the event bus.<p/>
+   *
+   * The thread model depends on the actual context thats registered the handler.<p/>
+   *
+   * <h3>Event loop context</h3>
+   *
+   * This method is invoked with the handler event loop thread.
+   *
+   * <h3>Worker context</h3>
+   *
+   * This method is invoked with a worker thread.
    *
    * @param handler the unregistered handler
    */
   void handlerUnregistered(H handler);
 
   /**
-   * Called when an handler begin to process a message.
+   * Called when an handler begin to process a message.<p/>
+   *
+   * The thread model depends on the actual context thats registered the handler.<p/>
+   *
+   * <h3>Event loop context</h3>
+   *
+   * This method is invoked with the handler event loop thread.
+   *
+   * <h3>Worker context</h3>
+   *
+   * This method is invoked with a worker thread.
    *
    * @param handler the handler processing the message
    * @param local when the received message is local
@@ -49,7 +72,17 @@ public interface EventBusMetrics<H> extends Metrics {
   void beginHandleMessage(H handler, boolean local);
 
   /**
-   * Called when an handler finish to process a message.
+   * Called when an handler finish to process a message.<p/>
+   *
+   * The thread model depends on the actual context thats registered the handler.<p/>
+   *
+   * <h3>Event loop context</h3>
+   *
+   * This method is invoked with the handler event loop thread.
+   *
+   * <h3>Worker context</h3>
+   *
+   * This method is invoked with a worker thread.
    *
    * @param handler the handler processing the message
    * @param failure an optional failure thrown by handler
@@ -57,7 +90,9 @@ public interface EventBusMetrics<H> extends Metrics {
   void endHandleMessage(H handler, Throwable failure);
 
   /**
-   * Called when a message has been sent or published.
+   * Called when a message has been sent or published.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param address the address
    * @param publish true when the message is published
@@ -67,7 +102,9 @@ public interface EventBusMetrics<H> extends Metrics {
   void messageSent(String address, boolean publish, boolean local, boolean remote);
 
   /**
-   * Called when a message is received.
+   * Called when a message is received.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param address the address
    * @param publish true when the message is published
@@ -77,7 +114,9 @@ public interface EventBusMetrics<H> extends Metrics {
   void messageReceived(String address, boolean publish, boolean local, int handlers);
 
   /**
-   * A message has been sent over the network.
+   * A message has been sent over the network.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param address the message address
    * @param numberOfBytes the number of bytes written
@@ -85,7 +124,9 @@ public interface EventBusMetrics<H> extends Metrics {
   void messageWritten(String address, int numberOfBytes);
 
   /**
-   * A message has been received from the network.
+   * A message has been received from the network.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param address the message address
    * @param numberOfBytes the number of bytes read
@@ -93,7 +134,9 @@ public interface EventBusMetrics<H> extends Metrics {
   void messageRead(String address, int numberOfBytes);
 
   /**
-   * Called whenever there is a reply failure on the event bus
+   * Called whenever there is a reply failure on the event bus.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param address the address
    * @param failure the {@link io.vertx.core.eventbus.ReplyFailure}

--- a/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/HttpClientMetrics.java
@@ -22,7 +22,21 @@ import io.vertx.core.http.WebSocket;
 import io.vertx.core.net.SocketAddress;
 
 /**
- * The http client metrics SPI that Vert.x will use to call when http client events occur.
+ * The http client metrics SPI that Vert.x will use to call when http client events occur.<p/>
+ *
+ * The thread model for the http server metrics depends on the actual context thats started the server.<p/>
+ *
+ * <h3>Event loop context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with the thread of the http client and therefore are the same than the
+ * {@link io.vertx.core.spi.metrics.VertxMetrics} {@code createMetrics} method that created and returned
+ * this metrics object.
+ *
+ * <h3>Worker context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with a worker thread.
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */

--- a/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/HttpServerMetrics.java
@@ -21,7 +21,21 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
 
 /**
- * The http server metrics SPI that Vert.x will use to call when each http server event occurs.
+ * The http server metrics SPI that Vert.x will use to call when each http server event occurs.<p/>
+ *
+ * The thread model for the http server metrics depends on the actual context thats started the server.<p/>
+ *
+ * <h3>Event loop context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with the thread of the http server and therefore are the same than the
+ * {@link io.vertx.core.spi.metrics.VertxMetrics} {@code createMetrics} method that created and returned
+ * this metrics object.
+ *
+ * <h3>Worker context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with a worker thread.
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */

--- a/src/main/java/io/vertx/core/spi/metrics/Metrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/Metrics.java
@@ -32,7 +32,9 @@ public interface Metrics {
   boolean isEnabled();
 
   /**
-   * Used to close out the metrics, for example when an http server/client has been closed.
+   * Used to close out the metrics, for example when an http server/client has been closed.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    */
   void close();
 }

--- a/src/main/java/io/vertx/core/spi/metrics/NetworkMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/NetworkMetrics.java
@@ -20,7 +20,7 @@ import io.vertx.core.net.SocketAddress;
 
 /**
  * An SPI used internally by Vert.x to gather metrics on a net socket which serves
- * as a base class for TCP or UDP.
+ * as a base class for TCP or UDP.<p/>
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */

--- a/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/TCPMetrics.java
@@ -20,7 +20,21 @@ import io.vertx.core.net.SocketAddress;
 
 /**
  * An SPI used internally by Vert.x to gather metrics on a net socket which serves
- * as a base class for things like HttpServer and HttpClient, all of which serve TCP connections.
+ * as a base class for things like HttpServer and HttpClient, all of which serve TCP connections.<p/>
+ *
+ * The thread model for the tcp metrics depends on the actual context thats created the client/server.<p/>
+ *
+ * <h3>Event loop context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with the thread of the client/server and therefore are the same than the
+ * {@link io.vertx.core.spi.metrics.VertxMetrics} {@code createMetrics} method that created and returned
+ * this metrics object.
+ *
+ * <h3>Worker context</h3>
+ *
+ * Unless specified otherwise, all the methods on this object including the methods inherited from the super interfaces are invoked
+ * with a worker thread.
  *
  * @author <a href="mailto:nscavell@redhat.com">Nick Scavelli</a>
  */

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -42,14 +42,20 @@ import io.vertx.core.net.SocketAddress;
 public interface VertxMetrics extends Metrics, Measured {
 
   /**
-   * Called when a verticle is deployed in Vert.x
+   * Called when a verticle is deployed in Vert.x .<p/>
+   *
+   * This method is invoked with {@link io.vertx.core.Context} and thread of the deployed verticle and therefore
+   * might be  different on every invocation.
    *
    * @param verticle the verticle which was deployed
    */
   void verticleDeployed(Verticle verticle);
 
   /**
-   * Called when a verticle is undeployed in Vert.x
+   * Called when a verticle is undeployed in Vert.x .<p/>
+   *
+   * This method is invoked with {@link io.vertx.core.Context} and thread of the deployed verticle and therefore
+   * might be  different on every invocation, however these are the same than the {@link #verticleDeployed} invocation.
    *
    * @param verticle the verticle which was undeployed
    */
@@ -58,19 +64,28 @@ public interface VertxMetrics extends Metrics, Measured {
   /**
    * Called when a timer is created
    *
+   * No specific thread and context can be expected when this method is called.
+   *
    * @param id the id of the timer
    */
   void timerCreated(long id);
 
   /**
-   * Called when a timer has ended (setTimer) or has been cancelled.
+   * Called when a timer has ended (setTimer) or has been cancelled.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
+   *
    * @param id the id of the timer
    * @param cancelled if the timer was cancelled by the user
    */
   void timerEnded(long id, boolean cancelled);
 
   /**
-   * Provides the event bus metrics SPI when the event bus is created
+   * Provides the event bus metrics SPI when the event bus is created.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.<p/>
+   *
+   * This method should be called only once.
    *
    * @param eventBus the Vert.x event bus
    * @return the event bus metrics SPI
@@ -78,7 +93,12 @@ public interface VertxMetrics extends Metrics, Measured {
   EventBusMetrics createMetrics(EventBus eventBus);
 
   /**
-   * Provides the http server metrics SPI when an http server is created
+   * Provides the http server metrics SPI when an http server is created.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.<p/>
+   *
+   * Note: this method can be called more than one time for the same {@code localAddress} when a server is
+   * scaled, it is the responsibility of the metrics implementation to eventually merge metrics.
    *
    * @param server the Vert.x http server
    * @param localAddress localAddress the local address the net socket is listening on
@@ -88,7 +108,9 @@ public interface VertxMetrics extends Metrics, Measured {
   HttpServerMetrics<?, ?, ?> createMetrics(HttpServer server, SocketAddress localAddress, HttpServerOptions options);
 
   /**
-   * Provides the http client metrics SPI when an http client has been created
+   * Provides the http client metrics SPI when an http client has been created.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param client the Vert.x http client
    * @param options the options used to create the {@link io.vertx.core.http.HttpClient}
@@ -97,8 +119,13 @@ public interface VertxMetrics extends Metrics, Measured {
   HttpClientMetrics<?, ?, ?> createMetrics(HttpClient client, HttpClientOptions options);
 
   /**
-   * Provides the net server metrics SPI when a net server is created
+   * Provides the net server metrics SPI when a net server is created.<p/>
    *
+   * No specific thread and context can be expected when this method is called.<p/>
+   *
+   * Note: this method can be called more than one time for the same {@code localAddress} when a server is
+   * scaled, it is the responsibility of the metrics implementation to eventually merge metrics.
+   * 
    * @param server the Vert.x net server
    * @param localAddress localAddress the local address the net socket is listening on
    * @param options the options used to create the {@link io.vertx.core.net.NetServer}
@@ -107,7 +134,9 @@ public interface VertxMetrics extends Metrics, Measured {
   TCPMetrics<?> createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options);
 
   /**
-   * Provides the net client metrics SPI when a net client is created
+   * Provides the net client metrics SPI when a net client is created.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param client the Vert.x net client
    * @param options the options used to create the {@link io.vertx.core.net.NetClient}
@@ -116,7 +145,9 @@ public interface VertxMetrics extends Metrics, Measured {
   TCPMetrics<?> createMetrics(NetClient client, NetClientOptions options);
 
   /**
-   * Provides the datagram/udp metrics SPI when a datagram socket is created
+   * Provides the datagram/udp metrics SPI when a datagram socket is created.<p/>
+   *
+   * No specific thread and context can be expected when this method is called.
    *
    * @param socket the Vert.x datagram socket
    * @param options the options used to create the {@link io.vertx.core.datagram.DatagramSocket}

--- a/src/test/java/io/vertx/test/core/AsyncTestBase.java
+++ b/src/test/java/io/vertx/test/core/AsyncTestBase.java
@@ -16,6 +16,8 @@
 
 package io.vertx.test.core;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.impl.LoggerFactory;
 import org.hamcrest.Matcher;
@@ -30,6 +32,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -571,4 +575,37 @@ public class AsyncTestBase {
       handleThrowable(e);
     }
   }
+
+  protected <T> Handler<AsyncResult<T>> onFailure(Consumer<Throwable> consumer) {
+    return result -> {
+      assertFalse(result.succeeded());
+      consumer.accept(result.cause());
+    };
+  }
+
+  protected void awaitLatch(CountDownLatch latch) throws InterruptedException {
+    assertTrue(latch.await(10, TimeUnit.SECONDS));
+  }
+
+  protected void waitUntil(BooleanSupplier supplier) {
+    waitUntil(supplier, 10000);
+  }
+
+  protected void waitUntil(BooleanSupplier supplier, long timeout) {
+    long start = System.currentTimeMillis();
+    while (true) {
+      if (supplier.getAsBoolean()) {
+        break;
+      }
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException ignore) {
+      }
+      long now = System.currentTimeMillis();
+      if (now - start > timeout) {
+        throw new IllegalStateException("Timed out");
+      }
+    }
+  }
+
 }

--- a/src/test/java/io/vertx/test/core/ConfigurableMetricsFactory.java
+++ b/src/test/java/io/vertx/test/core/ConfigurableMetricsFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.metrics.impl.DummyVertxMetrics;
+import io.vertx.core.spi.VertxMetricsFactory;
+import io.vertx.core.spi.metrics.VertxMetrics;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ConfigurableMetricsFactory implements VertxMetricsFactory {
+
+  public static VertxMetricsFactory delegate;
+
+  @Override
+  public VertxMetrics metrics(Vertx vertx, VertxOptions options) {
+    return delegate != null ? delegate.metrics(vertx, options) : new DummyVertxMetrics();
+  }
+}

--- a/src/test/java/io/vertx/test/core/MetricsContextTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsContextTest.java
@@ -1,0 +1,983 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.datagram.DatagramSocket;
+import io.vertx.core.datagram.DatagramSocketOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.core.metrics.impl.DummyVertxMetrics;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.DatagramSocketMetrics;
+import io.vertx.core.spi.metrics.EventBusMetrics;
+import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.TCPMetrics;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class MetricsContextTest extends AsyncTestBase {
+
+  @Test
+  public void testFactory() throws Exception {
+    AtomicReference<Thread> metricsThread = new AtomicReference<>();
+    AtomicReference<Context> metricsContext = new AtomicReference<>();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> {
+      metricsThread.set(Thread.currentThread());
+      metricsContext.set(Vertx.currentContext());
+      return new DummyVertxMetrics();
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    assertSame(Thread.currentThread(), metricsThread.get());
+    assertNull(metricsContext.get());
+  }
+
+  @Test
+  public void testFactoryInCluster() throws Exception {
+    AtomicReference<Thread> metricsThread = new AtomicReference<>();
+    AtomicReference<Context> metricsContext = new AtomicReference<>();
+    Thread testThread = Thread.currentThread();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> {
+      metricsThread.set(Thread.currentThread());
+      metricsContext.set(Vertx.currentContext());
+      return new DummyVertxMetrics();
+    };
+    Vertx.clusteredVertx(new VertxOptions().setClustered(true).setMetricsOptions(new MetricsOptions().setEnabled(true)), ar -> {
+      assertTrue(ar.succeeded());
+      assertSame(testThread, metricsThread.get());
+      assertNull(metricsContext.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testHttpServerRequestEventLoop() throws Exception {
+    testHttpServerRequest(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testHttpServerRequestWorker() throws Exception {
+    testHttpServerRequest(workerContextFactory, workerChecker);
+  }
+
+  private void testHttpServerRequest(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) throws Exception {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean requestBeginCalled = new AtomicBoolean();
+    AtomicBoolean responseEndCalled = new AtomicBoolean();
+    AtomicBoolean socketConnectedCalled = new AtomicBoolean();
+    AtomicBoolean socketDisconnectedCalled = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public HttpServerMetrics createMetrics(HttpServer server, SocketAddress localAddress, HttpServerOptions options) {
+        return new DummyHttpServerMetrics() {
+          @Override
+          public Void requestBegin(Void socketMetric, HttpServerRequest request) {
+            requestBeginCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void responseEnd(Void requestMetric, HttpServerResponse response) {
+            responseEndCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public Void connected(SocketAddress remoteAddress) {
+            socketConnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+            socketDisconnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+        };
+      }
+    };
+    CountDownLatch latch = new CountDownLatch(1);
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    Context ctx = contextFactory.apply(vertx);
+    ctx.runOnContext(v1 -> {
+      HttpServer server = vertx.createHttpServer().requestHandler(req -> {
+        HttpServerResponse response = req.response();
+        response.setStatusCode(200).setChunked(true).write("bye").end();
+        response.close();
+      });
+      server.listen(8080, "localhost", ar -> {
+        assertTrue(ar.succeeded());
+        expectedThread.set(Thread.currentThread());
+        expectedContext.set(Vertx.currentContext());
+        latch.countDown();
+      });
+    });
+    awaitLatch(latch);
+    HttpClient client = vertx.createHttpClient();
+    client.put(8080, "localhost", "/", resp -> {
+      resp.netSocket().closeHandler(v -> {
+        vertx.close(v4 -> {
+          assertTrue(requestBeginCalled.get());
+          assertTrue(responseEndCalled.get());
+          assertTrue(bytesReadCalled.get());
+          assertTrue(bytesWrittenCalled.get());
+          assertTrue(socketConnectedCalled.get());
+          assertTrue(socketDisconnectedCalled.get());
+          assertTrue(closeCalled.get());
+          testComplete();
+        });
+      });
+    }).exceptionHandler(err -> {
+      fail(err.getMessage());
+    }).setChunked(true).write(Buffer.buffer("hello")).end();
+    await();
+  }
+
+  @Test
+  public void testHttpServerWebsocketEventLoop() throws Exception {
+    testHttpServerWebsocket(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testHttpServerWebsocketWorker() throws Exception {
+    testHttpServerWebsocket(workerContextFactory, workerChecker);
+  }
+
+  private void testHttpServerWebsocket(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) throws Exception {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean websocketConnected = new AtomicBoolean();
+    AtomicBoolean websocketDisconnected = new AtomicBoolean();
+    AtomicBoolean socketConnectedCalled = new AtomicBoolean();
+    AtomicBoolean socketDisconnectedCalled = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public HttpServerMetrics createMetrics(HttpServer server, SocketAddress localAddress, HttpServerOptions options) {
+        return new DummyHttpServerMetrics() {
+          @Override
+          public Void connected(Void socketMetric, ServerWebSocket serverWebSocket) {
+            websocketConnected.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void serverWebSocketMetric) {
+            websocketDisconnected.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public Void connected(SocketAddress remoteAddress) {
+            socketConnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+            socketDisconnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+        };
+      }
+    };
+    CountDownLatch latch = new CountDownLatch(1);
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    Context ctx = contextFactory.apply(vertx);
+    ctx.runOnContext(v1 -> {
+      HttpServer server = vertx.createHttpServer().websocketHandler(ws -> {
+        ws.handler(buf -> {
+          ws.write(Buffer.buffer("bye"));
+        });
+      });
+      server.listen(8080, "localhost", ar -> {
+        assertTrue(ar.succeeded());
+        expectedThread.set(Thread.currentThread());
+        expectedContext.set(Vertx.currentContext());
+        latch.countDown();
+      });
+    });
+    awaitLatch(latch);
+    HttpClient client = vertx.createHttpClient();
+    client.websocket(8080, "localhost", "/", ws -> {
+      ws.handler(buf -> {
+        ws.closeHandler(v -> {
+          vertx.close(v4 -> {
+            assertTrue(websocketConnected.get());
+            assertTrue(websocketDisconnected.get());
+            assertTrue(bytesReadCalled.get());
+            assertTrue(bytesWrittenCalled.get());
+            assertTrue(socketConnectedCalled.get());
+            assertTrue(socketDisconnectedCalled.get());
+            assertTrue(closeCalled.get());
+            testComplete();
+          });
+        });
+        ws.close();
+      });
+      ws.write(Buffer.buffer("hello"));
+    });
+    await();
+  }
+
+  @Test
+  public void testHttpClientRequestEventLoop() throws Exception {
+    testHttpClientRequest(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testHttpClientRequestWorker() throws Exception {
+    testHttpClientRequest(workerContextFactory, workerChecker);
+  }
+
+  private void testHttpClientRequest(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) throws Exception {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean requestBeginCalled = new AtomicBoolean();
+    AtomicBoolean responseEndCalled = new AtomicBoolean();
+    AtomicBoolean socketConnectedCalled = new AtomicBoolean();
+    AtomicBoolean socketDisconnectedCalled = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public HttpClientMetrics createMetrics(HttpClient client, HttpClientOptions options) {
+        return new DummyHttpClientMetrics() {
+          @Override
+          public Void requestBegin(Void socketMetric, SocketAddress localAddress, SocketAddress remoteAddress, HttpClientRequest request) {
+            requestBeginCalled.set(true);
+            return null;
+          }
+          @Override
+          public void responseEnd(Void requestMetric, HttpClientResponse response) {
+            responseEndCalled.set(true);
+          }
+          @Override
+          public Void connected(SocketAddress remoteAddress) {
+            socketConnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+            socketDisconnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+        };
+      }
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    HttpServer server = vertx.createHttpServer();
+    server.requestHandler(req -> {
+      req.endHandler(buf -> {
+        HttpServerResponse resp = req.response();
+        resp.setChunked(true).write(Buffer.buffer("bye")).end();
+        resp.close();
+      });
+    });
+    CountDownLatch latch = new CountDownLatch(1);
+    server.listen(8080, "localhost", ar -> {
+      assertTrue(ar.succeeded());
+      latch.countDown();
+    });
+    awaitLatch(latch);
+    Context ctx = contextFactory.apply(vertx);
+    ctx.runOnContext(v1 -> {
+      expectedThread.set(Thread.currentThread());
+      expectedContext.set(Vertx.currentContext());
+      HttpClient client = vertx.createHttpClient();
+      checker.accept(expectedThread.get(), expectedContext.get());
+      HttpClientRequest req = client.put(8080, "localhost", "/");
+      req.handler(resp -> {
+        executeInVanillaThread(() -> {
+          client.close();
+          vertx.close(v2 -> {
+            assertTrue(requestBeginCalled.get());
+            assertTrue(responseEndCalled.get());
+            assertTrue(socketConnectedCalled.get());
+            assertTrue(socketDisconnectedCalled.get());
+            assertTrue(bytesReadCalled.get());
+            assertTrue(bytesWrittenCalled.get());
+            assertTrue(closeCalled.get());
+            testComplete();
+          });
+        });
+      });
+      req.setChunked(true).write("hello");
+      req.end();
+    });
+    await();
+  }
+
+  @Test
+  public void testHttpClientWebsocketEventLoop() throws Exception {
+    testHttpClientWebsocket(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testHttpClientWebsocketWorker() throws Exception {
+    testHttpClientWebsocket(workerContextFactory, workerChecker);
+  }
+
+  private void testHttpClientWebsocket(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) throws Exception {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean websocketConnected = new AtomicBoolean();
+    AtomicBoolean websocketDisconnected = new AtomicBoolean();
+    AtomicBoolean socketConnectedCalled = new AtomicBoolean();
+    AtomicBoolean socketDisconnectedCalled = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public HttpClientMetrics createMetrics(HttpClient client, HttpClientOptions options) {
+        return new DummyHttpClientMetrics() {
+          @Override
+          public Void connected(Void socketMetric, WebSocket webSocket) {
+            websocketConnected.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void webSocketMetric) {
+            websocketDisconnected.set(true);
+          }
+          @Override
+          public Void connected(SocketAddress remoteAddress) {
+            socketConnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+            socketDisconnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+        };
+      }
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    HttpServer server = vertx.createHttpServer();
+    server.websocketHandler(ws -> {
+      ws.handler(buf -> {
+        ws.write(Buffer.buffer("bye"));
+      });
+    });
+    CountDownLatch latch = new CountDownLatch(1);
+    server.listen(8080, "localhost", ar -> {
+      assertTrue(ar.succeeded());
+      latch.countDown();
+    });
+    awaitLatch(latch);
+    Context ctx = contextFactory.apply(vertx);
+    ctx.runOnContext(v1 -> {
+      expectedThread.set(Thread.currentThread());
+      expectedContext.set(Vertx.currentContext());
+      HttpClient client = vertx.createHttpClient();
+      checker.accept(expectedThread.get(), expectedContext.get());
+      client.websocket(8080, "localhost", "/", ws -> {
+        ws.handler(buf -> {
+          ws.closeHandler(v2 -> {
+            executeInVanillaThread(() -> {
+              client.close();
+              vertx.close(v3 -> {
+                assertTrue(websocketConnected.get());
+                assertTrue(websocketDisconnected.get());
+                assertTrue(socketConnectedCalled.get());
+                assertTrue(socketDisconnectedCalled.get());
+                assertTrue(bytesReadCalled.get());
+                assertTrue(bytesWrittenCalled.get());
+                assertTrue(closeCalled.get());
+                testComplete();
+              });
+            });
+          });
+          ws.close();
+        });
+        ws.write(Buffer.buffer("hello"));
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testNetServerEventLoop() throws Exception {
+    testNetServer(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testNetServerWorker() throws Exception {
+    testNetServer(workerContextFactory, workerChecker);
+  }
+
+  private void testNetServer(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) throws Exception {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean socketConnectedCalled = new AtomicBoolean();
+    AtomicBoolean socketDisconnectedCalled = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public TCPMetrics createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options) {
+        return new DummyTCPMetrics() {
+          @Override
+          public Void connected(SocketAddress remoteAddress) {
+            socketConnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+            socketDisconnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+        };
+      }
+    };
+    CountDownLatch latch = new CountDownLatch(1);
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    Context ctx = contextFactory.apply(vertx);
+    ctx.runOnContext(v1 -> {
+      NetServer server = vertx.createNetServer().connectHandler(so -> {
+        so.handler(buf -> {
+          so.write("bye");
+        });
+      });
+      server.listen(1234, "localhost", ar -> {
+        assertTrue(ar.succeeded());
+        expectedThread.set(Thread.currentThread());
+        expectedContext.set(Vertx.currentContext());
+        checker.accept(expectedThread.get(), expectedContext.get());
+        latch.countDown();
+      });
+    });
+    awaitLatch(latch);
+    NetClient client = vertx.createNetClient();
+    client.connect(1234, "localhost", ar -> {
+      assertTrue(ar.succeeded());
+      NetSocket so = ar.result();
+      so.handler(buf -> {
+        so.closeHandler(v -> {
+          executeInVanillaThread(() -> {
+            vertx.close(v4 -> {
+              assertTrue(bytesReadCalled.get());
+              assertTrue(bytesWrittenCalled.get());
+              assertTrue(socketConnectedCalled.get());
+              assertTrue(socketDisconnectedCalled.get());
+              assertTrue(closeCalled.get());
+              testComplete();
+            });
+          });
+        });
+        so.close();
+      });
+      so.write("hello");
+    });
+    await();
+  }
+
+  @Test
+  public void testNetClientEventLoop() throws Exception {
+    testNetClient(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testNetClientWorker() throws Exception {
+    testNetClient(workerContextFactory, workerChecker);
+  }
+
+  private void testNetClient(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) throws Exception {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean socketConnectedCalled = new AtomicBoolean();
+    AtomicBoolean socketDisconnectedCalled = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public TCPMetrics createMetrics(NetClient client, NetClientOptions options) {
+        return new DummyTCPMetrics() {
+          @Override
+          public Void connected(SocketAddress remoteAddress) {
+            socketConnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+            return null;
+          }
+          @Override
+          public void disconnected(Void socketMetric, SocketAddress remoteAddress) {
+            socketDisconnectedCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+        };
+      }
+    };
+    CountDownLatch latch = new CountDownLatch(1);
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    Context ctx = contextFactory.apply(vertx);
+    NetServer server = vertx.createNetServer().connectHandler(so -> {
+      so.handler(buf -> {
+        so.write("bye");
+      });
+    });
+    server.listen(1234, "localhost", ar -> {
+      assertTrue(ar.succeeded());
+      latch.countDown();
+    });
+    awaitLatch(latch);
+    ctx.runOnContext(v1 -> {
+      NetClient client = vertx.createNetClient();
+      expectedThread.set(Thread.currentThread());
+      expectedContext.set(Vertx.currentContext());
+      client.connect(1234, "localhost", ar -> {
+        assertTrue(ar.succeeded());
+        NetSocket so = ar.result();
+        so.handler(buf -> {
+          so.closeHandler(v -> {
+            assertTrue(bytesReadCalled.get());
+            assertTrue(bytesWrittenCalled.get());
+            assertTrue(socketConnectedCalled.get());
+            assertTrue(socketDisconnectedCalled.get());
+            executeInVanillaThread(() -> {
+              client.close();
+              vertx.close(v4 -> {
+                assertTrue(closeCalled.get());
+                testComplete();
+              });
+            });
+          });
+          so.close();
+        });
+        so.write("hello");
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testDatagramEventLoop() throws Exception {
+    testDatagram(eventLoopContextFactory, eventLoopChecker);
+  }
+
+  @Test
+  public void testDatagramWorker() throws Exception {
+    testDatagram(workerContextFactory, workerChecker);
+  }
+
+  private void testDatagram(Function<Vertx, Context> contextFactory, BiConsumer<Thread, Context> checker) {
+    AtomicReference<Thread> expectedThread = new AtomicReference<>();
+    AtomicReference<Context> expectedContext = new AtomicReference<>();
+    AtomicBoolean listening = new AtomicBoolean();
+    AtomicBoolean bytesReadCalled = new AtomicBoolean();
+    AtomicBoolean bytesWrittenCalled = new AtomicBoolean();
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public DatagramSocketMetrics createMetrics(DatagramSocket socket, DatagramSocketOptions options) {
+        return new DummyDatagramMetrics() {
+          @Override
+          public void listening(SocketAddress localAddress) {
+            listening.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesRead(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesReadCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void bytesWritten(Void socketMetric, SocketAddress remoteAddress, long numberOfBytes) {
+            bytesWrittenCalled.set(true);
+            checker.accept(expectedThread.get(), expectedContext.get());
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+        };
+      }
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    Context ctx = contextFactory.apply(vertx);
+    ctx.runOnContext(v1 -> {
+      expectedThread.set(Thread.currentThread());
+      expectedContext.set(Vertx.currentContext());
+      DatagramSocket socket = vertx.createDatagramSocket();
+      socket.listen(1234, "localhost", ar1 -> {
+        assertTrue(ar1.succeeded());
+        checker.accept(expectedThread.get(), expectedContext.get());
+        socket.handler(packet -> {
+          assertTrue(listening.get());
+          assertTrue(bytesReadCalled.get());
+          assertTrue(bytesWrittenCalled.get());
+          executeInVanillaThread(() -> {
+            socket.close(ar2 -> {
+              assertTrue(closeCalled.get());
+              assertTrue(ar2.succeeded());
+              testComplete();
+            });
+          });
+        });
+        socket.send(Buffer.buffer("msg"), 1234, "localhost", ar2 -> {
+          assertTrue(ar2.succeeded());
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testEventBusLifecycle() {
+    AtomicBoolean closeCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public EventBusMetrics createMetrics(EventBus eventBus) {
+        return new DummyEventBusMetrics() {
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+          @Override
+          public void close() {
+            closeCalled.set(true);
+          }
+        };
+      }
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    vertx.eventBus();
+    executeInVanillaThread(() -> {
+      vertx.close(ar -> {
+        assertTrue(ar.succeeded());
+        assertTrue(closeCalled.get());
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testMessageHandler() {
+    testMessageHandler((vertx, handler) -> handler.handle(null), eventLoopChecker);
+  }
+
+  @Test
+  public void testMessageHandlerEventLoop() {
+    testMessageHandler((vertx, handler) -> eventLoopContextFactory.apply(vertx).runOnContext(handler), eventLoopChecker);
+  }
+
+  @Test
+  public void testMessageHandlerWorker() {
+    testMessageHandler((vertx, handler) -> workerContextFactory.apply(vertx).runOnContext(handler), workerChecker);
+  }
+
+  private void testMessageHandler(BiConsumer<Vertx, Handler<Void>> runOnContext, BiConsumer<Thread, Context> checker) {
+    AtomicReference<Thread> registerThread = new AtomicReference<>();
+    AtomicReference<Context> registerContext = new AtomicReference<>();
+    AtomicBoolean unregisteredCalled = new AtomicBoolean();
+    AtomicBoolean beginHandleCalled = new AtomicBoolean();
+    AtomicBoolean endHandleCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public EventBusMetrics createMetrics(EventBus eventBus) {
+        return new DummyEventBusMetrics() {
+          @Override
+          public boolean isEnabled() {
+            return true;
+          }
+          @Override
+          public Void handlerRegistered(String address, boolean replyHandler) {
+            registerThread.set(Thread.currentThread());
+            registerContext.set(Vertx.currentContext());
+            return null;
+          }
+          @Override
+          public void handlerUnregistered(Void handler) {
+            unregisteredCalled.set(true);
+            checker.accept(registerThread.get(), registerContext.get());
+          }
+          @Override
+          public void beginHandleMessage(Void handler, boolean local) {
+            beginHandleCalled.set(true);
+            checker.accept(registerThread.get(), registerContext.get());
+          }
+          @Override
+          public void endHandleMessage(Void handler, Throwable failure) {
+            endHandleCalled.set(true);
+            checker.accept(registerThread.get(), registerContext.get());
+          }
+        };
+      }
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    EventBus eb = vertx.eventBus();
+    runOnContext.accept(vertx, v -> {
+      MessageConsumer<Object> consumer = eb.consumer("the_address");
+      consumer.handler(msg -> {
+        // checker.accept(thread, context);
+        executeInVanillaThread(() -> {
+          vertx.getOrCreateContext().runOnContext(v2 -> {
+            consumer.unregister(ar -> {
+              assertTrue(beginHandleCalled.get());
+              assertTrue(endHandleCalled.get());
+              waitUntil(() -> unregisteredCalled.get());
+              testComplete();
+            });
+          });
+        });
+      }).completionHandler(ar -> {
+        assertTrue(ar.succeeded());
+        eb.send("the_address", "the_msg");
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testDeployEventLoop() {
+    testDeploy(false, false, eventLoopChecker);
+  }
+
+  @Test
+  public void testDeployWorker() {
+    testDeploy(true, false, workerChecker);
+  }
+
+  @Test
+  public void testDeployMultiThreadedWorker() {
+    testDeploy(true, true, workerChecker);
+  }
+
+  private void testDeploy(boolean worker, boolean multiThreaded, BiConsumer<Thread, Context> checker) {
+    AtomicReference<Thread> verticleThread = new AtomicReference<>();
+    AtomicReference<Context> verticleContext = new AtomicReference<>();
+    AtomicBoolean deployedCalled = new AtomicBoolean();
+    AtomicBoolean undeployedCalled = new AtomicBoolean();
+    ConfigurableMetricsFactory.delegate = (vertx, options) -> new DummyVertxMetrics() {
+      @Override
+      public void verticleDeployed(Verticle verticle) {
+        deployedCalled.set(true);
+        checker.accept(verticleThread.get(), verticleContext.get());
+      }
+      @Override
+      public void verticleUndeployed(Verticle verticle) {
+        undeployedCalled.set(true);
+        checker.accept(verticleThread.get(), verticleContext.get());
+      }
+    };
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        verticleThread.set(Thread.currentThread());
+        verticleContext.set(Vertx.currentContext());
+      }
+    }, new DeploymentOptions().setWorker(worker).setMultiThreaded(multiThreaded), ar1 -> {
+      assertTrue(ar1.succeeded());
+      vertx.undeploy(ar1.result(), ar2 -> {
+        assertTrue(ar1.succeeded());
+        assertTrue(deployedCalled.get());
+        assertTrue(undeployedCalled.get());
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  private void executeInVanillaThread(Runnable task) {
+    new Thread(task).start();
+  }
+
+  private Function<Vertx, Context> eventLoopContextFactory = Vertx::getOrCreateContext;
+
+  private BiConsumer<Thread, Context> eventLoopChecker = (thread, ctx) -> {
+    assertSame(Vertx.currentContext(), ctx);
+    assertSame(Thread.currentThread(), thread);
+  };
+
+  private Function<Vertx, Context> workerContextFactory = vertx -> {
+    AtomicReference<Context> ctx = new AtomicReference<>();
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        ctx.set(context);
+        super.start();
+      }
+    }, new DeploymentOptions().setWorker(true));
+    waitUntil(() -> ctx.get() != null);
+    return ctx.get();
+  };
+
+  private BiConsumer<Thread, Context> workerChecker = (thread, ctx) -> {
+    assertSame(Vertx.currentContext(), ctx);
+    assertTrue(Context.isOnWorkerThread());
+  };
+}

--- a/src/test/java/io/vertx/test/core/MetricsTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsTest.java
@@ -24,10 +24,13 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.test.fakemetrics.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -36,6 +39,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class MetricsTest extends VertxTestBase {
 
   private static final String ADDRESS1 = "some-address1";
+
+  @BeforeClass
+  public static void setFactory() {
+    ConfigurableMetricsFactory.delegate = new FakeMetricsFactory();
+  }
+
+  @AfterClass
+  public static void unsetFactory() {
+    ConfigurableMetricsFactory.delegate = null;
+  }
 
   @Override
   protected VertxOptions getOptions() {
@@ -201,16 +214,26 @@ public class MetricsTest extends VertxTestBase {
   }
 
   @Test
-  public void testHandlerRegistration() {
+  public void testHandlerRegistration() throws Exception {
     FakeEventBusMetrics metrics = FakeMetricsBase.getMetrics(vertx.eventBus());
     MessageConsumer<Object> consumer = vertx.eventBus().consumer(ADDRESS1, msg -> {
     });
+    CountDownLatch latch = new CountDownLatch(1);
+    consumer.completionHandler(ar -> {
+      assertTrue(ar.succeeded());
+      latch.countDown();
+    });
+    awaitLatch(latch);
     assertEquals(1, metrics.getRegistrations().size());
     HandlerMetric registration = metrics.getRegistrations().get(0);
     assertEquals(ADDRESS1, registration.address);
     assertEquals(false, registration.replyHandler);
-    consumer.unregister();
-    assertEquals(0, metrics.getRegistrations().size());
+    consumer.unregister(ar -> {
+      assertTrue(ar.succeeded());
+      assertEquals(0, metrics.getRegistrations().size());
+      testComplete();
+    });
+    await();
   }
 
   @Test
@@ -259,7 +282,7 @@ public class MetricsTest extends VertxTestBase {
   @Test
   public void testHandlerProcessMessageFailure() throws Exception {
     FakeEventBusMetrics metrics = FakeMetricsBase.getMetrics(vertx.eventBus());
-    vertx.eventBus().consumer(ADDRESS1, msg -> {
+    MessageConsumer<Object> consumer = vertx.eventBus().consumer(ADDRESS1, msg -> {
       assertEquals(1, metrics.getReceivedMessages().size());
       HandlerMetric registration = metrics.getRegistrations().get(0);
       assertEquals(1, registration.beginCount.get());
@@ -267,6 +290,12 @@ public class MetricsTest extends VertxTestBase {
       assertEquals(0, registration.failureCount.get());
       throw new RuntimeException();
     });
+    CountDownLatch latch = new CountDownLatch(1);
+    consumer.completionHandler(ar -> {
+      assertTrue(ar.succeeded());
+      latch.countDown();
+    });
+    awaitLatch(latch);
     vertx.eventBus().send(ADDRESS1, "ping");
     assertEquals(1, metrics.getReceivedMessages().size());
     HandlerMetric registration = metrics.getRegistrations().get(0);
@@ -281,19 +310,23 @@ public class MetricsTest extends VertxTestBase {
 
   @Test
   public void testHandlerMetricReply() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
     FakeEventBusMetrics metrics = FakeMetricsBase.getMetrics(vertx.eventBus());
     vertx.eventBus().consumer(ADDRESS1, msg -> {
-      assertEquals(2, metrics.getRegistrations().size());
       assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
+      waitUntil(() -> metrics.getRegistrations().size() == 2);
       HandlerMetric registration = metrics.getRegistrations().get(1);
       assertTrue(registration.replyHandler);
       assertEquals(0, registration.beginCount.get());
       assertEquals(0, registration.endCount.get());
       assertEquals(0, registration.localCount.get());
       msg.reply("pong");
+    }).completionHandler(ar -> {
+      assertTrue(ar.succeeded());
+      latch.countDown();
     });
+    awaitLatch(latch);
     vertx.eventBus().send(ADDRESS1, "ping", reply -> {
-      assertEquals(2, metrics.getRegistrations().size());
       assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
       HandlerMetric registration = metrics.getRegistrations().get(1);
       assertTrue(registration.replyHandler);
@@ -301,7 +334,6 @@ public class MetricsTest extends VertxTestBase {
       assertEquals(0, registration.endCount.get());
       assertEquals(1, registration.localCount.get());
       vertx.runOnContext(v -> {
-        assertEquals(1, metrics.getRegistrations().size());
         assertEquals(ADDRESS1, metrics.getRegistrations().get(0).address);
         assertTrue(registration.replyHandler);
         assertEquals(1, registration.beginCount.get());
@@ -380,6 +412,27 @@ public class MetricsTest extends VertxTestBase {
         ws.handler(buffer -> {
           ws.close();
         });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testMulti() {
+    HttpServer s1 = vertx.createHttpServer();
+    s1.requestHandler(req -> {
+    });
+    s1.listen(8080, ar1 -> {
+      assertTrue(ar1.succeeded());
+      HttpServer s2 = vertx.createHttpServer();
+      s2.requestHandler(req -> {});
+      s2.listen(8080, ar2 -> {
+        assertTrue(ar2.succeeded());
+        FakeHttpServerMetrics metrics1 = FakeMetricsBase.getMetrics(ar1.result());
+        assertSame(ar1.result(), metrics1.server);
+        FakeHttpServerMetrics metrics2 = FakeMetricsBase.getMetrics(ar2.result());
+        assertSame(ar2.result(), metrics2.server);
+        testComplete();
       });
     });
     await();

--- a/src/test/java/io/vertx/test/core/VertxTestBase.java
+++ b/src/test/java/io/vertx/test/core/VertxTestBase.java
@@ -150,38 +150,6 @@ public class VertxTestBase extends AsyncTestBase {
     };
   }
 
-  protected <T> Handler<AsyncResult<T>> onFailure(Consumer<Throwable> consumer) {
-    return result -> {
-      assertFalse(result.succeeded());
-      consumer.accept(result.cause());
-    };
-  }
-
-  protected void awaitLatch(CountDownLatch latch) throws InterruptedException {
-    assertTrue(latch.await(10, TimeUnit.SECONDS));
-  }
-
-  protected void waitUntil(BooleanSupplier supplier) {
-    waitUntil(supplier, 10000);
-  }
-
-  protected void waitUntil(BooleanSupplier supplier, long timeout) {
-    long start = System.currentTimeMillis();
-    while (true) {
-      if (supplier.getAsBoolean()) {
-        break;
-      }
-      try {
-        Thread.sleep(10);
-      } catch (InterruptedException ignore) {
-      }
-      long now = System.currentTimeMillis();
-      if (now - start > timeout) {
-        throw new IllegalStateException("Timed out");
-      }
-    }
-  }
-
   protected void setOptions(TCPSSLOptions sslOptions, KeyCertOptions options) {
     if (options instanceof JksOptions) {
       sslOptions.setKeyStoreOptions((JksOptions) options);

--- a/src/test/java/io/vertx/test/fakemetrics/FakeEventBusMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeEventBusMetrics.java
@@ -138,6 +138,5 @@ public class FakeEventBusMetrics extends FakeMetricsBase implements EventBusMetr
   }
 
   public void close() {
-    throw new UnsupportedOperationException();
   }
 }

--- a/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeHttpServerMetrics.java
@@ -33,13 +33,15 @@ import java.util.concurrent.ConcurrentMap;
 public class FakeHttpServerMetrics extends FakeMetricsBase implements HttpServerMetrics<Void, WebSocketMetric, SocketMetric> {
 
   private final ConcurrentMap<WebSocketBase, WebSocketMetric> webSockets = new ConcurrentHashMap<>();
-
-  public WebSocketMetric getMetric(ServerWebSocket ws) {
-    return webSockets.get(ws);
-  }
+  public final HttpServer server;
 
   public FakeHttpServerMetrics(HttpServer server) {
     super(server);
+    this.server = server;
+  }
+
+  public WebSocketMetric getMetric(ServerWebSocket ws) {
+    return webSockets.get(ws);
   }
 
   @Override

--- a/src/test/resources/META-INF/services/io.vertx.core.spi.VertxMetricsFactory
+++ b/src/test/resources/META-INF/services/io.vertx.core.spi.VertxMetricsFactory
@@ -30,4 +30,4 @@
 #  You may elect to redistribute this code under either of these licenses.
 #
 
-io.vertx.test.fakemetrics.FakeMetricsFactory
+io.vertx.test.core.ConfigurableMetricsFactory


### PR DESCRIPTION
same PR than before (so with removed create/close context/thread constraints)
+ race condition fixes for websocket client/server workers that were seen in metrics test