### PR TITLE
Add OSGi metadata to the vert.x core jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,57 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <!-- Generate a jar INDEX.LIST -->
+                <index>true</index>
+                <!-- A manifest containing the OSGi metadata has been generated using the maven-bundle-plugin -->
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                <!-- Add the Maven coordinates in the manifest -->
+                <manifestEntries>
+                  <Maven-Group-Id>${project.groupId}</Maven-Group-Id>
+                  <Maven-Artifact-Id>${project.artifactId}</Maven-Artifact-Id>
+                  <Maven-Version>${project.version}</Maven-Version>
+                </manifestEntries>
+              </archive>
+              <!-- Remove examples and docoverride -->
+              <excludes>
+                <exclude>/docoverride/**</exclude>
+                <exclude>/examples/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.3</version>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Export-Package>io.vertx.core*</Export-Package>
+                <Private-Package>!docoverride*, !examples*</Private-Package>
+                <Import-Package>org.slf4j*;resolution:=optional,
+                  org.apache.log4j;resolution:=optional,
+                  *
+                </Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <resources>
       <resource>

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -674,6 +674,40 @@ to the classpath. The metrics SPI is an advanced feature which allows implemente
 order to gather metrics. For more information on this, please consult the
 `link:../../apidocs/io/vertx/core/spi/metrics/VertxMetrics.html[API Documentation]`.
 
+== OSGi
+
+Vert.x Core is packaged as an OSGi bundle, so can be used in any OSGi R4.2+ environment such as Apache Felix
+or Eclipse Equinox. The bundle exports `io.vertx.core*`.
+
+However, the bundle has some dependencies on Jackson and Netty. To get the vert.x core bundle resolved deploy:
+
+* Jackson Annotation [2.5.0,3)
+* Jackson Core [2.5.0,3)
+* Jackson Databind [2.5.0,3)
+* Netty Buffer [4.0.27,5)
+* Netty Codec [4.0.27,5)
+* Netty Codec/Socks [4.0.27,5)
+* Netty Codec/Common [4.0.27,5)
+* Netty Codec/Handler [4.0.27,5)
+* Netty Codec/Transport [4.0.27,5)
+
+Here is a working deployment on Apache Felix 4.6.1:
+
+[source]
+----
+  14|Active     |    1|Jackson-annotations (2.5.3)
+  15|Active     |    1|Jackson-core (2.5.3)
+  16|Active     |    1|jackson-databind (2.5.3)
+  17|Active     |    1|Netty/Buffer (4.0.27.Final)
+  18|Active     |    1|Netty/Codec (4.0.27.Final)
+  19|Active     |    1|Netty/Codec/HTTP (4.0.27.Final)
+  20|Active     |    1|Netty/Codec/Socks (4.0.27.Final)
+  21|Active     |    1|Netty/Common (4.0.27.Final)
+  22|Active     |    1|Netty/Handler (4.0.27.Final)
+  23|Active     |    1|Netty/Transport (4.0.27.Final)
+  25|Active     |    1|Vert.x Core (3.0.0.SNAPSHOT)
+----
+
 == Clustering
 
 === Trouble-shooting clustering

--- a/src/main/java/io/vertx/core/ServiceHelper.java
+++ b/src/main/java/io/vertx/core/ServiceHelper.java
@@ -19,7 +19,7 @@ package io.vertx.core;
 import java.util.ServiceLoader;
 
 /**
- * A helper class for loading factories from the classpath.
+ * A helper class for loading factories from the classpath and from the vert.x OSGi bundle.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -30,7 +30,15 @@ public class ServiceHelper {
     if (factories.iterator().hasNext()) {
       return factories.iterator().next();
     } else {
-      throw new IllegalStateException("Cannot find META-INF/services/" + clazz.getName() + " on classpath");
+      // By default ServiceLoader.load uses the TCCL, this may not be enough in environement deadling with
+      // classloaders differently such as OSGi. So try with the classloader having loaded this class. In OSGi
+      // this would be the bundle exposing vert.x
+      factories = ServiceLoader.load(clazz, ServiceHelper.class.getClassLoader());
+      if (factories.iterator().hasNext()) {
+        return factories.iterator().next();
+      } else {
+        throw new IllegalStateException("Cannot find META-INF/services/" + clazz.getName() + " on classpath");
+      }
     }
   }
 }

--- a/src/main/java/io/vertx/core/ServiceHelper.java
+++ b/src/main/java/io/vertx/core/ServiceHelper.java
@@ -30,9 +30,9 @@ public class ServiceHelper {
     if (factories.iterator().hasNext()) {
       return factories.iterator().next();
     } else {
-      // By default ServiceLoader.load uses the TCCL, this may not be enough in environement deadling with
-      // classloaders differently such as OSGi. So try with the classloader having loaded this class. In OSGi
-      // this would be the bundle exposing vert.x
+      // By default ServiceLoader.load uses the TCCL, this may not be enough in environment deading with
+      // classloaders differently such as OSGi. So we should try to use the  classloader having loaded this
+      // class. In OSGi it would be the bundle exposing vert.x and so have access to all its classes.
       factories = ServiceLoader.load(clazz, ServiceHelper.class.getClassLoader());
       if (factories.iterator().hasNext()) {
         return factories.iterator().next();

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -643,6 +643,40 @@
  * order to gather metrics. For more information on this, please consult the
  * {@link io.vertx.core.spi.metrics.VertxMetrics API Documentation}.
  *
+ * == OSGi
+ *
+ * Vert.x Core is packaged as an OSGi bundle, so can be used in any OSGi R4.2+ environment such as Apache Felix
+ * or Eclipse Equinox. The bundle exports `io.vertx.core*`.
+ *
+ * However, the bundle has some dependencies on Jackson and Netty. To get the vert.x core bundle resolved deploy:
+ *
+ * * Jackson Annotation [2.5.0,3)
+ * * Jackson Core [2.5.0,3)
+ * * Jackson Databind [2.5.0,3)
+ * * Netty Buffer [4.0.27,5)
+ * * Netty Codec [4.0.27,5)
+ * * Netty Codec/Socks [4.0.27,5)
+ * * Netty Codec/Common [4.0.27,5)
+ * * Netty Codec/Handler [4.0.27,5)
+ * * Netty Codec/Transport [4.0.27,5)
+ *
+ * Here is a working deployment on Apache Felix 4.6.1:
+ *
+ *[source]
+ *----
+ *   14|Active     |    1|Jackson-annotations (2.5.3)
+ *   15|Active     |    1|Jackson-core (2.5.3)
+ *   16|Active     |    1|jackson-databind (2.5.3)
+ *   17|Active     |    1|Netty/Buffer (4.0.27.Final)
+ *   18|Active     |    1|Netty/Codec (4.0.27.Final)
+ *   19|Active     |    1|Netty/Codec/HTTP (4.0.27.Final)
+ *   20|Active     |    1|Netty/Codec/Socks (4.0.27.Final)
+ *   21|Active     |    1|Netty/Common (4.0.27.Final)
+ *   22|Active     |    1|Netty/Handler (4.0.27.Final)
+ *   23|Active     |    1|Netty/Transport (4.0.27.Final)
+ *   25|Active     |    1|Vert.x Core (3.0.0.SNAPSHOT)
+ *----
+ *
  * == Clustering
  *
  * === Trouble-shooting clustering


### PR DESCRIPTION
Make vert.x core a valid OSGi bundle.

* Generate OSGi metadata
* Fix ServiceFactory classloading
* Add documentation

This commit fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=469363

The resulting jar is still a valid jar.
