### PR TITLE
Provide the client HTTP Error handling documentation

### DIFF
--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -741,7 +741,7 @@ request.end(buffer);
 When you're writing to a request, the first call to `write` will result in the request headers being written
 out to the wire.
 
-The actual write is asychronous and might not occur until some time after the call has returned.
+The actual write is asynchronous and might not occur until some time after the call has returned.
 
 Non-chunked HTTP requests with a request body require a `Content-Length` header to be provided.
 
@@ -836,8 +836,8 @@ If the request does not return any data within the timeout period an exception w
 
 ==== Handling exceptions
 
-You can handle exceptions corresponding to a request by setting an exception handler on the `link:../../apidocs/io/vertx/core/http/HttpClientRequest.html[HttpClientRequest]`
-instance:
+You can handle exceptions corresponding to a request by setting an exception handler on the
+`link:../../apidocs/io/vertx/core/http/HttpClientRequest.html[HttpClientRequest]` instance:
 
 [source,java]
 ----
@@ -850,9 +850,25 @@ request.exceptionHandler(e -> {
 });
 ----
 
-TODO - what about exceptions in the getNow methods where no exception handler can be provided??
+This does not handle non _2xx_ response that need to be handled in the
+`link:../../apidocs/io/vertx/core/http/HttpClientResponse.html[HttpClientResponse]` code:
 
-Maybe need a catch all exception handler??
+[source, java]
+----
+HttpClientRequest request = client.post("some-uri", response -> {
+  if (response.statusCode() == 200) {
+    System.out.println("Everything fine");
+    return;
+  }
+  if (response.statusCode() == 500) {
+    System.out.println("Unexpected behavior on the server side");
+    return;
+  }
+});
+request.end();
+----
+
+IMPORTANT: `XXXNow` methods cannot receive an exception handler.
 
 ==== Specifying a handler on the client request
 

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -416,6 +416,20 @@ public class HTTPExamples {
     });
   }
 
+  public void  statusCodeHandling(HttpClient client) {
+    HttpClientRequest request = client.post("some-uri", response -> {
+      if (response.statusCode() == 200) {
+        System.out.println("Everything fine");
+        return;
+      }
+      if (response.statusCode() == 500) {
+        System.out.println("Unexpected behavior on the server side");
+        return;
+      }
+    });
+    request.end();
+  }
+
   public void example43(HttpClient client) {
 
     HttpClientRequest request = client.post("some-uri");

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -603,7 +603,7 @@
  * When you're writing to a request, the first call to `write` will result in the request headers being written
  * out to the wire.
  *
- * The actual write is asychronous and might not occur until some time after the call has returned.
+ * The actual write is asynchronous and might not occur until some time after the call has returned.
  *
  * Non-chunked HTTP requests with a request body require a `Content-Length` header to be provided.
  *
@@ -686,17 +686,23 @@
  *
  * ==== Handling exceptions
  *
- * You can handle exceptions corresponding to a request by setting an exception handler on the {@link io.vertx.core.http.HttpClientRequest}
- * instance:
+ * You can handle exceptions corresponding to a request by setting an exception handler on the
+ * {@link io.vertx.core.http.HttpClientRequest} instance:
  *
  * [source,$lang]
  * ----
  * {@link examples.HTTPExamples#example42}
  * ----
  *
- * TODO - what about exceptions in the getNow methods where no exception handler can be provided??
+ * This does not handle non _2xx_ response that need to be handled in the
+ * {@link io.vertx.core.http.HttpClientResponse} code:
  *
- * Maybe need a catch all exception handler??
+ * [source, $lang]
+ * ----
+ * {@link examples.HTTPExamples#statusCodeHandling}
+ * ----
+ *
+ * IMPORTANT: `XXXNow` methods cannot receive an exception handler.
  *
  * ==== Specifying a handler on the client request
  *


### PR DESCRIPTION
Was mostly there already, just add an example to handle non 2XX responses.

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>