### PR TITLE
Make it easier for working with subclassed Starters

### DIFF
--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -494,7 +494,7 @@ public class Starter {
         Manifest manifest = new Manifest(resources.nextElement().openStream());
         Attributes attributes = manifest.getMainAttributes();
         String mainClass = attributes.getValue("Main-Class");
-        if (Starter.class.getName().equals(mainClass)) {
+        if (this.getClass().getName().equals(mainClass)) {
           String theMainVerticle = attributes.getValue("Main-Verticle");
           if (theMainVerticle != null) {
             return theMainVerticle;

--- a/src/main/java/io/vertx/core/Starter.java
+++ b/src/main/java/io/vertx/core/Starter.java
@@ -183,7 +183,14 @@ public class Starter {
   /**
    * Hook for sub classes of {@link Starter} before the verticle is deployed.
    */
-  protected void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {
+  protected void beforeDeployingVerticle(String verticle, DeploymentOptions deploymentOptions) {
+    
+  }
+
+  /**
+   * Hook for sub classes of {@link Starter} after the verticle is deployed.
+   */
+  protected void afterDeployingVerticle(String verticle, AsyncResult<String> result) {
     
   }
 
@@ -339,8 +346,9 @@ public class Starter {
 
     deploymentOptions.setConfig(conf).setWorker(worker).setHa(ha).setInstances(instances);
 
-    beforeDeployingVerticle(deploymentOptions);
+    beforeDeployingVerticle(main, deploymentOptions);
     vertx.deployVerticle(main, deploymentOptions, createLoggingHandler(message, res -> {
+      afterDeployingVerticle(main, res);
       if (res.failed()) {
         // Failed to deploy
         unblock();


### PR DESCRIPTION
Some minor changes to make it easier to use a subclassed io.vertx.core.Starter as the Main-Class in a fat JAR. 
I needed this for some early-stage setup stuff (logging, configuration) that needs to happen before actually bringing Vert.x up.