### PR TITLE
HTTP Server Sharing Documentation

### DIFF
--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -298,7 +298,7 @@ The object passed into the handler is a `link:../../apidocs/io/vertx/core/http/H
 server.requestHandler(request -> {
   request.setExpectMultipart(true);
   request.uploadHandler(upload -> {
-    System.out.println("Got a file upload " +  upload.name());
+    System.out.println("Got a file upload " + upload.name());
   });
 });
 ----
@@ -1099,8 +1099,52 @@ responses have returned and there are no outstanding pending requests to write.
 
 === Server sharing
 
-TODO
-round robin requests etc
+When several HTTP servers listen on the same port, vert.x orchestrates the request handling using a
+round-robin strategy.
+
+Let's take a verticle creating a HTTP server such as:
+
+.io.vertx.examples.http.sharing.HttpServerVerticle
+[source,java]
+----
+vertx.createHttpServer().requestHandler(request -> {
+  request.response().end("Hello from server " + this);
+}).listen(8080);
+----
+
+This service is listening on the port 8080. So, when this verticle is instantiated multiple times as with:
+`vertx run io.vertx.examples.http.sharing.HttpServerVerticle -instances 2`, what's happening ? If both
+verticles would bind to the same port, you would receive a socket exception. Fortunately, vert.x is handling
+this case for you. When you deploy another server on the same host and port as an existing server it doesn't
+actually try and create a new server listening on the same host/port. It binds only once to the socket. When
+receiving a request it calls the server handlers following a round robin strategy.
+
+Let's now imagine a client such as:
+[source,java]
+----
+vertx.setPeriodic(100, (l) -> {
+  vertx.createHttpClient().getNow(8080, "localhost", "/", resp -> {
+    resp.bodyHandler(body -> {
+      System.out.println(body.toString("ISO-8859-1"));
+    });
+  });
+});
+----
+
+Vert.x delegates the requests to one of the server sequentially:
+
+[source]
+----
+Hello from i.v.e.h.s.HttpServerVerticle@1
+Hello from i.v.e.h.s.HttpServerVerticle@2
+Hello from i.v.e.h.s.HttpServerVerticle@1
+Hello from i.v.e.h.s.HttpServerVerticle@2
+...
+----
+
+Consequently the servers can scale over available cores while each Vert.x verticle instance remains strictly
+single threaded, and you don't have to do any special tricks like writing load-balancers in order to scale your
+server on your multi-core machine.
 
 === Using HTTPS with Vert.x
 

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -90,7 +90,6 @@ public class HTTPExamples {
   }
 
 
-
   public void example8(HttpServerRequest request) {
 
     MultiMap headers = request.headers();
@@ -104,9 +103,9 @@ public class HTTPExamples {
 
   public void example9(HttpServerRequest request) {
 
-   request.handler(buffer -> {
-     System.out.println("I have received a chunk of the body of length " + buffer.length());
-   });
+    request.handler(buffer -> {
+      System.out.println("I have received a chunk of the body of length " + buffer.length());
+    });
   }
 
   public void example10(HttpServerRequest request) {
@@ -147,7 +146,7 @@ public class HTTPExamples {
     server.requestHandler(request -> {
       request.setExpectMultipart(true);
       request.uploadHandler(upload -> {
-        System.out.println("Got a file upload " +  upload.name());
+        System.out.println("Got a file upload " + upload.name());
       });
     });
   }
@@ -577,4 +576,21 @@ public class HTTPExamples {
     });
 
   }
+
+  public void serversharing(Vertx vertx) {
+    vertx.createHttpServer().requestHandler(request -> {
+      request.response().end("Hello from server " + this);
+    }).listen(8080);
+  }
+
+  public void serversharingclient(Vertx vertx) {
+    vertx.setPeriodic(100, (l) -> {
+      vertx.createHttpClient().getNow(8080, "localhost", "/", resp -> {
+        resp.bodyHandler(body -> {
+          System.out.println(body.toString("ISO-8859-1"));
+        });
+      });
+    });
+  }
+
 }

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -893,8 +893,44 @@
  *
  * === Server sharing
  *
- * TODO
- * round robin requests etc
+ * When several HTTP servers listen on the same port, vert.x orchestrates the request handling using a
+ * round-robin strategy.
+ *
+ * Let's take a verticle creating a HTTP server such as:
+ *
+ * .io.vertx.examples.http.sharing.HttpServerVerticle
+ * [source,$lang]
+ * ----
+ * {@link examples.HTTPExamples#serversharing(io.vertx.core.Vertx)}
+ * ----
+ *
+ * This service is listening on the port 8080. So, when this verticle is instantiated multiple times as with:
+ * `vertx run io.vertx.examples.http.sharing.HttpServerVerticle -instances 2`, what's happening ? If both
+ * verticles would bind to the same port, you would receive a socket exception. Fortunately, vert.x is handling
+ * this case for you. When you deploy another server on the same host and port as an existing server it doesn't
+ * actually try and create a new server listening on the same host/port. It binds only once to the socket. When
+ * receiving a request it calls the server handlers following a round robin strategy.
+ *
+ * Let's now imagine a client such as:
+ * [source,$lang]
+ * ----
+ * {@link examples.HTTPExamples#serversharingclient(io.vertx.core.Vertx)}
+ * ----
+ *
+ * Vert.x delegates the requests to one of the server sequentially:
+ *
+ * [source]
+ * ----
+ * Hello from i.v.e.h.s.HttpServerVerticle@1
+ * Hello from i.v.e.h.s.HttpServerVerticle@2
+ * Hello from i.v.e.h.s.HttpServerVerticle@1
+ * Hello from i.v.e.h.s.HttpServerVerticle@2
+ * ...
+ * ----
+ *
+ * Consequently the servers can scale over available cores while each Vert.x verticle instance remains strictly
+ * single threaded, and you don't have to do any special tricks like writing load-balancers in order to scale your
+ * server on your multi-core machine.
  *
  * === Using HTTPS with Vert.x
  *


### PR DESCRIPTION
Add the paragraph about server sharing and explain the round robin strategy Vert.x uses.

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>