### PR TITLE
Add API to copy a Buffer into a byte array more efficiently

### DIFF
--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -186,6 +186,44 @@ public interface Buffer extends ClusterSerializable {
   byte[] getBytes(int start, int end);
 
   /**
+   * Transfers the content of the Buffer into a {@code byte[]}.
+   *
+   * @param dst the destination byte array
+   * @throws IndexOutOfBoundsException if the content of the Buffer cannot fit into the destination byte array
+   */
+  @GenIgnore
+  Buffer getBytes(byte[] dst);
+
+  /**
+   * Transfers the content of the Buffer into a {@code byte[]} at the specific destination.
+   *
+   * @param dst the destination byte array
+   * @throws IndexOutOfBoundsException if the content of the Buffer cannot fit into the destination byte array
+   */
+  @GenIgnore
+  Buffer getBytes(byte[] dst, int dstIndex);
+
+  /**
+   * Transfers the content of the Buffer starting at position {@code start} and ending at position {@code end - 1}
+   * into a {@code byte[]}.
+   *
+   * @param dst the destination byte array
+   * @throws IndexOutOfBoundsException if the content of the Buffer cannot fit into the destination byte array
+   */
+  @GenIgnore
+  Buffer getBytes(int start, int end, byte[] dst);
+
+  /**
+   * Transfers the content of the Buffer starting at position {@code start} and ending at position {@code end - 1}
+   * into a {@code byte[]} at the specific destination.
+   *
+   * @param dst the destination byte array
+   * @throws IndexOutOfBoundsException if the content of the Buffer cannot fit into the destination byte array
+   */
+  @GenIgnore
+  Buffer getBytes(int start, int end, byte[] dst, int dstIndex);
+
+  /**
    * Returns a copy of a sub-sequence the Buffer as a {@link io.vertx.core.buffer.Buffer} starting at position {@code start}
    * and ending at position {@code end - 1}
    */

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -119,6 +119,28 @@ public class BufferImpl implements Buffer {
     return arr;
   }
 
+  @Override
+  public Buffer getBytes(byte[] dst) {
+   return getBytes(dst, 0);
+  }
+
+  @Override
+  public Buffer getBytes(byte[] dst, int dstIndex) {
+    return getBytes(0, buffer.writerIndex(), dst, dstIndex);
+  }
+
+  @Override
+  public Buffer getBytes(int start, int end, byte[] dst) {
+    return getBytes(start, end, dst, 0);
+  }
+
+  @Override
+  public Buffer getBytes(int start, int end, byte[] dst, int dstIndex) {
+    Arguments.require(end >= start, "end must be greater or equal than start");
+    buffer.getBytes(start, dst, dstIndex, end - start);
+    return this;
+  }
+
   public Buffer getBuffer(int start, int end) {
     return new BufferImpl(getBytes(start, end));
   }

--- a/src/test/java/io/vertx/test/core/BufferTest.java
+++ b/src/test/java/io/vertx/test/core/BufferTest.java
@@ -408,6 +408,50 @@ public class BufferTest {
     assertTrue(TestUtils.byteArraysEqual(sub, b.getBytes(bytes.length / 4, bytes.length / 4 + bytes.length / 2)));
   }
 
+  @Test
+  public void testGetBytesWithByteArray() throws Exception {
+    byte[] bytes = TestUtils.randomByteArray(100);
+    Buffer b = Buffer.buffer(bytes);
+
+    byte[] sub = new byte[bytes.length / 2];
+    System.arraycopy(bytes, bytes.length / 4, sub, 0, bytes.length / 2);
+
+    byte[] result = new byte[bytes.length / 2];
+    b.getBytes(bytes.length / 4, bytes.length / 4 + bytes.length / 2, result);
+
+    assertTrue(TestUtils.byteArraysEqual(sub, result));
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testGetBytesWithTooSmallByteArray() throws Exception {
+    byte[] bytes = TestUtils.randomByteArray(100);
+    Buffer b = Buffer.buffer(bytes);
+    byte[] result = new byte[bytes.length / 4];
+    b.getBytes(bytes.length / 4, bytes.length / 4 + bytes.length / 2, result);
+  }
+
+  @Test
+  public void testGetBytesWithByteArrayFull() throws Exception {
+    byte[] bytes = TestUtils.randomByteArray(100);
+    Buffer b = Buffer.buffer(bytes);
+
+    byte[] sub = new byte[bytes.length];
+    System.arraycopy(bytes, bytes.length / 4, sub, 12, bytes.length / 2);
+
+    byte[] result = new byte[bytes.length];
+    b.getBytes(bytes.length / 4, bytes.length / 4 + bytes.length / 2, result, 12);
+
+    assertTrue(TestUtils.byteArraysEqual(sub, result));
+  }
+
+  @Test(expected = IndexOutOfBoundsException.class)
+  public void testGetBytesWithBadOffset() throws Exception {
+    byte[] bytes = TestUtils.randomByteArray(100);
+    Buffer b = Buffer.buffer(bytes);
+    byte[] result = new byte[bytes.length / 2];
+    b.getBytes(bytes.length / 4, bytes.length / 4 + bytes.length / 2, result, -1);
+  }
+
   private final int numSets = 100;
 
   @Test


### PR DESCRIPTION
Add API to copy a Buffer into a byte array more efficiently without array allocation.

Signed-off-by: Testo Nakada <test1@doramail.com>