### PR TITLE
Documentation override and parsetools

### DIFF
--- a/src/main/asciidoc/java/eventbus.adoc
+++ b/src/main/asciidoc/java/eventbus.adoc
@@ -197,17 +197,7 @@ You can send a message with `link:../../apidocs/io/vertx/core/eventbus/EventBus.
 eventBus.send("news.uk.sport", "Yay! Someone kicked a ball");
 ----
 
-==== Setting headers on messages
-
-Messages sent over the event bus can also contain headers. This can be specified by providing a
-`link:../../apidocs/io/vertx/core/eventbus/DeliveryOptions.html[DeliveryOptions]` when sending or publishing:
-
-[source,java]
-----
-DeliveryOptions options = new DeliveryOptions();
-options.addHeader("some-header", "some-value");
-eventBus.send("news.uk.sport", "Yay! Someone kicked a ball", options);
-----
+include::override/eventbus_headers.adoc[]
 
 ==== The Message object
 
@@ -305,7 +295,7 @@ for example the default `HazelcastClusterManager`.
 
 You can run Vert.x clustered on the command line with
 
- vertx run MyVerticle -cluster
+ vertx run my-verticle.js -cluster
 
 === Automatic clean-up in verticles
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -276,7 +276,16 @@ vertx.executeBlocking(future -> {
 });
 ----
 
+By default, if executeBlocking is called several times from the same context (e.g. the same verticle instance) then
+the different executeBlocking are executed _serially_ (i.e. one after another).
+
+If you don't care about ordering you can call `link:../../apidocs/io/vertx/core/Vertx.html#executeBlocking-io.vertx.core.Handler-boolean-io.vertx.core.Handler-[executeBlocking]`
+specifying `false` as the argument to `ordered`. In this case any executeBlocking may be executed in parallel
+on the worker pool.
+
 An alternative way to run blocking code is to use a <<worker_verticles, worker verticle>>
+
+A worker verticle is always executed with a thread from the worker pool.
 
 == Verticles
 
@@ -471,32 +480,7 @@ vertx.deployVerticle("com.mycompany.MyOrderProcessorVerticle", options);
 This is useful for scaling easily across multiple cores. For example you might have a web-server verticle to deploy
 and multiple cores on your machine, so you want to deploy multiple instances to take utilise all the cores.
 
-=== Passing configuration to a verticle
-
-Configuration in the form of JSON can be passed to a verticle at deployment time:
-
-[source,java]
-----
-JsonObject config = new JsonObject().put("name", "tim").put("directory", "/blah");
-DeploymentOptions options = new DeploymentOptions().setConfig(config);
-vertx.deployVerticle("com.mycompany.MyOrderProcessorVerticle", options);
-----
-
-This configuration is then available via the `link:../../apidocs/io/vertx/core/Context.html[Context]` object or directly using the
-`link:../../apidocs/io/vertx/core/AbstractVerticle.html#config--[config]` method. The configuration is returned as a JSON object so you can
-retrieve data as follows:
-
-[source,java]
-----
-System.out.println("Configuration: " + config().getString("name"));
-----
-
-=== Accessing environment variables in a Verticle
-
-Environment variables and system properties are accessible from a verticle by following the Java way. To retrieve
-system properties, use `link:../../apidocs/java/lang/System.html#getProperty-java.lang.String-[System.getProperty]`
-(or `link:../../apidocs/java/lang/System.html#getProperty-java.lang.String-java.lang.String-[System.getProperty]`). You can also retrieve the
-environment variables using `link:../../apidocs/java/lang/System.html#getenv-java.lang.String-[System.getenv]`.
+include::override/verticle-configuration.adoc[]
 
 === Verticle Isolation Groups
 

--- a/src/main/asciidoc/java/override/eventbus_headers.adoc
+++ b/src/main/asciidoc/java/override/eventbus_headers.adoc
@@ -1,0 +1,13 @@
+==== Setting headers on messages
+
+Messages sent over the event bus can also contain headers.
+
+This can be specified by providing a
+`link:../../apidocs/io/vertx/core/eventbus/DeliveryOptions.html[DeliveryOptions]` when sending or publishing:
+
+[source,java]
+----
+DeliveryOptions options = new DeliveryOptions();
+options.addHeader("some-header", "some-value");
+eventBus.send("news.uk.sport", "Yay! Someone kicked a ball", options);
+----

