### PR TITLE
Make sure currentResponse is set to null after response has ended to …

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -287,6 +287,7 @@ class ClientConnection extends ConnectionBase {
     if (currentResponse.statusCode() != 100 && requestForResponse.getRequest().getMethod() != HttpMethod.CONNECT) {
       listener.responseEnded(this);
     }
+    currentResponse = null;
   }
 
   synchronized void handleWsFrame(WebSocketFrameInternal frame) {

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -1664,6 +1664,25 @@ public class HttpTest extends HttpTestBase {
   }
 
   @Test
+  public void testNoExceptionHandlerCalledWhenResponseReceivedOK() throws Exception {
+    server.requestHandler(request -> {
+      request.response().end();
+    }).listen(DEFAULT_HTTP_PORT, onSuccess(s -> {
+      client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        resp.endHandler(v -> {
+          vertx.setTimer(100, tid -> testComplete());
+        });
+        resp.exceptionHandler(t -> {
+          fail("Should not be called");
+        });
+      }).exceptionHandler(t -> {
+        fail("Should not be called");
+      }).end();
+    }));
+    await();
+  }
+
+  @Test
   public void testDefaultStatus() {
     testStatusCode(-1, null);
   }


### PR DESCRIPTION
…prevent exception being fired when conn is closed