### PR TITLE
Bug fix: HttpClientImpl::requestAbs does not respect default port option

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -250,7 +250,8 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
   @Override
   public HttpClientRequest requestAbs(HttpMethod method, String absoluteURI) {
     URL url = parseUrl(absoluteURI);
-    return doRequest(method, url.getHost(), url.getPort(), url.getFile(), null);
+    int port = url.getPort();
+    return doRequest(method, url.getHost(), port == -1 ? options.getDefaultPort() : port, url.getFile(), null);
   }
 
   @Override


### PR DESCRIPTION
At this section, 
https://github.com/eclipse/vert.x/blob/master/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java#L252
```Java
  public HttpClientRequest requestAbs(HttpMethod method, String absoluteURI) {
    URL url = parseUrl(absoluteURI);
    return doRequest(method, url.getHost(), url.getPort(), url.getFile(), null);
  }
```
If `absoluteURI` does not include a port, `url.getPort()` gives -1, which is not handled before it's used to set up a connection and throws port out of range error.

The patch itself does not include a test case as I am not sure how you would like to maintain the test cases, but a sample can be found here:
https://gist.github.com/simonpai/a2d7aa0832854df4634a