### PR TITLE
Fix bare instance creation

### DIFF
--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -143,6 +143,10 @@ public class Starter {
           runVerticle(main, args);
           return;
         }
+      } else if (first.equals("-ha")) {
+        // Create a bare instance
+        runBare(args);
+        return;
       }
     }
 
@@ -234,6 +238,21 @@ public class Starter {
       vertx = Vertx.vertx(options);
     }
     return vertx;
+  }
+
+  private void runBare(Args args) {
+    // ha is necessarily true here,
+    // so clustered is
+    Vertx vertx = startVertx(true, true, args);
+    if (vertx == null) {
+      // Throwable should have been logged at this point
+      return;
+    }
+
+    // As we do not deploy a verticle, other options are irrelevant (instances, worker, conf and redeploy)
+
+    addShutdownHook(vertx);
+    block();
   }
 
   private void runVerticle(String main, Args args) {

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -820,6 +820,17 @@
  *
  * The config will be available inside the verticle via the core API.
  *
+ * When using the high-availability feature of vert.x you may want to create a _bare_ instance of vert.x. This
+ * instance does not deploy any verticles when launched, but will receive a verticle if another node of the cluster
+ * dies. To create a _bare_ instance, launch:
+ *
+ * [source]
+ * ----
+ * vertx -ha
+ * ----
+ *
+ * Depending on your cluster configuration, you may have to append the `cluster-host` and `cluster-port` parameters.
+ *
  * === Executing verticles packaged as a fat jar
  *
  * A _fat jar_ is an executable jar embedding its dependencies. This means you don't have to have Vert.x pre-installed


### PR DESCRIPTION
Fix https://bugs.eclipse.org/bugs/show_bug.cgi?id=469604 by checking whether or not `-ha` is the first parameter. In that case, it creates the vert.x instance without deploying a vertical
Also update the command line documentation
