### PR TITLE
Bug - using a reference comparing operator for string comparison.

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -283,7 +283,7 @@ public class HttpServerOptions extends NetServerOptions {
 
     if (compressionSupported != that.compressionSupported) return false;
     if (maxWebsocketFrameSize != that.maxWebsocketFrameSize) return false;
-    if (websocketSubProtocols != that.websocketSubProtocols) return false;
+    if (websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null) return false;
 
     return true;
   }

--- a/src/main/java/io/vertx/core/net/JksOptions.java
+++ b/src/main/java/io/vertx/core/net/JksOptions.java
@@ -142,6 +142,40 @@ public class JksOptions implements KeyCertOptions, TrustOptions, Cloneable {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof JksOptions)) {
+      return false;
+    }
+
+    JksOptions that = (JksOptions) o;
+
+    if (password != null ? !password.equals(that.password) : that.password != null) {
+      return false;
+    }
+    if (path != null ? !path.equals(that.path) : that.path != null) {
+      return false;
+    }
+    if (value != null ? !value.equals(that.value) : that.value != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result += 31 * result + (password != null ? password.hashCode() : 0);
+    result += 31 * result + (path != null ? path.hashCode() : 0);
+    result += 31 * result + (value != null ? value.hashCode() : 0);
+
+    return result;
+  }
+
+  @Override
   public JksOptions clone() {
     return new JksOptions(this);
   }

--- a/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
+++ b/src/main/java/io/vertx/core/net/PemKeyCertOptions.java
@@ -190,6 +190,43 @@ public class PemKeyCertOptions implements KeyCertOptions, Cloneable {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PemKeyCertOptions)) {
+      return false;
+    }
+
+    PemKeyCertOptions that = (PemKeyCertOptions) o;
+    if (keyPath != null ? !keyPath.equals(that.keyPath) : that.keyPath != null) {
+      return false;
+    }
+    if (keyValue != null ? !keyValue.equals(that.keyValue) : that.keyValue != null) {
+      return false;
+    }
+    if (certPath != null ? !certPath.equals(that.certPath) : that.certPath != null) {
+      return false;
+    }
+    if (certValue != null ? !certValue.equals(that.certValue) : that.certValue != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result += 31 * result + (keyPath != null ? keyPath.hashCode() : 0);
+    result += 31 * result + (keyValue != null ? keyValue.hashCode() : 0);
+    result += 31 * result + (certPath != null ? certPath.hashCode() : 0);
+    result += 31 * result + (certValue != null ? certValue.hashCode() : 0);
+
+    return result;
+  }
+
+  @Override
   public PemKeyCertOptions clone() {
     return new PemKeyCertOptions(this);
   }

--- a/src/main/java/io/vertx/core/net/PfxOptions.java
+++ b/src/main/java/io/vertx/core/net/PfxOptions.java
@@ -144,6 +144,38 @@ public class PfxOptions implements KeyCertOptions, TrustOptions, Cloneable {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PfxOptions)) {
+      return false;
+    }
+
+    PfxOptions that = (PfxOptions) o;
+    if (password != null ? !password.equals(that.password) : that.password != null) {
+      return false;
+    }
+    if (path != null ? !path.equals(that.path) : that.path != null) {
+      return false;
+    }
+    if (value != null ? !value.equals(that.value) : that.value != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result += 31 * result + (password != null ? password.hashCode() : 0);
+    result += 31 * result + (path != null ? path.hashCode() : 0);
+    result += 31 * result + (value != null ? value.hashCode() : 0);
+    return result;
+  }
+
+  @Override
   public PfxOptions clone() {
     return new PfxOptions(this);
   }

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -281,6 +281,9 @@ public class HttpTest extends HttpTestBase {
     assertEquals(options, options.setWebsocketSubProtocol("foo"));
     assertEquals("foo", options.getWebsocketSubProtocols());
 
+    HttpServerOptions optionsCopy = new HttpServerOptions(options);
+    assertEquals(options, optionsCopy.setWebsocketSubProtocol(new String(options.getWebsocketSubProtocols())));
+
     assertTrue(options.getEnabledCipherSuites().isEmpty());
     assertEquals(options, options.addEnabledCipherSuite("foo"));
     assertEquals(options, options.addEnabledCipherSuite("bar"));

--- a/src/test/java/io/vertx/test/core/KeyStoreTest.java
+++ b/src/test/java/io/vertx/test/core/KeyStoreTest.java
@@ -334,6 +334,27 @@ public class KeyStoreTest extends VertxTestBase {
     testTrustStore(options);
   }
 
+  @Test
+  public void testKeyOptionsEquality() {
+    JksOptions jksOptions = (JksOptions) getServerCertOptions(KeyCert.JKS);
+    JksOptions jksOptionsCopy = new JksOptions(jksOptions);
+
+    PfxOptions pfxOptions = (PfxOptions) getServerCertOptions(KeyCert.PKCS12);
+    PfxOptions pfxOptionsCopy = new PfxOptions(pfxOptions);
+
+    PemKeyCertOptions pemKeyCertOptions = (PemKeyCertOptions) getServerCertOptions(KeyCert.PEM);
+    PemKeyCertOptions pemKeyCertOptionsCopy = new PemKeyCertOptions(pemKeyCertOptions);
+
+    assertEquals(jksOptions, jksOptionsCopy);
+    assertEquals(jksOptions.hashCode(), jksOptionsCopy.hashCode());
+
+    assertEquals(pfxOptions, pfxOptionsCopy);
+    assertEquals(pfxOptions.hashCode(), pfxOptionsCopy.hashCode());
+
+    assertEquals(pemKeyCertOptions, pemKeyCertOptionsCopy);
+    assertEquals(pemKeyCertOptions.hashCode(), pemKeyCertOptionsCopy.hashCode());
+  }
+
   private void testKeyStore(KeyCertOptions options) throws Exception {
     KeyStoreHelper helper = KeyStoreHelper.create((VertxInternal) vertx, options);
     KeyManager[] keyManagers = helper.getKeyMgrs((VertxInternal) vertx);


### PR DESCRIPTION
It's also worth considering using the Lombok project to generate boiler plate code like equals, hashcode and getters (https://projectlombok.org/features). Not sure though, whether it would interfere with the CodeGenProcessor class.

Signed-off-by: Radoslaw Busz <radoslaw.busz@gmail.com>