### PR TITLE
Deprecate ClusterManager.nodeListener() and replace it with add/removeNodeListener()

### DIFF
--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -133,7 +133,7 @@ public class HAManager {
     haInfo.put("server_id", new JsonObject().put("host", serverID.host).put("port", serverID.port));
     this.clusterMap = clusterManager.getSyncMap(CLUSTER_MAP_NAME);
     this.nodeID = clusterManager.getNodeID();
-    clusterManager.nodeListener(new NodeListener() {
+    clusterManager.addNodeListener(new NodeListener() {
       @Override
       public void nodeAdded(String nodeID) {
         HAManager.this.nodeAdded(nodeID);

--- a/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -100,7 +100,7 @@ public interface ClusterManager {
    * @param listener
    */
   void removeNodeListener(NodeListener listener);
-
+ 
   /**
    * Join the cluster
    */

--- a/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -49,11 +49,11 @@ public interface ClusterManager {
 
   void setVertx(Vertx vertx);
 
-  /**
+  /** 
    * Return an async multi-map for the given name
    */
   <K, V> void getAsyncMultiMap(String name, Handler<AsyncResult<AsyncMultiMap<K, V>>> resultHandler);
-  
+
   /**
    * Return an async map for the given name
    */

--- a/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -53,7 +53,7 @@ public interface ClusterManager {
    * Return an async multi-map for the given name
    */
   <K, V> void getAsyncMultiMap(String name, Handler<AsyncResult<AsyncMultiMap<K, V>>> resultHandler);
-
+  
   /**
    * Return an async map for the given name
    */
@@ -100,7 +100,7 @@ public interface ClusterManager {
    * @param listener
    */
   void removeNodeListener(NodeListener listener);
- 
+
   /**
    * Join the cluster
    */

--- a/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
+++ b/src/main/java/io/vertx/core/spi/cluster/ClusterManager.java
@@ -84,7 +84,22 @@ public interface ClusterManager {
    *
    * @param listener
    */
+  @Deprecated
   void nodeListener(NodeListener listener);
+
+  /**
+   * Add a listener that will be called when a node joins or leaves the cluster.
+   *
+   * @param listener
+   */
+  void addNodeListener(NodeListener listener);
+
+  /**
+   * Remove a listener.
+   *
+   * @param listener
+   */
+  void removeNodeListener(NodeListener listener);
 
   /**
    * Join the cluster

--- a/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -167,6 +167,17 @@ public class FakeClusterManager implements ClusterManager {
   }
 
   @Override
+  public void addNodeListener(NodeListener listener) {
+    doAddNodeListener(listener);
+    this.nodeListener = listener;
+  }
+
+  @Override
+  public void removeNodeListener(NodeListener listener) {
+    doRemoveNodeListener(listener);
+  }
+
+  @Override
   public void join(Handler<AsyncResult<Void>> resultHandler) {
     this.nodeID = UUID.randomUUID().toString();
     doJoin(nodeID, this);


### PR DESCRIPTION
Hi all,

This pull request is a proposal to deprecate ClusterManager.nodeListener() and replace it with add/removeNodeListener().
This will allow the applicationa to listen for cluster membership events. An example use case is - fault-tolerance: verticles with persistent state, which previously resided on a crashed node, need to be recovered on the available cluster nodes, while the application logic handles the deployment of verticles.