### PR TITLE
Implementation of Eclipse bug #469623

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpClientResponse.java
@@ -16,6 +16,7 @@
 
 package io.vertx.core.http;
 
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
@@ -79,6 +80,15 @@ public interface HttpClientResponse extends ReadStream<Buffer> {
    * @return the header value
    */
   String getHeader(String headerName);
+
+  /**
+   * Return the first header value with the specified name
+   *
+   * @param headerName  the header
+   * @return the header value
+   */
+  @GenIgnore
+  String getHeader(CharSequence headerName);
 
   /**
    * Return the first trailer value with the specified name

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -108,6 +108,15 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   String getHeader(String headerName);
 
   /**
+   * Return the first header value with the specified name
+   *
+   * @param headerName  the header name
+   * @return the header value
+   */
+  @GenIgnore
+  String getHeader(CharSequence headerName);
+
+  /**
    * @return the query parameters in the request
    */
   @CacheReturn

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -395,6 +395,11 @@ public class HttpClientRequestImpl implements HttpClientRequest {
           }
 
           @Override
+          public String getHeader(CharSequence headerName) {
+            return resp.getHeader(headerName.toString());
+          }
+
+          @Override
           public String getTrailer(String trailerName) {
             return resp.getTrailer(trailerName);
           }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -396,7 +396,7 @@ public class HttpClientRequestImpl implements HttpClientRequest {
 
           @Override
           public String getHeader(CharSequence headerName) {
-            return resp.getHeader(headerName.toString());
+            return resp.getHeader(headerName);
           }
 
           @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -103,7 +103,7 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
 
   @Override
   public String getHeader(CharSequence headerName) {
-    return headers().get(headerName.toString());
+    return headers().get(headerName);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -102,6 +102,11 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
   }
 
   @Override
+  public String getHeader(CharSequence headerName) {
+    return headers().get(headerName.toString());
+  }
+
+  @Override
   public synchronized MultiMap trailers() {
     if (trailers == null) {
       trailers = new HeadersAdaptor(new DefaultHttpHeaders());

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -170,7 +170,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
 
   @Override
   public String getHeader(CharSequence headerName) {
-    return headers().get(headerName.toString());
+    return headers().get(headerName);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -169,6 +169,11 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   }
 
   @Override
+  public String getHeader(CharSequence headerName) {
+    return headers().get(headerName.toString());
+  }
+
+  @Override
   public MultiMap params() {
     if (params == null) {
       QueryStringDecoder queryStringDecoder = new QueryStringDecoder(uri());

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -1300,6 +1300,32 @@ public class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testResponseHeadersWithCharSequence() {
+    HashMap<CharSequence, String> headers = new HashMap<>();
+    headers.put(HttpHeaders.TEXT_HTML, "text/html");
+    headers.put(HttpHeaders.USER_AGENT, "User-Agent");
+    headers.put(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded");
+
+    server.requestHandler(req -> {
+      headers.forEach((k, v) -> req.response().headers().add(k, v));
+      req.response().end();
+    });
+
+    server.listen(onSuccess(server -> {
+      client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        assertEquals(headers.size() + 1, resp.headers().size());
+
+        headers.forEach((k,v) -> assertEquals(v, resp.headers().get(k)));
+        headers.forEach((k,v) -> assertEquals(v, resp.getHeader(k)));
+
+        testComplete();
+      }).end();
+    }));
+
+    await();
+  }
+
+  @Test
   public void testResponseMultipleSetCookieInHeader() {
     testResponseMultipleSetCookie(true, false);
   }

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -1262,6 +1262,33 @@ public class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testRequestHeadersWithCharSequence() {
+    HashMap<CharSequence, String> headers = new HashMap<>();
+    headers.put(HttpHeaders.TEXT_HTML, "text/html");
+    headers.put(HttpHeaders.USER_AGENT, "User-Agent");
+    headers.put(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded");
+
+    server.requestHandler(req -> {
+      assertEquals(headers.size() + 1, req.headers().size());
+
+      headers.forEach((k, v) -> assertEquals(v, req.headers().get(k)));
+      headers.forEach((k, v) -> assertEquals(v, req.getHeader(k)));
+
+      req.response().end();
+    });
+
+    server.listen(onSuccess(server -> {
+      HttpClientRequest req = client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> testComplete());
+
+      headers.forEach((k, v) -> req.headers().add(k, v));
+
+      req.end();
+    }));
+
+    await();
+  }
+
+  @Test
   public void testResponseHeadersPutAll() {
     testResponseHeaders(false);
   }


### PR DESCRIPTION
This code adds the ability to get headers using CharSequence instead of String for consistency.