### PR TITLE
Support switching to netty transport epoll in GNU/Linux, significantly improve performance

### DIFF
--- a/src/main/asciidoc/cheatsheet/VertxOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/VertxOptions.adoc
@@ -89,4 +89,11 @@ Set the metrics options+++
 |`Number`
 |+++
 Set the threshold value above this, the blocked warning contains a stack trace.+++
+
+|[[nettyTransport]]`nettyTransport`
+|`String`
+|+++
+Set the netty transport to be used while in GNU/Linux, the choices include: nio, epoll
+ Since 4.0.16, Netty provides the native socket transport for GNU/Linux using JNI - epoll
+ The epoll transport has higher performance and produces less garbage, but multicast not supported+++
 |===

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -276,7 +276,16 @@ vertx.executeBlocking(future -> {
 });
 ----
 
+By default, if executeBlocking is called several times from the same context (e.g. the same verticle instance) then
+the different executeBlocking are executed _serially_ (i.e. one after another).
+
+If you don't care about ordering you can call `link:../../apidocs/io/vertx/core/Vertx.html#executeBlocking-io.vertx.core.Handler-boolean-io.vertx.core.Handler-[executeBlocking]`
+specifying `false` as the argument to `ordered`. In this case any executeBlocking may be executed in parallel
+on the worker pool.
+
 An alternative way to run blocking code is to use a <<worker_verticles, worker verticle>>
