### PR TITLE
Enable pattern replacement (Slf4j / Logback like)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <metrics.version>3.0.2</metrics.version>
     <log4j.version>1.2.17</log4j.version>
     <slf4j.version>1.7.7</slf4j.version>
+    <logback.version>1.1.3</logback.version>
     <junit.version>4.11</junit.version>
     <asciidoclet.version>1.5.1</asciidoclet.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>
@@ -105,6 +106,12 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+   <groupId>ch.qos.logback</groupId>
+     <artifactId>logback-classic</artifactId>
+     <version>${logback.version}</version>
+     <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/src/main/java/io/vertx/core/logging/Logger.java
+++ b/src/main/java/io/vertx/core/logging/Logger.java
@@ -1,10 +1,17 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
- * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
- * which accompanies this distribution. The Eclipse Public License is available at
- * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
- * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
- * licenses.
+ * Copyright (c) 2009 Red Hat, Inc.
+ * -------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package io.vertx.core.logging;

--- a/src/main/java/io/vertx/core/logging/Logger.java
+++ b/src/main/java/io/vertx/core/logging/Logger.java
@@ -1,17 +1,10 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc.
- * -------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
- *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
- *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
+ * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
+ * which accompanies this distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.core.logging;
@@ -19,18 +12,18 @@ package io.vertx.core.logging;
 import io.vertx.core.logging.impl.LogDelegate;
 
 /**
- * This class allows us to isolate all our logging dependencies in one place. It also allows us to have zero runtime
- * 3rd party logging jar dependencies, since we default to JUL by default.
+ * This class allows us to isolate all our logging dependencies in one place. It also allows us to have zero runtime 3rd
+ * party logging jar dependencies, since we default to JUL by default.
  * <p>
- * By default logging will occur using JUL (Java-Util-Logging). The logging configuration file (logging.properties)
- * used by JUL will taken from the default logging.properties in the JDK installation if no {@code  java.util.logging.config.file} system
- * property is set.
+ * By default logging will occur using JUL (Java-Util-Logging). The logging configuration file (logging.properties) used
+ * by JUL will taken from the default logging.properties in the JDK installation if no
+ * {@code  java.util.logging.config.file} system property is set.
  * <p>
  * If you would prefer to use Log4J or SLF4J instead of JUL then you can set a system property called
- * {@code io.vertx.logger-delegate-factory-class-name} to the class name of the delegate for your logging system.
- * For Log4J the value is {@code io.vertx.core.logging.impl.Log4JLogDelegateFactory}, for SLF4J the value
- * is {@code io.vertx.core.logging.impl.SLF4JLogDelegateFactory}. You will need to ensure whatever jar files
- * required by your favourite log framework are on your classpath.
+ * {@code io.vertx.logger-delegate-factory-class-name} to the class name of the delegate for your logging system. For
+ * Log4J the value is {@code io.vertx.core.logging.impl.Log4JLogDelegateFactory}, for SLF4J the value is
+ * {@code io.vertx.core.logging.impl.SLF4JLogDelegateFactory}. You will need to ensure whatever jar files required by
+ * your favourite log framework are on your classpath.
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  */
@@ -58,48 +51,95 @@ public class Logger {
     delegate.fatal(message);
   }
 
