### PR TITLE
Keepalive pipelining

### DIFF
--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -4468,6 +4468,38 @@ public class HttpTest extends HttpTestBase {
     await();
   }
 
+  @Test
+  public void testMultipleRecursiveCallsAndPipelining() throws Exception {
+    int sendRequests = 100;
+    AtomicInteger receivedRequests = new AtomicInteger();
+    vertx.createHttpServer()
+      .requestHandler(x -> {
+        x.response().end("hello");
+      })
+      .listen(8080, r -> {
+        if (r.succeeded()) {
+          HttpClient client = vertx.createHttpClient(new HttpClientOptions()
+              .setKeepAlive(true)
+              .setPipelining(true)
+              .setDefaultPort(8080)
+          );
+          IntStream.range(0, 5).forEach(i -> recursiveCall(client, receivedRequests, sendRequests));
+        }
+      });
+    await();
+  }
+
+  private void recursiveCall(HttpClient client, AtomicInteger receivedRequests, int sendRequests){
+    client.getNow("/", r -> {
+      int numRequests = receivedRequests.incrementAndGet();
+      if (numRequests == sendRequests) {
+        testComplete();
+      } else if (numRequests < sendRequests) {
+        recursiveCall(client, receivedRequests, sendRequests);
+      }
+    });
+  }
+
 
   private void pausingServer(Consumer<HttpServer> consumer) {
     server.requestHandler(req -> {


### PR DESCRIPTION
1. Fixes bug in pipelining which could result in requests waiting indefinitely in waiters queue
2. Changes behaviour of keep alive so keep alive connections are never automatically closed.