+
+A worker verticle is always executed with a thread from the worker pool.
 
 == Verticles
 

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -113,6 +113,18 @@ public class VertxOptions {
    */
   private static final long DEFAULT_WARNING_EXECPTION_TIME = 5l * 1000 * 1000000;
 
+  /**
+   * default socket transport in netty
+   */
+  public static final String NETTY_TRANSPORT_NIO = "nio";
+  
+  /**
+   * Since 4.0.16, Netty provides the native socket transport for GNU/Linux using JNI
+   * This transport has higher performance and produces less garbage
+   * But multicast not supported
+   */
+  public static final String NETTY_TRANSPORT_EPOLL = "epoll";
+
   private int eventLoopPoolSize = DEFAULT_EVENT_LOOP_POOL_SIZE;
   private int workerPoolSize = DEFAULT_WORKER_POOL_SIZE;
   private int internalBlockingPoolSize = DEFAULT_INTERNAL_BLOCKING_POOL_SIZE;
@@ -131,6 +143,8 @@ public class VertxOptions {
   private MetricsOptions metrics;
 
   private long warningExceptionTime = DEFAULT_WARNING_EXECPTION_TIME;
+
+  private String nettyTransport = NETTY_TRANSPORT_NIO;
 
   /**
    * Default constructor
@@ -161,6 +175,7 @@ public class VertxOptions {
     this.haGroup = other.getHAGroup();
     this.metrics = other.getMetricsOptions() != null ? new MetricsOptions(other.getMetricsOptions()) : null;
     this.warningExceptionTime = other.warningExceptionTime;
+    this.nettyTransport = other.nettyTransport;
   }
 
   /**
@@ -186,6 +201,7 @@ public class VertxOptions {
     JsonObject metricsJson = json.getJsonObject("metricsOptions");
     this.metrics = metricsJson != null ? new MetricsOptions(metricsJson) : null;
     this.warningExceptionTime = json.getLong("warningExceptionTime", DEFAULT_WARNING_EXECPTION_TIME);
+    this.nettyTransport = json.getString("nettyTransport", NETTY_TRANSPORT_NIO);
   }
 
   /**
@@ -587,6 +603,30 @@ public class VertxOptions {
     return this;
   }
 
+  
+
+  /**
+   * Get the netty transport to be used.
+   * 
+   * @return the netty transport
+   */
+  public String getNettyTransport() {
+    return nettyTransport;
+  }
+
+  /**
+   * Set the netty transport to be used while in GNU/Linux, the choices include: nio, epoll
+   * Since 4.0.16, Netty provides the native socket transport for GNU/Linux using JNI - epoll
+   * The epoll transport has higher performance and produces less garbage, but multicast not supported
+   * 
+   * @param nettyTransport
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setNettyTransport(String nettyTransport) {
+    this.nettyTransport = nettyTransport;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -609,6 +649,7 @@ public class VertxOptions {
       return false;
     if (haGroup != null ? !haGroup.equals(that.haGroup) : that.haGroup != null) return false;
     if (warningExceptionTime != that.warningExceptionTime) return false;
+    if (nettyTransport != null ? !nettyTransport.equals(that.nettyTransport) : that.nettyTransport != null) return false;
 
     return true;
   }
@@ -629,6 +670,7 @@ public class VertxOptions {
     result = 31 * result + quorumSize;
     result = 31 * result + (haGroup != null ? haGroup.hashCode() : 0);
     result = 31 * result + (int) (warningExceptionTime ^ (warningExceptionTime >>> 32));
+    result = 31 * result + (nettyTransport != null ? nettyTransport.hashCode() : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -21,7 +21,6 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
-import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -31,6 +30,7 @@ import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.datagram.PacketWritestream;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.NettyTransportFactory;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -262,21 +262,21 @@ public class DatagramSocketImpl extends ConnectionBase implements DatagramSocket
     return (DatagramChannel) channel;
   }
 
-  private static NioDatagramChannel createChannel(io.vertx.core.datagram.impl.InternetProtocolFamily family,
+  private static DatagramChannel createChannel(io.vertx.core.datagram.impl.InternetProtocolFamily family,
                                                   DatagramSocketOptions options) {
-    NioDatagramChannel channel;
+    DatagramChannel channel;
     if (family == null) {
-      channel = new NioDatagramChannel();
+      channel = NettyTransportFactory.getDefaultFactory().instantiateDatagramChannel();
     } else {
       switch (family) {
         case IPv4:
-          channel = new NioDatagramChannel(InternetProtocolFamily.IPv4);
+          channel = NettyTransportFactory.getDefaultFactory().instantiateDatagramChannel(InternetProtocolFamily.IPv4);
           break;
         case IPv6:
-          channel = new NioDatagramChannel(InternetProtocolFamily.IPv6);
+          channel = NettyTransportFactory.getDefaultFactory().instantiateDatagramChannel(InternetProtocolFamily.IPv6);
           break;
         default:
-          channel = new NioDatagramChannel();
+          channel = NettyTransportFactory.getDefaultFactory().instantiateDatagramChannel();
       }
     }
     if (options.getSendBufferSize() != -1) {

--- a/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
-import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -81,7 +80,7 @@ public final class DnsClientImpl implements DnsClient {
     actualCtx = vertx.getOrCreateContext();
     bootstrap = new Bootstrap();
     bootstrap.group(actualCtx.eventLoop());
-    bootstrap.channel(NioDatagramChannel.class);
+    bootstrap.channel(vertx.getNettyTransportFactory().chooseDatagramChannel());
     bootstrap.option(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
     bootstrap.handler(new ChannelInitializer<DatagramChannel>() {
       @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -25,7 +25,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FixedRecvByteBufAllocator;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpContentDecompressor;
@@ -647,7 +646,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
                                Handler<Throwable> connectErrorHandler, ConnectionLifeCycleListener listener) {
     Bootstrap bootstrap = new Bootstrap();
     bootstrap.group(context.eventLoop());
-    bootstrap.channel(NioSocketChannel.class);
+    bootstrap.channel(vertx.getNettyTransportFactory().chooseSocketChannel());
     sslHelper.validate(vertx);
     bootstrap.handler(new ChannelInitializer<Channel>() {
       @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -21,7 +21,6 @@ import io.netty.channel.*;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
@@ -182,7 +181,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
         serverChannelGroup = new DefaultChannelGroup("vertx-acceptor-channels", GlobalEventExecutor.INSTANCE);
         ServerBootstrap bootstrap = new ServerBootstrap();
         bootstrap.group(availableWorkers);
-        bootstrap.channel(NioServerSocketChannel.class);
+        bootstrap.channel(vertx.getNettyTransportFactory().chooseServerSocketChannel());
         applyConnectionOptions(bootstrap);
         sslHelper.validate(vertx);
         bootstrap.childHandler(new ChannelInitializer<Channel>() {

--- a/src/main/java/io/vertx/core/impl/NettyTransportFactory.java
+++ b/src/main/java/io/vertx/core/impl/NettyTransportFactory.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.vertx.core.impl;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Automatically choose netty socket transport: nio or epoll(only for GNU/Linux,
+ * higher performance)
+ * 
+ * @author <a href="http://vertxer.org">Mike Bai <lostitle@gmail.com></a>
+ */
+public class NettyTransportFactory {
+  private static final Logger log = LoggerFactory.getLogger(NettyTransportFactory.class);
+
+  private String nettyTransport = VertxOptions.NETTY_TRANSPORT_NIO;
+
+  /**
+   * Get the netty socket transport to be used.
+   * 
+   * @return the netty transport
+   */
+  public String getNettyTransport() {
+    return nettyTransport;
+  }
+
+  /**
+   * Set the netty transport to be used while in GNU/Linux, the choices include:
+   * nio, epoll Since 4.0.16, Netty provides the native socket transport for
+   * GNU/Linux using JNI - epoll The epoll transport has higher performance and
+   * produces less garbage, but multicast not supported
+   * 
+   * @param nettyTransport
+   * @return a reference to this, so the API can be used fluently
+   */
+  public NettyTransportFactory setNettyTransport(String nettyTransport) {
+    if (!Utils.isLinux() && VertxOptions.NETTY_TRANSPORT_EPOLL.equals(nettyTransport)) {
+      log.warn("can not set nettyTransport to epoll while in non-linux");
+    } else {
+      this.nettyTransport = nettyTransport;
+    }
+    return this;
+  }
+
+  private boolean isEpoll() {
+    return VertxOptions.NETTY_TRANSPORT_EPOLL.equals(nettyTransport);
+  }
+
+  // default factory instance
+  private static NettyTransportFactory defaultFactory;
+  static {
+    defaultFactory = new NettyTransportFactory();
+    if (VertxOptions.NETTY_TRANSPORT_EPOLL.equals(System.getProperty("nettyTransport"))) {
+      defaultFactory.setNettyTransport(VertxOptions.NETTY_TRANSPORT_EPOLL);
+    }
+  }
+
+  /**
+   * return the default netty socket transport factory
+   * 
+   * @return
+   */
+  public static NettyTransportFactory getDefaultFactory() {
+    return defaultFactory;
+  }
+
+  /**
+   * @return
+   */
+  public Class<? extends ServerChannel> chooseServerSocketChannel() {
+    if (isEpoll()) {
+      return EpollServerSocketChannel.class;
+    }
+    return NioServerSocketChannel.class;
+  }
+
+  /**
+   * @return
+   */
+  public Class<? extends Channel> chooseSocketChannel() {
+    if (isEpoll()) {
+      return EpollSocketChannel.class;
+    }
+    return NioSocketChannel.class;
+  }
+
+  /**
+   * @return
+   */
+  public Class<? extends DatagramChannel> chooseDatagramChannel() {
+    if (isEpoll()) {
+      return EpollDatagramChannel.class;
+    }
+    return NioDatagramChannel.class;
+  }
+
+  /**
+   * @return
+   */
+  public DatagramChannel instantiateDatagramChannel() {
+    if (isEpoll()) {
+      return new EpollDatagramChannel();
+    }
+    return new NioDatagramChannel();
+  }
+
+  /**
+   * @param ipFamily
+   * @return
+   */
+  public DatagramChannel instantiateDatagramChannel(InternetProtocolFamily ipFamily) {
+    if (isEpoll()) {
+      // EpollDatagramChannel use default constructor
+      return new EpollDatagramChannel();
+    }
+    return new NioDatagramChannel(ipFamily);
+  }
+
+  /**
+   * @return
+   */
+  public Class<? extends EventLoopGroup> chooseEventLoopGroup() {
+    if (isEpoll()) {
+      return EpollEventLoopGroup.class;
+    }
+    return NioEventLoopGroup.class;
+  }
+
+  /**
+   * @param nThreads
+   * @param threadFactory
+   * @return
+   */
+  public EventLoopGroup instantiateEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
+    if (isEpoll()) {
+      return new EpollEventLoopGroup(nThreads, threadFactory);
+    }
+    return new NioEventLoopGroup(nThreads, threadFactory);
+  }
+
+}

--- a/src/main/java/io/vertx/core/impl/Utils.java
+++ b/src/main/java/io/vertx/core/impl/Utils.java
@@ -27,10 +27,12 @@ public class Utils {
   public static String LINE_SEPARATOR = System.getProperty("line.separator");
 
   private static final boolean isWindows;
+  private static final boolean isLinux;
 
   static {
     String os = System.getProperty("os.name").toLowerCase();
     isWindows = os.contains("win");
+    isLinux = os.contains("linux");
   }
 
   /**
@@ -39,5 +41,13 @@ public class Utils {
   public static boolean isWindows() {
     return isWindows;
   }
+
+  /**
+   * @return true, if running on GNU/Linux
+   */
+  public static boolean isLinux() {
+    return isLinux;
+  }
+
 
 }

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -46,6 +46,13 @@ public interface VertxInternal extends Vertx {
 
   EventLoopGroup getEventLoopGroup();
 
+  /**
+   * get NettyTransportFactory instance
+   * 
+   * @return NettyTransportFactory instance
+   */
+  NettyTransportFactory getNettyTransportFactory();
+
   ExecutorService getWorkerPool();
 
   Map<ServerID, HttpServerImpl> sharedHttpServers();

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FixedRecvByteBufAllocator;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -154,7 +153,7 @@ public class NetClientImpl implements NetClient, MetricsProvider {
     sslHelper.validate(vertx);
     Bootstrap bootstrap = new Bootstrap();
     bootstrap.group(context.eventLoop());
-    bootstrap.channel(NioSocketChannel.class);
+    bootstrap.channel(vertx.getNettyTransportFactory().chooseSocketChannel());
     bootstrap.handler(new ChannelInitializer<Channel>() {
       @Override
       protected void initChannel(Channel ch) throws Exception {

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -28,7 +28,6 @@ import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -162,7 +161,7 @@ public class NetServerImpl implements NetServer, Closeable, MetricsProvider {
 
         ServerBootstrap bootstrap = new ServerBootstrap();
         bootstrap.group(availableWorkers);
-        bootstrap.channel(NioServerSocketChannel.class);
+        bootstrap.channel(vertx.getNettyTransportFactory().chooseServerSocketChannel());
         sslHelper.validate(vertx);
 
         bootstrap.childHandler(new ChannelInitializer<Channel>() {

--- a/src/test/java/io/vertx/test/core/NettyTransportFactoryTest.java
+++ b/src/test/java/io/vertx/test/core/NettyTransportFactoryTest.java
@@ -1,0 +1,92 @@
+package io.vertx.test.core;
+
+import static org.junit.Assert.assertEquals;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollDatagramChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.impl.NettyTransportFactory;
+import io.vertx.core.impl.Utils;
+import io.vertx.core.impl.VertxInternal;
+
+import org.junit.Test;
+
+/**
+ * test NettyTransportFactory class
+ * 
+ * @author <a href="http://vertxer.org">Mike Bai <lostitle@gmail.com></a>
+ *
+ */
+public class NettyTransportFactoryTest {
+
+  /**
+   * test 4 method of NettyTransportFactory in GNU/Linux or other OS.
+   * 
+   * @throws Exception
+   */
+  @Test
+  public void testFactory() throws Exception {
+
+    NettyTransportFactory factory = NettyTransportFactory.getDefaultFactory();
+
+    if (Utils.isLinux()) {
+      factory.setNettyTransport(VertxOptions.NETTY_TRANSPORT_EPOLL);
+
+      Class<? extends ServerChannel> serverSocketChannel = factory.chooseServerSocketChannel();
+      Class<? extends Channel> socketChannel = factory.chooseSocketChannel();
+      Class<? extends DatagramChannel> datagramChannel = factory.chooseDatagramChannel();
+      DatagramChannel dcInstance = factory.instantiateDatagramChannel();
+      Class<? extends EventLoopGroup> eventLoopGroup = factory.chooseEventLoopGroup();
+      EventLoopGroup elgInstance = factory.instantiateEventLoopGroup(0, null);
+      assertEquals(true, Utils.isLinux());
+      assertEquals(EpollServerSocketChannel.class, serverSocketChannel);
+      assertEquals(EpollSocketChannel.class, socketChannel);
+      assertEquals(EpollDatagramChannel.class, datagramChannel);
+      assertEquals(EpollDatagramChannel.class, dcInstance.getClass());
+      assertEquals(EpollEventLoopGroup.class, eventLoopGroup);
+      assertEquals(EpollEventLoopGroup.class, elgInstance.getClass());
+    }
+
+    {
+      factory.setNettyTransport(VertxOptions.NETTY_TRANSPORT_NIO);
+
+      Class<? extends ServerChannel> serverSocketChannel = factory.chooseServerSocketChannel();
+      Class<? extends Channel> socketChannel = factory.chooseSocketChannel();
+      Class<? extends DatagramChannel> datagramChannel = factory.chooseDatagramChannel();
+      DatagramChannel dcInstance = factory.instantiateDatagramChannel();
+      Class<? extends EventLoopGroup> eventLoopGroup = factory.chooseEventLoopGroup();
+      EventLoopGroup elgInstance = factory.instantiateEventLoopGroup(0, null);
+      assertEquals(NioServerSocketChannel.class, serverSocketChannel);
+      assertEquals(NioSocketChannel.class, socketChannel);
+      assertEquals(NioDatagramChannel.class, datagramChannel);
+      assertEquals(NioDatagramChannel.class, dcInstance.getClass());
+      assertEquals(NioEventLoopGroup.class, eventLoopGroup);
+      assertEquals(NioEventLoopGroup.class, elgInstance.getClass());
+
+    }
+  }
+
+  @Test
+  public void testVertxWithOption() {
+    VertxOptions options = new VertxOptions().setNettyTransport(VertxOptions.NETTY_TRANSPORT_EPOLL);
+    Vertx vertx = Vertx.vertx(options);
+    if (Utils.isLinux()) {
+      assertEquals(VertxOptions.NETTY_TRANSPORT_EPOLL, ((VertxInternal) vertx).getNettyTransportFactory()
+          .getNettyTransport());
+    } else {
+      assertEquals(VertxOptions.NETTY_TRANSPORT_NIO, ((VertxInternal) vertx).getNettyTransportFactory()
+          .getNettyTransport());
+    }
+  }
+
+}

--- a/src/test/java/io/vertx/test/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/test/core/VertxOptionsTest.java
@@ -215,6 +215,7 @@ public class VertxOptionsTest extends VertxTestBase {
     options.setHAEnabled(haEnabled);
     options.setQuorumSize(quorumSize);
     options.setHAGroup(haGroup);
+    options.setNettyTransport(VertxOptions.NETTY_TRANSPORT_NIO);
     options.setMetricsOptions(
         new MetricsOptions().
             setEnabled(metricsEnabled));
@@ -233,6 +234,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(haEnabled, options.isHAEnabled());
     assertEquals(quorumSize, options.getQuorumSize());
     assertEquals(haGroup, options.getHAGroup());
+    assertEquals(VertxOptions.NETTY_TRANSPORT_NIO, options.getNettyTransport());
     MetricsOptions metricsOptions = options.getMetricsOptions();
     assertNotNull(metricsOptions);
     assertEquals(metricsEnabled, metricsOptions.isEnabled());
@@ -257,6 +259,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(def.getQuorumSize(), json.getQuorumSize());
     assertEquals(def.getHAGroup(), json.getHAGroup());
     assertEquals(def.getWarningExceptionTime(), json.getWarningExceptionTime());
+    assertEquals(def.getNettyTransport(), json.getNettyTransport());
   }
 
   @Test
@@ -277,6 +280,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertFalse(options.isHAEnabled());
     assertEquals(1, options.getQuorumSize());
     assertEquals(VertxOptions.DEFAULT_HA_GROUP, options.getHAGroup());
+    assertEquals(VertxOptions.NETTY_TRANSPORT_NIO, options.getNettyTransport());
     assertNull(options.getMetricsOptions());
     assertEquals(5000000000l, options.getWarningExceptionTime());
     int clusterPort = TestUtils.randomPortInt();


### PR DESCRIPTION
1), Vert.x 3.0 use nio socket transport, nio have more feature, such as Multicast, but nio's performance is low. http://netty.io/wiki/native-transports.html

2), When I change nio to epoll in GNU/Linux, the performance significantly improved. Send 90000 1k messages time-consuming reduced to 25%. As follows:
`
Send machine: i7 4790, 32G RAM, 256G SSD, 1G Lan, CentOS 6.5, Java8;
Receive machine: i7 4790, 32G RAM, 256G SSD, 1G Lan, Gentoo, Java8;
90000 message, 1KB/message.

netty nio:
receive data: index is 2 (10000 message) , interval time is 2107 ms
receive data: index is 3 (10000 message) , interval time is 1785 ms
receive data: index is 4 (10000 message) , interval time is 2477 ms
receive data: index is 5 (10000 message) , interval time is 4083 ms
receive data: index is 6 (10000 message) , interval time is 4288 ms
receive data: index is 7 (10000 message) , interval time is 5127 ms
receive data: index is 8 (10000 message) , interval time is 5068 ms
receive data: index is 9 (10000 message) , interval time is 5563 ms
receive data: index is 10 (10000 message) , interval time is 5178 ms

netty epoll:
receive data: index is 2 (10000 message) , interval time is 985 ms
receive data: index is 3 (10000 message) , interval time is 998 ms
receive data: index is 4 (10000 message) , interval time is 1001 ms
receive data: index is 5 (10000 message) , interval time is 990 ms
receive data: index is 6 (10000 message) , interval time is 1009 ms
receive data: index is 7 (10000 message) , interval time is 1016 ms
receive data: index is 8 (10000 message) , interval time is 1009 ms
receive data: index is 9 (10000 message) , interval time is 997 ms
receive data: index is 10 (10000 message) , interval time is 1271 ms
`

3) I wrote NettyTransportFactory class for swtich nio/epoll/possible anything in the future, and NettyTransportFactoryTest class. All testcase successed.

4) Now any user can pass nettyTransport args to vert.x in GNU/Linux, enable epoll, enjoy high performance.

Signed-off-by: Mike Bai <lostitle@gmail.com>