### PR TITLE
Fix links in the documentation

### DIFF
--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -294,7 +294,7 @@
  * ----
  *
  * WARNING: Make sure you check the filename in a production system to avoid malicious clients uploading files
- * to arbitrary places on your filesystem. See <<security_notes, security notes>> for more information.
+ * to arbitrary places on your filesystem. See <<Security notes, security notes>> for more information.
  *
  * === Sending back responses
  *
@@ -942,7 +942,7 @@
  *
  * Vert.x http servers and clients can be configured to use HTTPS in exactly the same way as net servers.
  *
- * Please see <<netserver_ssl, configuring net servers to use SSL>> for more information.
+ * Please see <<ssl, configuring net servers to use SSL>> for more information.
  *
  * === WebSockets
  *

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -929,8 +929,9 @@
  * can be easily replaced by a different implementation as Vert.x cluster managers are pluggable.
  *
  * A cluster manager must implement the interface {@link io.vertx.core.spi.cluster.ClusterManager}. Vert.x locates
- * cluster managers at run-time by using the Java {@link java.util.ServiceLoader} functionality to locate instances of
- * {@link io.vertx.core.spi.cluster.ClusterManager} on the classpath.
+ * cluster managers at run-time by using the Java
+ * https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html[Service Loader] functionality to locate
+ * instances of {@link io.vertx.core.spi.cluster.ClusterManager} on the classpath.
  *
  * If you are using Vert.x at the command line and you want to use clustering you should make sure the `lib` directory
  * of the Vert.x installation contains your cluster manager jar.


### PR DESCRIPTION
* Fix the bad anchor names (see https://github.com/vert-x3/vertx-web-site/issues/71)
* Fix the link to the Service Loader class (need a full url, as only vert.x classes can be correctly linked using `{@link ...}`.