-  public void fatal(final Object message, final Throwable t) {
-    delegate.fatal(message, t);
+  public void fatal(String format, Object arg) {
+    delegate.fatal(format, arg);
+  }
+
+  public void fatal(String format, Object arg1, Object arg2) {
+    delegate.fatal(format, arg1, arg2);
+  }
+
+  public void fatal(String format, Object... arguments) {
+    delegate.fatal(format, arguments);
   }
 
   public void error(final Object message) {
     delegate.error(message);
   }
 
-  public void error(final Object message, final Throwable t) {
-    delegate.error(message, t);
+  public void error(String format, Object arg) {
+    delegate.error(format, arg);
+  }
+
+  public void error(String format, Object arg1, Object arg2) {
+    delegate.error(format, arg1, arg2);
+  }
+
+  public void error(String format, Object... arguments) {
+    delegate.error(format, arguments);
   }
 
   public void warn(final Object message) {
     delegate.warn(message);
   }
 
-  public void warn(final Object message, final Throwable t) {
-    delegate.warn(message, t);
+  public void warn(String format, Object arg) {
+    delegate.warn(format, arg);
+  }
+
+  public void warn(String format, Object arg1, Object arg2) {
+    delegate.warn(format, arg1, arg2);
+  }
+
+  public void warn(String format, Object... arguments) {
+    delegate.warn(format, arguments);
   }
 
   public void info(final Object message) {
     delegate.info(message);
   }
 
-  public void info(final Object message, final Throwable t) {
-    delegate.info(message, t);
+  public void info(String format, Object arg) {
+    delegate.info(format, arg);
+  }
+
+  public void info(String format, Object arg1, Object arg2) {
+    delegate.info(format, arg1, arg2);
+  }
+
+  public void info(String format, Object... arguments) {
+    delegate.info(format, arguments);
   }
 
   public void debug(final Object message) {
     delegate.debug(message);
   }
 
-  public void debug(final Object message, final Throwable t) {
-    delegate.debug(message, t);
+  public void debug(String format, Object arg) {
+    delegate.debug(format, arg);
+  }
+
+  public void debug(String format, Object arg1, Object arg2) {
+    delegate.debug(format, arg1, arg2);
+  }
+
+  public void debug(String format, Object... arguments) {
+    delegate.debug(format, arguments);
   }
 
   public void trace(final Object message) {
     delegate.trace(message);
   }
 
-  public void trace(final Object message, final Throwable t) {
-    delegate.trace(message, t);
+  public void trace(String format, Object arg) {
+    delegate.trace(format, arg);
   }
 
+  public void trace(String format, Object arg1, Object arg2) {
+    delegate.trace(format, arg1, arg2);
+  }
+
+  public void trace(String format, Object... arguments) {
+    delegate.trace(format, arguments);
+  }
 }

--- a/src/main/java/io/vertx/core/logging/Logger.java
+++ b/src/main/java/io/vertx/core/logging/Logger.java
@@ -19,20 +19,21 @@ package io.vertx.core.logging;
 import io.vertx.core.logging.impl.LogDelegate;
 
 /**
- * This class allows us to isolate all our logging dependencies in one place. It also allows us to have zero runtime 3rd
- * party logging jar dependencies, since we default to JUL by default.
+ * This class allows us to isolate all our logging dependencies in one place. It also allows us to have zero runtime
+ * 3rd party logging jar dependencies, since we default to JUL by default.
  * <p>
- * By default logging will occur using JUL (Java-Util-Logging). The logging configuration file (logging.properties) used
- * by JUL will taken from the default logging.properties in the JDK installation if no
- * {@code  java.util.logging.config.file} system property is set.
+ * By default logging will occur using JUL (Java-Util-Logging). The logging configuration file (logging.properties)
+ * used by JUL will taken from the default logging.properties in the JDK installation if no {@code  java.util.logging.config.file} system
+ * property is set.
  * <p>
  * If you would prefer to use Log4J or SLF4J instead of JUL then you can set a system property called
- * {@code io.vertx.logger-delegate-factory-class-name} to the class name of the delegate for your logging system. For
- * Log4J the value is {@code io.vertx.core.logging.impl.Log4JLogDelegateFactory}, for SLF4J the value is
- * {@code io.vertx.core.logging.impl.SLF4JLogDelegateFactory}. You will need to ensure whatever jar files required by
- * your favourite log framework are on your classpath.
+ * {@code io.vertx.logger-delegate-factory-class-name} to the class name of the delegate for your logging system.
+ * For Log4J the value is {@code io.vertx.core.logging.impl.Log4JLogDelegateFactory}, for SLF4J the value
+ * is {@code io.vertx.core.logging.impl.SLF4JLogDelegateFactory}. You will need to ensure whatever jar files
+ * required by your favourite log framework are on your classpath.
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
+ * @author Patrick Sauts
  */
 public class Logger {
 

--- a/src/main/java/io/vertx/core/logging/helper/LogFormatter.java
+++ b/src/main/java/io/vertx/core/logging/helper/LogFormatter.java
@@ -1,0 +1,345 @@
+package io.vertx.core.logging.helper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Inspired from LogBack and Slf4j<br>
+ * 
+ * @author Patrick Sauts
+ */
+final public class LogFormatter {
+  static final char PARAM_START = '{';
+  static final char PARAM_STOP = '}';
+  static final String PARAM_STR = "{}";
+  private static final char ESCAPE_CHAR = '\\';
+  private static final String SEPARATOR = ", ";
+
+  /**
+   * @param messagePattern
+   * @param arg
+   * @return
+   */
+  final public static LogTupple format(String messagePattern, Object arg) {
+    if(arg instanceof Object[]) return paramsFormat(messagePattern, (Object[]) arg);
+    return paramsFormat(messagePattern, new Object[] { arg });
+  }
+
+  /**
+   * @param messagePattern
+   * @param arg1
+   * @param arg2
+   * @return
+   */
+  final public static LogTupple format(final String messagePattern, Object arg1, Object arg2) {
+    return paramsFormat(messagePattern, new Object[] { arg1, arg2 });
+  }
+
+  /**
+   * @param messagePattern
+   * @param params
+   * @return
+   */
+  final public static LogTupple paramsFormat(final String messagePattern, final Object[] params) {
+
+    if (params == null) {
+      return new LogTupple(messagePattern);
+    }
+
+    Throwable throwableCandidate = getThrowableCandidate(params);
+    int length = params.length;
+    if(throwableCandidate != null) --length;
+    
+    if (messagePattern == null) {
+      return new LogTupple(join(params,length), throwableCandidate);
+    }
+
+
+    int i = 0;
+    int j;
+    StringBuilder sbuf = new StringBuilder(messagePattern.length() + 50);
+
+    int L;
+    for (L = 0; L < length; L++) {
+
+      j = messagePattern.indexOf(PARAM_STR, i);
+
+      if (j == -1) {
+        // no more variables
+        if (i == 0) { // this is a simple string
+          return new LogTupple(messagePattern, throwableCandidate);
+        } else { // add the tail string which contains no variables and return
+          // the result.
+          sbuf.append(messagePattern.substring(i, messagePattern.length()));
+          return new LogTupple(sbuf.toString(), throwableCandidate);
+        }
+      } else {
+        if (isEscapedDelimeter(messagePattern, j)) {
+          if (!isDoubleEscaped(messagePattern, j)) {
+            L--; // DELIM_START was escaped, thus should not be incremented
+            sbuf.append(messagePattern.substring(i, j - 1));
+            sbuf.append(PARAM_START);
+            i = j + 1;
+          } else {
+            // The escape character preceding the delimiter start is
+            // itself escaped: "abc x:\\{}"
+            // we have to consume one backward slash
+            sbuf.append(messagePattern.substring(i, j - 1));
+            deeplyAppendParameter(sbuf, params[L], new HashMap());
+            i = j + 2;
+          }
+        } else {
+          // normal case
+          sbuf.append(messagePattern.substring(i, j));
+          deeplyAppendParameter(sbuf, params[L], new HashMap());
+          i = j + 2;
+        }
+      }
+    }
+    // append the characters following the last {} pair.
+    sbuf.append(messagePattern.substring(i, messagePattern.length()));
+    if (L <= params.length - 1) {
+      return new LogTupple(sbuf.toString(), throwableCandidate);
+    } else {
+      return new LogTupple(sbuf.toString());
+    }
+  }
+
+  private static String join(Object[] array, int endIndex) {
+    if (array == null) {
+      return null;
+    }
+    int startIndex = 0;
+
+    // endIndex - startIndex > 0: Len = NofStrings *(len(firstString) + len(separator))
+    // (Assuming that all Strings are roughly equally long)
+    int bufSize = (endIndex - startIndex);
+    if (bufSize <= 0) {
+      return "";
+    }
+
+    bufSize *= ((array[startIndex] == null ? 16 : array[startIndex].toString().length()) + SEPARATOR.length());
+
+    StringBuilder buf = new StringBuilder(bufSize);
+
+    for (int i = startIndex; i < endIndex; i++) {
+      if (i > startIndex) {
+        buf.append(SEPARATOR);
+      }
+      if (array[i] != null) {
+        buf.append(array[i]);
+      }
+    }
+    return buf.toString();
+
+  }
+
+  final static boolean isEscapedDelimeter(String messagePattern, int delimeterStartIndex) {
+
+    if (delimeterStartIndex == 0) {
+      return false;
+    }
+    char potentialEscape = messagePattern.charAt(delimeterStartIndex - 1);
+    if (potentialEscape == ESCAPE_CHAR) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  final static boolean isDoubleEscaped(String messagePattern, int delimeterStartIndex) {
+    if (delimeterStartIndex >= 2 && messagePattern.charAt(delimeterStartIndex - 2) == ESCAPE_CHAR) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // special treatment of array values was suggested by 'lizongbo'
+  private static void deeplyAppendParameter(StringBuilder sbuf, Object o, Map seenMap) {
+    if (o == null) {
+      sbuf.append("null");
+      return;
+    }
+    if (!o.getClass().isArray()) {
+      safeObjectAppend(sbuf, o);
+    } else {
+      // check for primitive array types because they
+      // unfortunately cannot be cast to Object[]
+      if (o instanceof boolean[]) {
+        booleanArrayAppend(sbuf, (boolean[]) o);
+      } else if (o instanceof byte[]) {
+        byteArrayAppend(sbuf, (byte[]) o);
+      } else if (o instanceof char[]) {
+        charArrayAppend(sbuf, (char[]) o);
+      } else if (o instanceof short[]) {
+        shortArrayAppend(sbuf, (short[]) o);
+      } else if (o instanceof int[]) {
+        intArrayAppend(sbuf, (int[]) o);
+      } else if (o instanceof long[]) {
+        longArrayAppend(sbuf, (long[]) o);
+      } else if (o instanceof float[]) {
+        floatArrayAppend(sbuf, (float[]) o);
+      } else if (o instanceof double[]) {
+        doubleArrayAppend(sbuf, (double[]) o);
+      } else {
+        objectArrayAppend(sbuf, (Object[]) o, seenMap);
+      }
+    }
+  }
+
+  private static void safeObjectAppend(StringBuilder sbuf, Object o) {
+    try {
+      String oAsString = o.toString();
+      sbuf.append(oAsString);
+    } catch (Throwable t) {
+      sbuf.append("!! Invocation of toString() failed on object of type [" + o.getClass().getName() + "] !!");
+    }
+
+  }
+
+  private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Map seenMap) {
+    sbuf.append('[');
+    if (!seenMap.containsKey(a)) {
+      seenMap.put(a, null);
+      final int len = a.length;
+      for (int i = 0; i < len; i++) {
+        deeplyAppendParameter(sbuf, a[i], seenMap);
+        if (i != len - 1)
+          sbuf.append(", ");
+      }
+      // allow repeats in siblings
+      seenMap.remove(a);
+    } else {
+      sbuf.append("...");
+    }
+    sbuf.append(']');
+  }
+
+  private static void booleanArrayAppend(StringBuilder sbuf, boolean[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void byteArrayAppend(StringBuilder sbuf, byte[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void charArrayAppend(StringBuilder sbuf, char[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void shortArrayAppend(StringBuilder sbuf, short[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void intArrayAppend(StringBuilder sbuf, int[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void longArrayAppend(StringBuilder sbuf, long[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void floatArrayAppend(StringBuilder sbuf, float[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  private static void doubleArrayAppend(StringBuilder sbuf, double[] a) {
+    sbuf.append('[');
+    final int len = a.length;
+    for (int i = 0; i < len; i++) {
+      sbuf.append(a[i]);
+      if (i != len - 1)
+        sbuf.append(", ");
+    }
+    sbuf.append(']');
+  }
+
+  static final Throwable getThrowableCandidate(Object[] params) {
+    if (params == null || params.length == 0) {
+      return null;
+    }
+
+    final Object lastEntry = params[params.length - 1];
+    if (lastEntry instanceof Throwable) {
+      return (Throwable) lastEntry;
+    }
+    return null;
+  }
+
+  public static class LogTupple {
+
+    static public LogTupple NULL = new LogTupple(null);
+
+    private String message;
+    private Throwable throwable;
+
+    public LogTupple(String message) {
+      this(message, null);
+    }
+
+    public LogTupple(String message, Throwable throwable) {
+      this.message = message;
+      this.throwable = throwable;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public Throwable getThrowable() {
+      return throwable;
+    }
+
+  }
+
+}

--- a/src/main/java/io/vertx/core/logging/helper/LogFormatter.java
+++ b/src/main/java/io/vertx/core/logging/helper/LogFormatter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2009 Red Hat, Inc.
+ * -------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
 package io.vertx.core.logging.helper;
 
 import java.util.HashMap;

--- a/src/main/java/io/vertx/core/logging/impl/JULLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/JULLogDelegate.java
@@ -14,7 +14,10 @@
  * You may elect to redistribute this code under either of these licenses.
  */
 
-package io.vertx.core.logging.impl;
+ package io.vertx.core.logging.impl;
+
+import io.vertx.core.logging.helper.LogFormatter;
+import io.vertx.core.logging.helper.LogFormatter.LogTupple;
 
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -23,6 +26,7 @@ import java.util.logging.LogRecord;
  * A {@link LogDelegate} which delegates to java.util.logging
  *
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
+ * @author Patrick Sauts
  */
 public class JULLogDelegate implements LogDelegate {
   private final java.util.logging.Logger logger;
@@ -47,48 +51,24 @@ public class JULLogDelegate implements LogDelegate {
     log(Level.SEVERE, message);
   }
 
-  public void fatal(final Object message, final Throwable t) {
-    log(Level.SEVERE, message, t);
-  }
-
   public void error(final Object message) {
     log(Level.SEVERE, message);
-  }
-
-  public void error(final Object message, final Throwable t) {
-    log(Level.SEVERE, message, t);
   }
 
   public void warn(final Object message) {
     log(Level.WARNING, message);
   }
 
-  public void warn(final Object message, final Throwable t) {
-    log(Level.WARNING, message, t);
-  }
-
   public void info(final Object message) {
     log(Level.INFO, message);
-  }
-
-  public void info(final Object message, final Throwable t) {
-    log(Level.INFO, message, t);
   }
 
   public void debug(final Object message) {
     log(Level.FINE, message);
   }
 
-  public void debug(final Object message, final Throwable t) {
-    log(Level.FINE, message, t);
-  }
-
   public void trace(final Object message) {
     log(Level.FINEST, message);
-  }
-
-  public void trace(final Object message, final Throwable t) {
-    log(Level.FINEST, message, t);
   }
 
   private void log(Level level, Object message) {
@@ -108,5 +88,144 @@ public class JULLogDelegate implements LogDelegate {
     record.setSourceClassName(null);
 
     logger.log(record);
+  }
+
+  @Override
+  public void fatal(String format, Object arg) {
+    if (logger.isLoggable(Level.SEVERE)) {
+      logger.severe(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void fatal(String format, Object arg1, Object arg2) {
+    if (logger.isLoggable(Level.SEVERE)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.SEVERE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void fatal(String format, Object... arguments) {
+    if (logger.isLoggable(Level.SEVERE)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.SEVERE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    if (logger.isLoggable(Level.SEVERE)) {
+      logger.severe(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    if (logger.isLoggable(Level.SEVERE)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.SEVERE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    if (logger.isLoggable(Level.SEVERE)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.SEVERE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    if (logger.isLoggable(Level.WARNING)) {
+      logger.warning(LogFormatter.format(format, arg).getMessage());
+    }
+
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    if (logger.isLoggable(Level.WARNING)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.WARNING, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    if (logger.isLoggable(Level.WARNING)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.WARNING, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    if (logger.isLoggable(Level.INFO)) {
+      logger.info(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    if (logger.isLoggable(Level.INFO)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.INFO, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    if (logger.isLoggable(Level.INFO)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.INFO, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    if (logger.isLoggable(Level.FINE)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.FINE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    if (logger.isLoggable(Level.FINE)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.FINE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    if (logger.isLoggable(Level.FINEST)) {
+      logger.finest(LogFormatter.format(format, arg).getMessage());
+    }
+
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    if (logger.isLoggable(Level.FINEST)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.FINEST, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    if (logger.isLoggable(Level.FINEST)) {
+      logger.finest(LogFormatter.format(format, arguments).getMessage());
+    }
   }
 }

--- a/src/main/java/io/vertx/core/logging/impl/Log4jLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/Log4jLogDelegate.java
@@ -1,10 +1,17 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
- * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
- * which accompanies this distribution. The Eclipse Public License is available at
- * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
- * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
- * licenses.
+ * Copyright (c) 2009 Red Hat, Inc.
+ * -------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package io.vertx.core.logging.impl;

--- a/src/main/java/io/vertx/core/logging/impl/Log4jLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/Log4jLogDelegate.java
@@ -1,28 +1,25 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc.
- * -------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
- *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
- *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
+ * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
+ * which accompanies this distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.core.logging.impl;
 
 import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.helper.LogFormatter;
+import io.vertx.core.logging.helper.LogFormatter.LogTupple;
+
 import org.apache.log4j.Level;
 
 /**
  * A {@link LogDelegate} which delegates to Apache Log4j
  *
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
+ * @author Patrick Sauts
  */
 public class Log4jLogDelegate implements LogDelegate {
   private static final String FQCN = Logger.class.getCanonicalName();
@@ -45,52 +42,34 @@ public class Log4jLogDelegate implements LogDelegate {
     return logger.isTraceEnabled();
   }
 
+  @Override
   public void fatal(final Object message) {
     log(Level.FATAL, message);
   }
 
-  public void fatal(final Object message, final Throwable t) {
-    log(Level.FATAL, message, t);
-  }
-
+  @Override
   public void error(final Object message) {
     log(Level.ERROR, message);
   }
 
-  public void error(final Object message, final Throwable t) {
-    log(Level.ERROR, message, t);
-  }
-
+  @Override
   public void warn(final Object message) {
     log(Level.WARN, message);
   }
 
-  public void warn(final Object message, final Throwable t) {
-    log(Level.WARN, message, t);
-  }
-
+  @Override
   public void info(final Object message) {
     log(Level.INFO, message);
   }
 
-  public void info(final Object message, final Throwable t) {
-    log(Level.INFO, message, t);
-  }
-
+  @Override
   public void debug(final Object message) {
     log(Level.DEBUG, message);
   }
 
-  public void debug(final Object message, final Throwable t) {
-    log(Level.DEBUG, message, t);
-  }
-
+  @Override
   public void trace(final Object message) {
     log(Level.TRACE, message);
-  }
-
-  public void trace(final Object message, final Throwable t) {
-    log(Level.TRACE, message, t);
   }
 
   private void log(Level level, Object message) {
@@ -99,5 +78,147 @@ public class Log4jLogDelegate implements LogDelegate {
 
   private void log(Level level, Object message, Throwable t) {
     logger.log(FQCN, level, message, t);
+  }
+
+  @Override
+  public void fatal(String format, Object arg) {
+    if (logger.isEnabledFor(Level.FATAL)) {
+      logger.fatal(LogFormatter.format(format, arg).getMessage());
+    }
+    if (logger.isEnabledFor(Level.FATAL)) {
+      logger.fatal(LogFormatter.format(format, arg).getMessage());
+    }
+
+  }
+
+  @Override
+  public void fatal(String format, Object arg1, Object arg2) {
+    if (logger.isEnabledFor(Level.FATAL)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.FATAL, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void fatal(String format, Object... arguments) {
+    if (logger.isEnabledFor(Level.FATAL)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.FATAL, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    if (logger.isEnabledFor(Level.ERROR)) {
+      logger.error(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    if (logger.isEnabledFor(Level.ERROR)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.ERROR, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    if (logger.isEnabledFor(Level.ERROR)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.ERROR, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    if (logger.isEnabledFor(Level.WARN)) {
+      logger.warn(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    if (logger.isEnabledFor(Level.WARN)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.WARN, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    if (logger.isEnabledFor(Level.WARN)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.WARN, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    if (logger.isEnabledFor(Level.INFO)) {
+      logger.info(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    if (logger.isEnabledFor(Level.INFO)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.INFO, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    if (logger.isEnabledFor(Level.INFO)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.INFO, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    if (logger.isEnabledFor(Level.DEBUG)) {
+      logger.debug(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    if (logger.isEnabledFor(Level.DEBUG)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.DEBUG, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    if (logger.isEnabledFor(Level.DEBUG)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.DEBUG, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    if (logger.isEnabledFor(Level.TRACE)) {
+      logger.trace(LogFormatter.format(format, arg).getMessage());
+    }
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    if (logger.isEnabledFor(Level.TRACE)) {
+      LogTupple tuple = LogFormatter.format(format, arg1, arg2);
+      log(Level.TRACE, tuple.getMessage(), tuple.getThrowable());
+    }
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    if (logger.isEnabledFor(Level.TRACE)) {
+      LogTupple tuple = LogFormatter.format(format, arguments);
+      log(Level.TRACE, tuple.getMessage(), tuple.getThrowable());
+    }
   }
 }

--- a/src/main/java/io/vertx/core/logging/impl/LogBackLogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/impl/LogBackLogDelegateFactory.java
@@ -1,0 +1,15 @@
+package io.vertx.core.logging.impl;
+
+/**
+ * 
+ * @author Patrick Sauts
+ *
+ */
+public class LogBackLogDelegateFactory implements LogDelegateFactory
+{
+   public LogDelegate createDelegate(final String clazz)
+   {
+      return new SLF4JLogDelegate(clazz);
+   }
+
+}

--- a/src/main/java/io/vertx/core/logging/impl/LogBackLogDelegateFactory.java
+++ b/src/main/java/io/vertx/core/logging/impl/LogBackLogDelegateFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2009 Red Hat, Inc.
+ * -------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
 package io.vertx.core.logging.impl;
 
 /**

--- a/src/main/java/io/vertx/core/logging/impl/LogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/LogDelegate.java
@@ -1,10 +1,17 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
- * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
- * which accompanies this distribution. The Eclipse Public License is available at
- * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
- * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
- * licenses.
+ * Copyright (c) 2009 Red Hat, Inc.
+ * -------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package io.vertx.core.logging.impl;

--- a/src/main/java/io/vertx/core/logging/impl/LogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/LogDelegate.java
@@ -1,17 +1,10 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc.
- * -------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
- *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
- *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
+ * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
+ * which accompanies this distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.core.logging.impl;
@@ -20,6 +13,7 @@ package io.vertx.core.logging.impl;
  * I represent operations that are delegated to underlying logging frameworks.
  *
  * @author <a href="kenny.macleod@kizoom.com">Kenny MacLeod</a>
+ * @author Patrick Sauts
  */
 public interface LogDelegate {
   boolean isInfoEnabled();
@@ -30,25 +24,50 @@ public interface LogDelegate {
 
   void fatal(Object message);
 
-  void fatal(Object message, Throwable t);
+  void fatal(String format, Object arg);
+
+  void fatal(String format, Object arg1, Object arg2);
+
+  void fatal(String format, Object... arguments);
 
   void error(Object message);
 
-  void error(Object message, Throwable t);
+  void error(String format, Object arg);
+
+  void error(String format, Object arg1, Object arg2);
+
+  void error(String format, Object... arguments);
 
   void warn(Object message);
 
-  void warn(Object message, Throwable t);
+  void warn(String format, Object arg);
+
+  void warn(String format, Object arg1, Object arg2);
+
+  void warn(String format, Object... arguments);
 
   void info(Object message);
 
-  void info(Object message, Throwable t);
+  void info(String format, Object arg);
+
+  void info(String format, Object arg1, Object arg2);
+
+  void info(String format, Object... arguments);
 
   void debug(Object message);
 
-  void debug(Object message, Throwable t);
+  void debug(String format, Object arg);
+
+  void debug(String format, Object arg1, Object arg2);
+
+  void debug(String format, Object... arguments);
 
   void trace(Object message);
 
-  void trace(Object message, Throwable t);
+  void trace(String format, Object arg);
+
+  void trace(String format, Object arg1, Object arg2);
+
+  void trace(String format, Object... arguments);
+
 }

--- a/src/main/java/io/vertx/core/logging/impl/SLF4JLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/SLF4JLogDelegate.java
@@ -1,10 +1,17 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
- * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
- * which accompanies this distribution. The Eclipse Public License is available at
- * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
- * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
- * licenses.
+ * Copyright (c) 2009 Red Hat, Inc.
+ * -------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  */
 
 package io.vertx.core.logging.impl;

--- a/src/main/java/io/vertx/core/logging/impl/SLF4JLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/impl/SLF4JLogDelegate.java
@@ -1,21 +1,13 @@
 /*
- * Copyright (c) 2009 Red Hat, Inc.
- * -------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
- *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
- *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * Copyright (c) 2009 Red Hat, Inc. ------------------------------------- All rights reserved. This program and the
+ * accompanying materials are made available under the terms of the Eclipse Public License v1.0 and Apache License v2.0
+ * which accompanies this distribution. The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php You may elect to redistribute this code under either of these
+ * licenses.
  */
 
 package io.vertx.core.logging.impl;
-
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +17,9 @@ import static org.slf4j.spi.LocationAwareLogger.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author Patrick Sauts
  */
-public class SLF4JLogDelegate implements LogDelegate{
+public class SLF4JLogDelegate implements LogDelegate {
   private static final String FQCN = io.vertx.core.logging.Logger.class.getCanonicalName();
 
   private final Logger logger;
@@ -107,24 +100,114 @@ public class SLF4JLogDelegate implements LogDelegate{
       l.log(null, FQCN, level, msg, null, t);
     } else {
       switch (level) {
-        case TRACE_INT:
-          logger.trace(msg, t);
-          break;
-        case DEBUG_INT:
-          logger.debug(msg, t);
-          break;
-        case INFO_INT:
-          logger.info(msg, t);
-          break;
-        case WARN_INT:
-          logger.warn(msg, t);
-          break;
-        case ERROR_INT:
-          logger.error(msg, t);
-          break;
-        default:
-          throw new IllegalArgumentException("Unknown log level " + level);
+      case TRACE_INT:
+        logger.trace(msg, t);
+        break;
+      case DEBUG_INT:
+        logger.debug(msg, t);
+        break;
+      case INFO_INT:
+        logger.info(msg, t);
+        break;
+      case WARN_INT:
+        logger.warn(msg, t);
+        break;
+      case ERROR_INT:
+        logger.error(msg, t);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown log level " + level);
       }
     }
+  }
+
+  @Override
+  public void fatal(String format, Object arg) {
+    logger.error(format, arg);
+  }
+
+  @Override
+  public void fatal(String format, Object arg1, Object arg2) {
+    logger.error(format, arg1, arg2);
+  }
+
+  @Override
+  public void fatal(String format, Object... arguments) {
+    logger.error(format, arguments);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    logger.error(format, arg);
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    logger.error(format, arg1, arg2);
+  }
+
+  @Override
+  public void error(String format, Object... arguments) {
+    logger.error(format, arguments);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    logger.warn(format, arg);
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    logger.warn(format, arg1, arg2);
+  }
+
+  @Override
+  public void warn(String format, Object... arguments) {
+    logger.warn(format, arguments);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    logger.info(format, arg);
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    logger.info(format, arg1, arg2);
+  }
+
+  @Override
+  public void info(String format, Object... arguments) {
+    logger.info(format, arguments);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    logger.debug(format, arg);
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    logger.debug(format, arg1, arg2);
+  }
+
+  @Override
+  public void debug(String format, Object... arguments) {
+    logger.debug(format, arguments);
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    logger.trace(format, arg);
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    logger.trace(format, arg1, arg2);
+  }
+
+  @Override
+  public void trace(String format, Object... arguments) {
+    logger.trace(format, arguments);
   }
 }

--- a/src/test/java/io/vertx/core/logging/helper/LogFormatterTest.java
+++ b/src/test/java/io/vertx/core/logging/helper/LogFormatterTest.java
@@ -1,0 +1,64 @@
+package io.vertx.core.logging.helper;
+
+import io.vertx.core.logging.helper.LogFormatter.LogTupple;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogFormatterTest {
+  @Test
+  public void testParamsFormatOneParamNotThrowable() throws Exception {
+    LogTupple tupple = LogFormatter.format("the message pattern {} ...", "param1");
+    Assert.assertEquals("the message pattern param1 ...", tupple.getMessage());
+    Assert.assertNull("No throwable expected", tupple.getThrowable());
+  }
+
+  @Test
+  public void testParamsFormatOneParamThrowable() throws Exception {
+    Throwable throwable = new Throwable();
+    LogTupple tupple = LogFormatter.format("the message pattern {} ...", throwable);
+    Assert.assertEquals("the message pattern {} ...", tupple.getMessage());
+    Assert.assertEquals("Throwable expected", throwable, tupple.getThrowable());
+  }
+
+  @Test
+  public void testParamsFormatTwoParamsNoThrowable() throws Exception {
+    LogTupple tupple = LogFormatter.format("the message pattern {} {} ...", "param1", "param2");
+    Assert.assertEquals("the message pattern param1 param2 ...", tupple.getMessage());
+    Assert.assertNull("No throwable expected", tupple.getThrowable());
+  }
+
+  @Test
+  public void testParamsFormatTwoParamsOneThrowable() throws Exception {
+    Throwable throwable = new Throwable();
+    LogTupple tupple = LogFormatter.format("the message pattern {} ...", "param1", throwable);
+    Assert.assertEquals("the message pattern param1 ...", tupple.getMessage());
+    Assert.assertEquals("Throwable expected", throwable, tupple.getThrowable());
+  }
+
+  @Test
+  public void testParamsFormat10ParamsOneThrowable() throws Exception {
+    Throwable throwable = new Throwable();
+    LogTupple tupple = LogFormatter.format("the message pattern {} {} {} {} {} {} {} {} {} ...", new Object[]{"param1", "param2", "param3", "param4", "param5", "param6", "param7", "param8", "param9", throwable});
+    Assert.assertEquals("the message pattern param1 param2 param3 param4 param5 param6 param7 param8 param9 ...", tupple.getMessage());
+    Assert.assertEquals("Throwable expected", throwable, tupple.getThrowable());
+  }
+  @Test
+  public void testParamsFormat10ParamsNoThrowable() throws Exception {
+    LogTupple tupple = LogFormatter.format("the message pattern {} {} {} {} {} {} {} {} {} {} ...", new Object[]{"param1", "param2", "param3", "param4", "param5", "param6", "param7", "param8", "param9", "param10"});
+    Assert.assertEquals("the message pattern param1 param2 param3 param4 param5 param6 param7 param8 param9 param10 ...", tupple.getMessage());
+    Assert.assertNull("No throwable expected", tupple.getThrowable());
+  }
+  @Test
+  public void testParamsFormat10ParamsAsStringNoThrowable() throws Exception {
+    LogTupple tupple = LogFormatter.format("the message pattern {} {} {} {} {} {} {} {} {} {} ...", new String[]{"param1", "param2", "param3", "param4", "param5", "param6", "param7", "param8", "param9", "param10"});
+    Assert.assertEquals("the message pattern param1 param2 param3 param4 param5 param6 param7 param8 param9 param10 ...", tupple.getMessage());
+    Assert.assertNull("No throwable expected", tupple.getThrowable());
+  }
+  @Test
+  public void testParamsFormat6ParamsMixNoThrowable() throws Exception {
+    LogTupple tupple = LogFormatter.format("the message pattern {} {} {} {} {} {} ...", new Object[]{"param1", 2, 2.3, 200000000000000000l, 2.9999999999, new String[]{"param7", "param8", "param9", "param10"}});
+    Assert.assertEquals("the message pattern param1 2 2.3 200000000000000000 2.9999999999 [param7, param8, param9, param10] ...", tupple.getMessage());
+    Assert.assertNull("No throwable expected", tupple.getThrowable());
+  }
+}


### PR DESCRIPTION
The changes introduce what recent Loggers allow 

So know you can do

```
String myParam = "there"
LOG.debug("Hi {}.", myParam)
```
##### That will produce

```
Hi there.
``` 
##### Only if debug is enabled.

--------------------------

The main difference with 

```
LOG.debug("Hi "+ myParam + ".")
```

Is that in that case the string is always built at run time even if LOG.isDebugEnabled() == false

So 

```
LOG.debug("Hi {}.", myParam)
```

is equivalent to 

```
if(LOG.isDebugEnabled()){
  LOG.debug("Hi "+ myParam + ".")
}
```


You can write the Logs the way you're use to or use this neat way.

Example

```
LOG.debug("the message pattern {} {} {} {} {} {} ...", "param1", 2, 2.3, 200000000000000000l, 2.9999999999, new String[]{"param7", "param8", "param9", "param10"})
```

That will produce

```
the message pattern param1 2 2.3 200000000000000000 2.9999999999 [param7, param8, param9, param10] ...
```