### PR TITLE
respect JDK properties to limit SSL protocols

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -40,6 +40,8 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -223,8 +225,10 @@ public class SSLHelper {
       String[] toUse = enabledCipherSuites.toArray(new String[enabledCipherSuites.size()]);
       engine.setEnabledCipherSuites(toUse);
     }
-    engine.setEnabledProtocols(ENABLED_PROTOCOLS);
     engine.setUseClientMode(client);
+    Set<String> enabledProtocols = new HashSet<>(Arrays.asList(ENABLED_PROTOCOLS));
+    enabledProtocols.retainAll(Arrays.asList(engine.getEnabledProtocols()));
+    engine.setEnabledProtocols(enabledProtocols.toArray(new String[0]));
     if (!client) {
       switch (getClientAuth()) {
         case REQUEST: {


### PR DESCRIPTION
Signed-off-by: Piotr Wielgolaski <pwielgolaski@gmail.com>
Change take into account what protocols are enabled and only enable intersection of JDK and Vert.x protocols.
In this way client can use system properties described here http://www.oracle.com/technetwork/java/javase/documentation/cve-2014-3566-2342133.html

It also address issue https://groups.google.com/forum/#!topic/vertx/Wr10ljAPplo
as JDK8 by default disable SSL2vHello for clients, it can be enabled if needed by system properties.
