### PR TITLE
Documentation Maven / Gradle dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-parent</artifactId>
-    <version>5</version>
+    <version>8</version>
   </parent>
 
   <artifactId>vertx-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,11 @@
             <relativeBaseDir>true</relativeBaseDir>
             <backend>html</backend>
             <doctype>book</doctype>
+            <attributes>
+              <maven-groupId>${project.groupId}</maven-groupId>
+              <maven-artifactId>${project.artifactId}</maven-artifactId>
+              <maven-version>${project.version}</maven-version>
+            </attributes>
           </configuration>
           <executions>
             <execution>

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -33,6 +33,8 @@ Instead, we automatically generate an *idiomatic* equivalent of the core Java AP
 
 From now on we'll just use the word *core* to refer to Vert.x core.
 
+include::override/dependencies.adoc[]
+
 Let's discuss the different concepts and features in core.
 
 == In the beginning there was Vert.x

--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -1,0 +1,20 @@
+If you are using Maven or Gradle, add the following dependency to the _dependencies_ section of your
+project descriptor to access the Vert.x API:
+
+* Maven (in your `pom.xml`):
+
+[source,xml,subs="+attributes"]
+----
+<dependency>
+  <groupId>{maven-groupId}</groupId>
+  <artifactId>{maven-artifactId}</artifactId>
+  <version>{maven-version}</version>
+</dependency>
+----
+
+* Gradle (in your `build.gradle` file):
+
+[source,groovy,subs="+attributes"]
+----
+compile {maven-groupId}:{maven-artifactId}:{maven-version}
+----

--- a/src/main/java/docoverride/dependencies/package-info.java
+++ b/src/main/java/docoverride/dependencies/package-info.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+/**
+ * If you are using Maven or Gradle, add the following dependency to the _dependencies_ section of your
+ * project descriptor to access the Vert.x Core API:
+ *
+ * * Maven (in your `pom.xml`):
+ *
+ * [source,xml,subs="+attributes"]
+ * ----
+ * <dependency>
+ *   <groupId>{maven-groupId}</groupId>
+ *   <artifactId>{maven-artifactId}</artifactId>
+ *   <version>{maven-version}</version>
+ * </dependency>
+ * ----
+ *
+ * * Gradle (in your `build.gradle` file):
+ *
+ * [source,groovy,subs="+attributes"]
+ * ----
+ * compile {maven-groupId}:{maven-artifactId}:{maven-version}
+ * ----
+ */
+@Document(fileName = "override/dependencies.adoc")
+package docoverride.dependencies;
+
+import io.vertx.docgen.Document;

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -50,6 +50,8 @@
  *
  * From now on we'll just use the word *core* to refer to Vert.x core.
  *
+ * include::override/dependencies.adoc[]
+ *
  * Let's discuss the different concepts and features in core.
  *
  * == In the beginning there was Vert.x


### PR DESCRIPTION
Add  Maven and Gradle dependency information to the documentation.

This is related to: vert-x3/issues#14

As the set of dependencies depends on the language, the content is extracted to a _docoverride_ document that other languages can extend / replace.

It also updates the parent pom (see vert-x3/issues/issues/17)