### PR TITLE
Add Vertx Start Hooks Methods in io.vertx.core.Starter

### DIFF
--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -171,6 +171,20 @@ public class Starter {
     stopLatch.countDown();
   }
 
+  /**
+   * Hook for sub classes of {@link Starter} before the vertx instance is started.
+   */
+  protected void beforeStartingVertx(VertxOptions options) {
+    
+  }
+  
+  /**
+   * Hook for sub classes of {@link Starter} after the vertx instance is started.
+   */
+  protected void afterStartingVertx() {
+    
+  }
+
   private Vertx startVertx(boolean clustered, boolean ha, Args args) {
     MetricsOptions metricsOptions;
     ServiceLoader<VertxMetricsFactory> factories = ServiceLoader.load(VertxMetricsFactory.class);
@@ -215,6 +229,7 @@ public class Starter {
           options.setQuorumSize(quorumSize);
         }
       }
+      beforeStartingVertx(options);
       Vertx.clusteredVertx(options, ar -> {
         result.set(ar);
         latch.countDown();
@@ -235,8 +250,10 @@ public class Starter {
       }
       vertx = result.get().result();
     } else {
+      beforeStartingVertx(options);
       vertx = Vertx.vertx(options);
     }
+    afterStartingVertx();
     return vertx;
   }
 

--- a/src/test/java/io/vertx/test/core/StarterTest.java
+++ b/src/test/java/io/vertx/test/core/StarterTest.java
@@ -86,6 +86,7 @@ public class StarterTest extends VertxTestBase {
     assertTrue(t.isAlive()); // It's blocked
     List<String> processArgs = TestVerticle.processArgs;
     assertEquals(Arrays.asList(args), TestVerticle.processArgs);
+    starter.assertHooksInvoked();
     // Now unblock it
     starter.unblock();
     waitUntil(() -> !t.isAlive());
@@ -102,6 +103,7 @@ public class StarterTest extends VertxTestBase {
     waitUntil(() -> TestVerticle.instanceCount.get() == 1);
     assertTrue(t.isAlive()); // It's blocked
     assertEquals(Arrays.asList(args), TestVerticle.processArgs);
+    starter.assertHooksInvoked();
     // Now unblock it
     starter.unblock();
     waitUntil(() -> !t.isAlive());
@@ -118,6 +120,7 @@ public class StarterTest extends VertxTestBase {
     waitUntil(() -> TestVerticle.instanceCount.get() == 1);
     assertTrue(t.isAlive()); // It's blocked
     assertEquals(Arrays.asList(args), TestVerticle.processArgs);
+    starter.assertHooksInvoked();
     // Now unblock it
     starter.unblock();
     waitUntil(() -> !t.isAlive());
@@ -342,6 +345,9 @@ public class StarterTest extends VertxTestBase {
   }
 
   class MyStarter extends Starter {
+    boolean beforeStartingVertxInvoked = false;
+    boolean afterStartingVertxInvoked = false;
+    
     public Vertx getVert() {
       return vertx;
     }
@@ -360,6 +366,20 @@ public class StarterTest extends VertxTestBase {
     @Override
     public void run(String commandLine) {
       super.run(commandLine);
+    }
+    
+    @Override
+    public void beforeStartingVertx(VertxOptions options) {
+      beforeStartingVertxInvoked = true;
+    }
+    
+    public void afterStartingVertx() {
+      afterStartingVertxInvoked = true;
+    };
+    
+    public void assertHooksInvoked() {
+      assertTrue(beforeStartingVertxInvoked);
+      assertTrue(afterStartingVertxInvoked);
     }
   }
 }


### PR DESCRIPTION
This change enables subclasses of io.vertx.core.Starter to implement custom behavior before
and after the vertx instance has been started by overriding these methods:

* beforeStartingVertx(VertxOptions options)
* afterStartingVertx()