### PR TITLE
Add Verticle Deployment Hook Method in io.vertx.core.Starter

### DIFF
--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -184,6 +184,13 @@ public class Starter {
   protected void afterStartingVertx() {
     
   }
+  
+  /**
+   * Hook for sub classes of {@link Starter} before the verticle is deployed.
+   */
+  protected void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {
+    
+  }
 
   private Vertx startVertx(boolean clustered, boolean ha, Args args) {
     MetricsOptions metricsOptions;
@@ -332,8 +339,9 @@ public class Starter {
 
     boolean redeploy = args.map.get("-redeploy") != null;
 
-    vertx.deployVerticle(main, deploymentOptions.setConfig(conf).setWorker(worker).setHa(ha).setInstances(instances)
-                                 .setRedeploy(redeploy), createLoggingHandler(message, res -> {
+    deploymentOptions.setConfig(conf).setWorker(worker).setHa(ha).setInstances(instances).setRedeploy(redeploy);
+    beforeDeployingVerticle(deploymentOptions);
+    vertx.deployVerticle(main, deploymentOptions, createLoggingHandler(message, res -> {
       if (res.failed()) {
         // Failed to deploy
         unblock();

--- a/src/test/java/io/vertx/test/core/StarterTest.java
+++ b/src/test/java/io/vertx/test/core/StarterTest.java
@@ -347,6 +347,7 @@ public class StarterTest extends VertxTestBase {
   class MyStarter extends Starter {
     boolean beforeStartingVertxInvoked = false;
     boolean afterStartingVertxInvoked = false;
+    boolean beforeDeployingVerticle = false;
     
     public Vertx getVert() {
       return vertx;
@@ -372,14 +373,19 @@ public class StarterTest extends VertxTestBase {
     public void beforeStartingVertx(VertxOptions options) {
       beforeStartingVertxInvoked = true;
     }
-    
+    @Override
     public void afterStartingVertx() {
       afterStartingVertxInvoked = true;
-    };
+    }
+    @Override
+    protected void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {
+      beforeDeployingVerticle = true;
+    }
     
     public void assertHooksInvoked() {
       assertTrue(beforeStartingVertxInvoked);
       assertTrue(afterStartingVertxInvoked);
+      assertTrue(beforeDeployingVerticle);
     }
   }
 }


### PR DESCRIPTION
This change enables subclasses of io.vertx.core.Starter to implement
custom behavior (e.g. attach further configuration on the
DeploymentOptions.config) before the verticle managed by the Starter is
deployed:

* beforeDeployingVerticle(DeploymentOptions options)

Signed-off-by: Andreas Weise <andreas.weise@gmail.com>