### PR TITLE
Improve generic type usage

### DIFF
--- a/src/main/java/io/vertx/core/json/impl/Json.java
+++ b/src/main/java/io/vertx/core/json/impl/Json.java
@@ -112,10 +112,9 @@ public class Json {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  public static <T> T decodeValue(String str, Class<?> clazz) throws DecodeException {
+  public static <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
     try {
-      return (T)mapper.readValue(str, clazz);
+      return mapper.readValue(str, clazz);
     }
     catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage());


### PR DESCRIPTION
Previous version of Json class allows this instruction to fail during runtime instead of compilation time:

```
TypeA instance = Json.decodeValue(str, TypeB.class)
```

Signed-off-by: Radoslaw Busz <radoslaw.busz@gmail.com>