### PR TITLE
Some discrepancies in the handling of (non) keep-alive HTTP requests

### DIFF
--- a/src/main/asciidoc/cheatsheet/HttpClientOptions.adoc
+++ b/src/main/asciidoc/cheatsheet/HttpClientOptions.adoc
@@ -91,6 +91,11 @@ Set the trust options in pfx format+++
 |+++
 Set whether pipe-lining is enabled on the client+++
 
+|[[protocolVersion]]`protocolVersion`
+|`Enum`
+|+++
+Set the protocol version.+++
+
 |[[receiveBufferSize]]`receiveBufferSize`
 |`Number (int)`
 |+++

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -1096,7 +1096,9 @@ The http client supports pooling of connections, allowing you to reuse connectio
 For pooling to work, keep alive must be true using `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setKeepAlive-boolean-[setKeepAlive]`
 on the options used when configuring the client. The default value is true.
 
-When keep alive is enabled. Vert.x will add a `Connection: Keep-Alive` header to each HTTP request sent.
+When keep alive is enabled. Vert.x will add a `Connection: Keep-Alive` header to each HTTP/1.0 request sent.
+When keep alive is disabled. Vert.x will add a `Connection: Close` header to each HTTP/1.1 request sent to signal
+that the connection will be closed after completion of the response.
 
 The maximum number of connections to pool *for each server* is configured using `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setMaxPoolSize-int-[setMaxPoolSize]`
 

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -24,6 +24,9 @@ public class HttpClientOptionsConverter {
     if (json.getValue("pipelining") instanceof Boolean) {
       obj.setPipelining((Boolean)json.getValue("pipelining"));
     }
+    if (json.getValue("protocolVersion") instanceof String) {
+      obj.setProtocolVersion(io.vertx.core.http.HttpVersion.valueOf((String)json.getValue("protocolVersion")));
+    }
     if (json.getValue("tryUseCompression") instanceof Boolean) {
       obj.setTryUseCompression((Boolean)json.getValue("tryUseCompression"));
     }
@@ -41,6 +44,9 @@ public class HttpClientOptionsConverter {
     json.put("maxPoolSize", obj.getMaxPoolSize());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
     json.put("pipelining", obj.isPipelining());
+    if (obj.getProtocolVersion() != null) {
+      json.put("protocolVersion", obj.getProtocolVersion().name());
+    }
     json.put("tryUseCompression", obj.isTryUseCompression());
     json.put("verifyHost", obj.isVerifyHost());
   }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -74,6 +74,11 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public static final int DEFAULT_DEFAULT_PORT = 80;
 
+  /**
+   * The default protocol version = HTTP/1.1
+   */
+  public static final HttpVersion DEFAULT_PROTOCOL_VERSION = HttpVersion.HTTP_1_1;
+
   private boolean verifyHost = true;
   private int maxPoolSize;
   private boolean keepAlive;
@@ -82,6 +87,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int maxWebsocketFrameSize;
   private String defaultHost;
   private int defaultPort;
+  private HttpVersion protocolVersion;
 
   /**
    * Default constructor
@@ -106,6 +112,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.maxWebsocketFrameSize = other.maxWebsocketFrameSize;
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
+    this.protocolVersion = other.protocolVersion;
   }
 
   /**
@@ -128,6 +135,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxWebsocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
     defaultHost = DEFAULT_DEFAULT_HOST;
     defaultPort = DEFAULT_DEFAULT_PORT;
+    protocolVersion = DEFAULT_PROTOCOL_VERSION;
   }
 
   @Override
@@ -411,6 +419,29 @@ public class HttpClientOptions extends ClientOptionsBase {
     return this;
   }
 
+  /**
+   * Get the protocol version.
+   *
+   * @return the protocol version
+   */
+  public HttpVersion getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  /**
+   * Set the protocol version.
+   *
+   * @param protocolVersion the protocol version
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setProtocolVersion(HttpVersion protocolVersion) {
+    if (protocolVersion == null) {
+      throw new IllegalArgumentException("protocolVersion must not be null");
+    }
+    this.protocolVersion = protocolVersion;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -427,6 +458,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (tryUseCompression != that.tryUseCompression) return false;
     if (verifyHost != that.verifyHost) return false;
     if (!defaultHost.equals(that.defaultHost)) return false;
+    if (protocolVersion != that.protocolVersion) return false;
 
     return true;
   }
@@ -442,6 +474,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     result = 31 * result + maxWebsocketFrameSize;
     result = 31 * result + defaultHost.hashCode();
     result = 31 * result + defaultPort;
+    result = 31 * result + protocolVersion.hashCode();
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -286,6 +286,11 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   boolean ended();
 
   /**
+   * @return has the underlying TCP connection corresponding to the request already been closed?
+   */
+  boolean closed();
+
+  /**
    * @return have the headers for the response already been written?
    */
   boolean headWritten();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -88,7 +88,7 @@ public class HttpClientRequestImpl implements HttpClientRequest {
     this.host = host;
     this.port = port;
     this.client = client;
-    this.request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, toNettyHttpMethod(method), relativeURI, false);
+    this.request = new DefaultHttpRequest(toNettyHttpVersion(client.getOptions().getProtocolVersion()), toNettyHttpMethod(method), relativeURI, false);
     this.chunked = false;
     this.method = method;
     this.vertx = vertx;
@@ -130,7 +130,10 @@ public class HttpClientRequestImpl implements HttpClientRequest {
     if (written > 0) {
       throw new IllegalStateException("Cannot set chunked after data has been written on request");
     }
-    this.chunked = chunked;
+    // HTTP 1.0 does not support chunking so we ignore this if HTTP 1.0
+    if (client.getOptions().getProtocolVersion() != io.vertx.core.http.HttpVersion.HTTP_1_0) {
+      this.chunked = chunked;
+    }
     return this;
   }
 
@@ -605,6 +608,11 @@ public class HttpClientRequestImpl implements HttpClientRequest {
       // if compression should be used but nothing is specified by the user support deflate and gzip.
       request.headers().set(ACCEPT_ENCODING, DEFLATE_GZIP);
     }
+    if (!client.getOptions().isKeepAlive() && client.getOptions().getProtocolVersion() == io.vertx.core.http.HttpVersion.HTTP_1_1) {
+      request.headers().set(CONNECTION, CLOSE);
+    } else if (client.getOptions().isKeepAlive() && client.getOptions().getProtocolVersion() == io.vertx.core.http.HttpVersion.HTTP_1_0) {
+      request.headers().set(CONNECTION, KEEP_ALIVE);
+    }
   }
 
   private void write(ByteBuf buff, boolean end) {
@@ -707,4 +715,16 @@ public class HttpClientRequestImpl implements HttpClientRequest {
     }
   }
 