--- a/src/main/asciidoc/java/override/verticle-configuration.adoc
+++ b/src/main/asciidoc/java/override/verticle-configuration.adoc
@@ -22,7 +22,10 @@ System.out.println("Configuration: " + config().getString("name"));
 
 === Accessing environment variables in a Verticle
 
-Environment variables and system properties are accessible from a verticle by following the Java way. To
-retrieve system properties, use `link:../../apidocs/java/lang/System.html#getProperty-java.lang.String-[System.getProperty]`
-(or `link:../../apidocs/java/lang/System.html#getProperty-java.lang.String-java.lang.String-[System.getProperty]`). You can also retrieve the
-environment variables using `link:../../apidocs/java/lang/System.html#getenv-java.lang.String-[System.getenv]`.
+Environment variables and system properties are accessible using the Java API:
+
+[source,java]
+----
+System.getProperty("prop");
+System.getenv("HOME");
+----

--- a/src/main/asciidoc/java/override/verticle-configuration.adoc
+++ b/src/main/asciidoc/java/override/verticle-configuration.adoc
@@ -1,0 +1,28 @@
+=== Passing configuration to a verticle
+
+Configuration in the form of JSON can be passed to a verticle at deployment time:
+
+[source,java]
+----
+JsonObject config = new JsonObject().put("name", "tim").put("directory", "/blah");
+DeploymentOptions options = new DeploymentOptions().setConfig(config);
+vertx.deployVerticle("com.mycompany.MyOrderProcessorVerticle", options);
+----
+
+This configuration is then available via the `link:../../apidocs/io/vertx/core/Context.html[Context]` object or directly using the
+`link:../../apidocs/io/vertx/core/AbstractVerticle.html#config--[config]` method.
+
+The configuration is returned as a JSON object so you
+can retrieve data as follows:
+
+[source,java]
+----
+System.out.println("Configuration: " + config().getString("name"));
+----
+
+=== Accessing environment variables in a Verticle
+
+Environment variables and system properties are accessible from a verticle by following the Java way. To
+retrieve system properties, use `link:../../apidocs/java/lang/System.html#getProperty-java.lang.String-[System.getProperty]`
+(or `link:../../apidocs/java/lang/System.html#getProperty-java.lang.String-java.lang.String-[System.getProperty]`). You can also retrieve the
+environment variables using `link:../../apidocs/java/lang/System.html#getenv-java.lang.String-[System.getenv]`.

--- a/src/main/asciidoc/java/parsetools.adoc
+++ b/src/main/asciidoc/java/parsetools.adoc
@@ -1,3 +1,50 @@
-== Parse tools
+== Record Parser tools
 
-TODO
+The record parser allows you to easily parse protocols which are delimited by a sequence of bytes, or fixed
+size records.
+
+It transforms an sequence of input buffer to a sequence of buffer structured as configured (either
+fixed size or separated records).
+
+For example, if you have a simple ASCII text protocol delimited by '\n' and the input is the following:
+
+[source]
+----
+buffer1:HELLO\nHOW ARE Y
+buffer2:OU?\nI AM
+buffer3: DOING OK
+buffer4:\n
+----
+
+The record parser would produce
+[source]
+----
+buffer1:HELLO
+buffer2:HOW ARE YOU?
+buffer3:I AM DOING OK
+----
+
+Let's see the associated code:
+
+[source, java]
+----
+final RecordParser parser = RecordParser.newDelimited("\n", h -> {
+  System.out.println(h.toString());
+});
+
+parser.handle(Buffer.buffer("HELLO\nHOW ARE Y"));
+parser.handle(Buffer.buffer("OU?\nI AM"));
+parser.handle(Buffer.buffer("DOING OK"));
+parser.handle(Buffer.buffer("\n"));
+----
+
+You can also produce fixed sized chunks as follows:
+
+[source, java]
+----
+RecordParser.newFixed(4, h -> {
+  System.out.println(h.toString());
+});
+----
+
+For more details, check out the `link:../../apidocs/io/vertx/core/parsetools/RecordParser.html[RecordParser]` class.

--- a/src/main/java/docoverride/eventbus/Examples.java
+++ b/src/main/java/docoverride/eventbus/Examples.java
@@ -43,6 +43,12 @@ public class Examples {
     eventBus.send("orders", new MyPOJO());
   }
 