+  private HttpVersion toNettyHttpVersion(io.vertx.core.http.HttpVersion version) {
+    switch (version) {
+      case HTTP_1_0: {
+        return HttpVersion.HTTP_1_0;
+      }
+      case HTTP_1_1: {
+        return HttpVersion.HTTP_1_1;
+      }
+      default:
+        throw new IllegalArgumentException("Unsupported HTTP version: " + version);
+    }
+  }
 }

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -880,7 +880,9 @@
  * For pooling to work, keep alive must be true using {@link io.vertx.core.http.HttpClientOptions#setKeepAlive(boolean)}
  * on the options used when configuring the client. The default value is true.
  *
- * When keep alive is enabled. Vert.x will add a `Connection: Keep-Alive` header to each HTTP request sent.
+ * When keep alive is enabled. Vert.x will add a `Connection: Keep-Alive` header to each HTTP/1.0 request sent.
+ * When keep alive is disabled. Vert.x will add a `Connection: Close` header to each HTTP/1.1 request sent to signal
+ * that the connection will be closed after completion of the response.
  *
  * The maximum number of connections to pool *for each server* is configured using {@link io.vertx.core.http.HttpClientOptions#setMaxPoolSize(int)}
  *


### PR DESCRIPTION
Documentation says:

>Non keep-alive connections will be automatically closed by Vert.x when the response is ended.

This was only true for HTTP 1.0 requests, for non keep-alive / non persistent HTTP 1.1 requests (requests with Header "Connection: close") the connection was not closed.

>When keep alive is enabled. Vert.x will add a Connection: Keep-Alive header to each HTTP request sent.

This header was not set for keep-alive HTTP 1.0 request, neither was the "Connection: close" header set for non keep-alive / non persistent HTTP 1.1 requests.

Things changed:

* HTTP server response
  * A Request is considered keep-alive if either HTTP 1.1 and "Connection: close" header is **not** set or HTTP 1.0 and "Connection: keep-alive" header is set. This results in the closing of the undelying connection of non keep-alive requests also for non-persistent HTTP 1.1 requests.
  * for HTTP 1.0 keep-alive requests the "Connection: keep-alive" response header is set.
  * for HTTP 1.1 non keep-alive requests the "Connection: close" response header is set.
* HTTP client request
  * for HTTP 1.0 keep-alive requests the "Connection: keep-alive" request header is set.
  * for HTTP 1.1 non keep-alive requests the "Connection: close" request header is set.
* The protocol version is now configurable via the HttpClientOptions.