+  public void headers(EventBus eventBus) {
+    DeliveryOptions options = new DeliveryOptions();
+    options.addHeader("some-header", "some-value");
+    eventBus.send("news.uk.sport", "Yay! Someone kicked a ball", options);
+  }
+
   class MyPOJO {
 
   }

--- a/src/main/java/docoverride/eventbus/headers/package-info.java
+++ b/src/main/java/docoverride/eventbus/headers/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+/**
+ * ==== Setting headers on messages
+ *
+ * Messages sent over the event bus can also contain headers. This can be specified by providing a
+ * {@link io.vertx.core.eventbus.DeliveryOptions} when sending or publishing:
+ *
+ * [source,$lang]
+ * ----
+ * {@link docoverride.eventbus.Examples#headers(io.vertx.core.eventbus.EventBus)}
+ * ----
+ */
+@Document(fileName = "override/eventbus_headers.adoc")
+package docoverride.eventbus.headers;
+
+import io.vertx.docgen.Document;

--- a/src/main/java/docoverride/verticles/configuration/package-info.java
+++ b/src/main/java/docoverride/verticles/configuration/package-info.java
@@ -35,10 +35,12 @@
  *
  * === Accessing environment variables in a Verticle
  *
- * Environment variables and system properties are accessible from a verticle by following the Java way. To
- * retrieve system properties, use {@link java.lang.System#getProperty(java.lang.String)}
- * (or {@link java.lang.System#getProperty(java.lang.String, java.lang.String)}). You can also retrieve the
- * environment variables using {@link java.lang.System#getenv(java.lang.String)}.
+ * Environment variables and system properties are accessible using the Java API:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.CoreExamples#systemAndEnvProperties()}
+ * ----
  *
  */
 @Document(fileName = "override/verticle-configuration.adoc")

--- a/src/main/java/docoverride/verticles/configuration/package-info.java
+++ b/src/main/java/docoverride/verticles/configuration/package-info.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+/**
+ * === Passing configuration to a verticle
+ *
+ * Configuration in the form of JSON can be passed to a verticle at deployment time:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.CoreExamples#example13}
+ * ----
+ *
+ * This configuration is then available via the {@link io.vertx.core.Context} object or directly using the
+ * {@link io.vertx.core.AbstractVerticle#config()} method. The configuration is returned as a JSON object so you
+ * can retrieve data as follows:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.ConfigurableVerticleExamples#start()}
+ * ----
+ *
+ * === Accessing environment variables in a Verticle
+ *
+ * Environment variables and system properties are accessible from a verticle by following the Java way. To
+ * retrieve system properties, use {@link java.lang.System#getProperty(java.lang.String)}
+ * (or {@link java.lang.System#getProperty(java.lang.String, java.lang.String)}). You can also retrieve the
+ * environment variables using {@link java.lang.System#getenv(java.lang.String)}.
+ *
+ */
+@Document(fileName = "override/verticle-configuration.adoc")
+package docoverride.verticles.configuration;
+
+import io.vertx.docgen.Document;

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -216,6 +216,11 @@ public class CoreExamples {
     });
   }
 
+  public void systemAndEnvProperties() {
+    System.getProperty("prop");
+    System.getenv("HOME");
+  }
+
 
 
 

--- a/src/main/java/examples/EventBusExamples.java
+++ b/src/main/java/examples/EventBusExamples.java
@@ -76,12 +76,6 @@ public class EventBusExamples {
     eventBus.send("news.uk.sport", "Yay! Someone kicked a ball");
   }
 
-  public void example7(EventBus eventBus) {
-    DeliveryOptions options = new DeliveryOptions();
-    options.addHeader("some-header", "some-value");
-    eventBus.send("news.uk.sport", "Yay! Someone kicked a ball", options);
-  }
-
   public void example8(EventBus eventBus) {
     MessageConsumer<String> consumer = eventBus.consumer("news.uk.sport");
     consumer.handler(message -> {

--- a/src/main/java/examples/RecordParserExamples.java
+++ b/src/main/java/examples/RecordParserExamples.java
@@ -1,0 +1,28 @@
+package examples;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.parsetools.RecordParser;
+
+/**
+ * Example using the record parser.
+ */
+public class RecordParserExamples {
+
+
+  public void example1() {
+    final RecordParser parser = RecordParser.newDelimited("\n", h -> {
+      System.out.println(h.toString());
+    });
+
+    parser.handle(Buffer.buffer("HELLO\nHOW ARE Y"));
+    parser.handle(Buffer.buffer("OU?\nI AM"));
+    parser.handle(Buffer.buffer("DOING OK"));
+    parser.handle(Buffer.buffer("\n"));
+  }
+
+  public void example2() {
+    RecordParser.newFixed(4, h -> {
+      System.out.println(h.toString());
+    });
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/package-info.java
+++ b/src/main/java/io/vertx/core/eventbus/package-info.java
@@ -177,15 +177,7 @@
  * {@link examples.EventBusExamples#example6}
  * ----
  *
- * ==== Setting headers on messages
- *
- * Messages sent over the event bus can also contain headers. This can be specified by providing a
- * {@link io.vertx.core.eventbus.DeliveryOptions} when sending or publishing:
- *
- * [source,$lang]
- * ----
- * {@link examples.EventBusExamples#example7}
- * ----
+ * include::override/eventbus_headers.adoc[]
  *
  * ==== The Message object
  *
@@ -266,7 +258,7 @@
  *
  * You can run Vert.x clustered on the command line with
  *
- *  vertx run MyVerticle -cluster
+ *  vertx run my-verticle.js -cluster
  *
  * === Automatic clean-up in verticles
  *

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -461,30 +461,7 @@
  * This is useful for scaling easily across multiple cores. For example you might have a web-server verticle to deploy
  * and multiple cores on your machine, so you want to deploy multiple instances to take utilise all the cores.
  *
- * === Passing configuration to a verticle
- *
- * Configuration in the form of JSON can be passed to a verticle at deployment time:
- *
- * [source,$lang]
- * ----
- * {@link examples.CoreExamples#example13}
- * ----
- *
- * This configuration is then available via the {@link io.vertx.core.Context} object or directly using the
- * {@link io.vertx.core.AbstractVerticle#config()} method. The configuration is returned as a JSON object so you can
- * retrieve data as follows:
- *
- * [source,$lang]
- * ----
- * {@link examples.ConfigurableVerticleExamples#start()}
- * ----
- *
- * === Accessing environment variables in a Verticle
- *
- * Environment variables and system properties are accessible from a verticle by following the Java way. To retrieve
- * system properties, use {@link java.lang.System#getProperty(java.lang.String)}
- * (or {@link java.lang.System#getProperty(java.lang.String, java.lang.String)}). You can also retrieve the
- * environment variables using {@link java.lang.System#getenv(java.lang.String)}.
+ * include::override/verticle-configuration.adoc[]
  *
  * === Verticle Isolation Groups
  *

--- a/src/main/java/io/vertx/core/parsetools/package-info.java
+++ b/src/main/java/io/vertx/core/parsetools/package-info.java
@@ -15,9 +15,46 @@
  */
 
 /**
- * == Parse tools
+ * == Record Parser
  *
- * TODO
+ * The record parser allows you to easily parse protocols which are delimited by a sequence of bytes, or fixed
+ * size records. It transforms an sequence of input buffer to a sequence of buffer structured as configured (either
+ * fixed size or separated records).
+ *
+ * For example, if you have a simple ASCII text protocol delimited by '\n' and the input is the following:
+ *
+ * [source]
+ * ----
+ * buffer1:HELLO\nHOW ARE Y
+ * buffer2:OU?\nI AM
+ * buffer3: DOING OK
+ * buffer4:\n
+ * ----
+ *
+ * The record parser would produce
+ *[source]
+ * ----
+ * buffer1:HELLO
+ * buffer2:HOW ARE YOU?
+ * buffer3:I AM DOING OK
+ * ----
+ *
+ * Let's see the associated code:
+ *
+ * [source, $lang]
+ * ----
+ * {@link examples.RecordParserExamples#example1()}
+ * ----
+ *
+ * You can also produce fixed sized chunks as follows:
+ *
+ * [source, $lang]
+ * ----
+ * {@link examples.RecordParserExamples#example2()}
+ * ----
+ *
+ * For more details, check out the {@link io.vertx.core.parsetools.RecordParser} class.
+ *
  */
 @Document(fileName = "parsetools.adoc")
 package io.vertx.core.parsetools;


### PR DESCRIPTION
Here is the replacement of https://github.com/eclipse/vert.x/pull/1072.

Move the non translatable code and language specific parts in the docoverride so it can be customized per languages.

I've signed off all commits, and add the parse tools documentation. This means that all sections of the core documentation are there.