### PR TITLE
Added support to set the "Client Auth" value as enum. It allows us to…

### DIFF
--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -20,6 +20,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.*;
+import io.vertx.core.net.impl.SSLHelper;
 
 /**
  * Created by tim on 19/01/15.
@@ -253,7 +254,7 @@ public class NetExamples {
   public void example23(Vertx vertx) {
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuthRequired(true).
+        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
         setTrustStoreOptions(
             new JksOptions().
                 setPath("/path/to/your/truststore.jks").
@@ -266,7 +267,7 @@ public class NetExamples {
     Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.jks");
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuthRequired(true).
+        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
         setTrustStoreOptions(
             new JksOptions().
                 setValue(myTrustStoreAsABuffer).
@@ -278,7 +279,7 @@ public class NetExamples {
   public void example25(Vertx vertx) {
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuthRequired(true).
+        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
         setPfxTrustOptions(
             new PfxOptions().
                 setPath("/path/to/your/truststore.pfx").
@@ -291,7 +292,7 @@ public class NetExamples {
     Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.pfx");
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuthRequired(true).
+        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
         setPfxTrustOptions(
             new PfxOptions().
                 setValue(myTrustStoreAsABuffer).
@@ -303,7 +304,7 @@ public class NetExamples {
   public void example27(Vertx vertx) {
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuthRequired(true).
+        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
         setPemTrustOptions(
             new PemTrustOptions().
                 addCertPath("/path/to/your/server-ca.pem")
@@ -315,7 +316,7 @@ public class NetExamples {
     Buffer myCaAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-ca.pfx");
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuthRequired(true).
+        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
         setPemTrustOptions(
             new PemTrustOptions().
                 addCertValue(myCaAsABuffer)

--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -19,8 +19,8 @@ package examples;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.net.*;
-import io.vertx.core.net.impl.SSLHelper;
 
 /**
  * Created by tim on 19/01/15.
@@ -254,7 +254,7 @@ public class NetExamples {
   public void example23(Vertx vertx) {
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
+        setClientAuth(ClientAuth.REQUIRED).
         setTrustStoreOptions(
             new JksOptions().
                 setPath("/path/to/your/truststore.jks").
@@ -267,7 +267,7 @@ public class NetExamples {
     Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.jks");
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
+        setClientAuth(ClientAuth.REQUIRED).
         setTrustStoreOptions(
             new JksOptions().
                 setValue(myTrustStoreAsABuffer).
@@ -279,7 +279,7 @@ public class NetExamples {
   public void example25(Vertx vertx) {
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
+        setClientAuth(ClientAuth.REQUIRED).
         setPfxTrustOptions(
             new PfxOptions().
                 setPath("/path/to/your/truststore.pfx").
@@ -292,7 +292,7 @@ public class NetExamples {
     Buffer myTrustStoreAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/truststore.pfx");
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
+        setClientAuth(ClientAuth.REQUIRED).
         setPfxTrustOptions(
             new PfxOptions().
                 setValue(myTrustStoreAsABuffer).
@@ -304,7 +304,7 @@ public class NetExamples {
   public void example27(Vertx vertx) {
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
+        setClientAuth(ClientAuth.REQUIRED).
         setPemTrustOptions(
             new PemTrustOptions().
                 addCertPath("/path/to/your/server-ca.pem")
@@ -316,7 +316,7 @@ public class NetExamples {
     Buffer myCaAsABuffer = vertx.fileSystem().readFileBlocking("/path/to/your/server-ca.pfx");
     NetServerOptions options = new NetServerOptions().
         setSsl(true).
-        setClientAuth(SSLHelper.ClientAuth.REQUIRED).
+        setClientAuth(ClientAuth.REQUIRED).
         setPemTrustOptions(
             new PemTrustOptions().
                 addCertValue(myCaAsABuffer)

--- a/src/main/java/io/vertx/core/http/ClientAuth.java
+++ b/src/main/java/io/vertx/core/http/ClientAuth.java
@@ -1,8 +1,20 @@
 package io.vertx.core.http;
 
+import io.vertx.codegen.annotations.VertxGen;
+
 /**
+ * Configures the engine to require/request client authentication. Following are the options :
+ * <p>
+ * NONE - No client authentication is requested or required.
+ * <p>
+ * REQUEST - Accept authentication if presented by client. If this option is set and the client chooses
+ *      not to provide authentication information about itself, the negotiations will continue.
+ * <p>
+ * REQUIRED - Require client to present authentication, if not presented then negotiations will be declined.
+ * <p>
  * Created by manishk on 10/2/2015.
  */
+@VertxGen
 public enum ClientAuth {
     NONE, REQUEST, REQUIRED
 }

--- a/src/main/java/io/vertx/core/http/ClientAuth.java
+++ b/src/main/java/io/vertx/core/http/ClientAuth.java
@@ -1,0 +1,8 @@
+package io.vertx.core.http;
+
+/**
+ * Created by manishk on 10/2/2015.
+ */
+public enum ClientAuth {
+    NONE, REQUEST, REQUIRED
+}

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
+import io.vertx.core.net.impl.SSLHelper;
 
 /**
  * Represents options used by an {@link io.vertx.core.http.HttpServer} instance
@@ -272,10 +273,10 @@ public class HttpServerOptions extends NetServerOptions {
   public String getWebsocketSubProtocols() {
     return websocketSubProtocols;
   }
-  
+
   @Override
-  public HttpServerOptions setClientAuthRequired(boolean clientAuthRequired) {
-    super.setClientAuthRequired(clientAuthRequired);
+  public HttpServerOptions setClientAuth(SSLHelper.ClientAuth clientAuth) {
+    super.setClientAuth(clientAuth);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -20,7 +20,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
-import io.vertx.core.net.impl.SSLHelper;
 
 /**
  * Represents options used by an {@link io.vertx.core.http.HttpServer} instance
@@ -275,7 +274,14 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
-  public HttpServerOptions setClientAuth(SSLHelper.ClientAuth clientAuth) {
+  @Deprecated
+  public HttpServerOptions setClientAuthRequired(boolean clientAuthRequired) {
+    super.setClientAuthRequired(clientAuthRequired);
+    return this;
+  }
+
+  @Override
+  public HttpServerOptions setClientAuth(ClientAuth clientAuth) {
     super.setClientAuth(clientAuth);
     return this;
   }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -18,8 +18,8 @@ package io.vertx.core.net;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.impl.SSLHelper;
 
 /**
  * Options for configuring a {@link io.vertx.core.net.NetServer}.
@@ -46,10 +46,15 @@ public class NetServerOptions extends TCPSSLOptions {
    */
   public static final int DEFAULT_ACCEPT_BACKLOG = 1024;
 
+  /**
+   * Default value of whether client auth is required (SSL/TLS) = false
+   */
+  public static final boolean DEFAULT_CLIENT_AUTH_REQUIRED = false;
+
   private int port;
   private String host;
   private int acceptBacklog;
-  private SSLHelper.ClientAuth clientAuth = SSLHelper.ClientAuth.NONE;
+  private ClientAuth clientAuth = ClientAuth.NONE;
 
   /**
    * Default constructor
@@ -69,7 +74,6 @@ public class NetServerOptions extends TCPSSLOptions {
     this.port = other.getPort();
     this.host = other.getHost();
     this.acceptBacklog = other.getAcceptBacklog();
-    this.clientAuth = other.getClientAuth();
   }
 
   /**
@@ -259,7 +263,24 @@ public class NetServerOptions extends TCPSSLOptions {
    *
    * @return true if client auth is required
    */
-  public SSLHelper.ClientAuth getClientAuth() {
+  @Deprecated
+  public boolean isClientAuthRequired() {
+    return clientAuth == ClientAuth.REQUIRED;
+  }
+
+  /**
+   * Set whether client auth is required
+   *
+   * @param clientAuthRequired  true if client auth is required
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Deprecated
+  public NetServerOptions setClientAuthRequired(boolean clientAuthRequired) {
+    this.clientAuth = clientAuthRequired ? ClientAuth.REQUIRED : ClientAuth.NONE;
+    return this;
+  }
+
+  public ClientAuth getClientAuth() {
     return clientAuth;
   }
 
@@ -271,7 +292,7 @@ public class NetServerOptions extends TCPSSLOptions {
    *                   it won't mandate the certificate to be presented, basically make it optional.
    * @return a reference to this, so the API can be used fluently
    */
-  public NetServerOptions setClientAuth(SSLHelper.ClientAuth clientAuth) {
+  public NetServerOptions setClientAuth(ClientAuth clientAuth) {
     this.clientAuth = clientAuth;
     return this;
   }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -19,6 +19,7 @@ package io.vertx.core.net;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.impl.SSLHelper;
 
 /**
  * Options for configuring a {@link io.vertx.core.net.NetServer}.
@@ -45,15 +46,10 @@ public class NetServerOptions extends TCPSSLOptions {
    */
   public static final int DEFAULT_ACCEPT_BACKLOG = 1024;
 
-  /**
-   * Default value of whether client auth is required (SSL/TLS) = false
-   */
-  public static final boolean DEFAULT_CLIENT_AUTH_REQUIRED = false;
-
   private int port;
   private String host;
   private int acceptBacklog;
-  private boolean clientAuthRequired;
+  private SSLHelper.ClientAuth clientAuth = SSLHelper.ClientAuth.NONE;
 
   /**
    * Default constructor
@@ -73,7 +69,7 @@ public class NetServerOptions extends TCPSSLOptions {
     this.port = other.getPort();
     this.host = other.getHost();
     this.acceptBacklog = other.getAcceptBacklog();
-    this.clientAuthRequired = other.isClientAuthRequired();
+    this.clientAuth = other.getClientAuth();
   }
 
   /**
@@ -91,7 +87,6 @@ public class NetServerOptions extends TCPSSLOptions {
     this.port = DEFAULT_PORT;
     this.host = DEFAULT_HOST;
     this.acceptBacklog = DEFAULT_ACCEPT_BACKLOG;
-    this.clientAuthRequired = DEFAULT_CLIENT_AUTH_REQUIRED;
   }
 
   @Override
@@ -264,18 +259,20 @@ public class NetServerOptions extends TCPSSLOptions {
    *
    * @return true if client auth is required
    */
-  public boolean isClientAuthRequired() {
-    return clientAuthRequired;
+  public SSLHelper.ClientAuth getClientAuth() {
+    return clientAuth;
   }
 
   /**
    * Set whether client auth is required
    *
-   * @param clientAuthRequired  true if client auth is required
+   * @param clientAuth One of "NONE, REQUEST, REQUIRED". If it's set to "REQUIRED" then server will require the
+   *                   SSL cert to be presented otherwise it won't accept the request. If it's set to "REQUEST" then
+   *                   it won't mandate the certificate to be presented, basically make it optional.
    * @return a reference to this, so the API can be used fluently
    */
-  public NetServerOptions setClientAuthRequired(boolean clientAuthRequired) {
-    this.clientAuthRequired = clientAuthRequired;
+  public NetServerOptions setClientAuth(SSLHelper.ClientAuth clientAuth) {
+    this.clientAuth = clientAuth;
     return this;
   }
 
@@ -288,7 +285,7 @@ public class NetServerOptions extends TCPSSLOptions {
     NetServerOptions that = (NetServerOptions) o;
 
     if (acceptBacklog != that.acceptBacklog) return false;
-    if (clientAuthRequired != that.clientAuthRequired) return false;
+    if (clientAuth != that.clientAuth) return false;
     if (port != that.port) return false;
     if (host != null ? !host.equals(that.host) : that.host != null) return false;
 
@@ -301,7 +298,7 @@ public class NetServerOptions extends TCPSSLOptions {
     result = 31 * result + port;
     result = 31 * result + (host != null ? host.hashCode() : 0);
     result = 31 * result + acceptBacklog;
-    result = 31 * result + (clientAuthRequired ? 1 : 0);
+    result = 31 * result + clientAuth.hashCode();
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -86,7 +86,7 @@ public class SSLHelper {
     this.ssl = options.isSsl();
     this.keyStoreHelper = keyStoreHelper;
     this.trustStoreHelper = trustStoreHelper;
-    this.clientAuth = options.getClientAuth();
+    this.clientAuth = ClientAuth.valueOf(options.getClientAuth().name());
     this.crlPaths = options.getCrlPaths() != null ? new ArrayList<>(options.getCrlPaths()) : null;
     this.crlValues = options.getCrlValues() != null ? new ArrayList<>(options.getCrlValues()) : null;
     this.enabledCipherSuites = options.getEnabledCipherSuites();
@@ -106,7 +106,7 @@ public class SSLHelper {
     this.ssl = options.isSsl();
     this.keyStoreHelper = keyStoreHelper;
     this.trustStoreHelper = trustStoreHelper;
-    this.clientAuth = options.getClientAuth();
+    this.clientAuth = ClientAuth.valueOf(options.getClientAuth().name());
     this.crlPaths = options.getCrlPaths() != null ? new ArrayList<>(options.getCrlPaths()) : null;
     this.crlValues = options.getCrlValues() != null ? new ArrayList<>(options.getCrlValues()) : null;
     this.enabledCipherSuites = options.getEnabledCipherSuites();

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -19,6 +19,7 @@ package io.vertx.core.net.impl;
 import io.netty.handler.ssl.SslHandler;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.impl.VertxInternal;
@@ -86,7 +87,7 @@ public class SSLHelper {
     this.ssl = options.isSsl();
     this.keyStoreHelper = keyStoreHelper;
     this.trustStoreHelper = trustStoreHelper;
-    this.clientAuth = ClientAuth.valueOf(options.getClientAuth().name());
+    this.clientAuth = options.getClientAuth();
     this.crlPaths = options.getCrlPaths() != null ? new ArrayList<>(options.getCrlPaths()) : null;
     this.crlValues = options.getCrlValues() != null ? new ArrayList<>(options.getCrlValues()) : null;
     this.enabledCipherSuites = options.getEnabledCipherSuites();
@@ -106,14 +107,10 @@ public class SSLHelper {
     this.ssl = options.isSsl();
     this.keyStoreHelper = keyStoreHelper;
     this.trustStoreHelper = trustStoreHelper;
-    this.clientAuth = ClientAuth.valueOf(options.getClientAuth().name());
+    this.clientAuth = options.getClientAuth();
     this.crlPaths = options.getCrlPaths() != null ? new ArrayList<>(options.getCrlPaths()) : null;
     this.crlValues = options.getCrlValues() != null ? new ArrayList<>(options.getCrlValues()) : null;
     this.enabledCipherSuites = options.getEnabledCipherSuites();
-  }
-
-  public enum ClientAuth {
-    NONE, REQUEST, REQUIRED
   }
 
   public boolean isSSL() {

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -86,7 +86,7 @@ public class SSLHelper {
     this.ssl = options.isSsl();
     this.keyStoreHelper = keyStoreHelper;
     this.trustStoreHelper = trustStoreHelper;
-    this.clientAuth = options.isClientAuthRequired() ? ClientAuth.REQUIRED : ClientAuth.NONE;
+    this.clientAuth = options.getClientAuth();
     this.crlPaths = options.getCrlPaths() != null ? new ArrayList<>(options.getCrlPaths()) : null;
     this.crlValues = options.getCrlValues() != null ? new ArrayList<>(options.getCrlValues()) : null;
     this.enabledCipherSuites = options.getEnabledCipherSuites();
@@ -106,7 +106,7 @@ public class SSLHelper {
     this.ssl = options.isSsl();
     this.keyStoreHelper = keyStoreHelper;
     this.trustStoreHelper = trustStoreHelper;
-    this.clientAuth = options.isClientAuthRequired() ? ClientAuth.REQUIRED : ClientAuth.NONE;
+    this.clientAuth = options.getClientAuth();
     this.crlPaths = options.getCrlPaths() != null ? new ArrayList<>(options.getCrlPaths()) : null;
     this.crlValues = options.getCrlValues() != null ? new ArrayList<>(options.getCrlValues()) : null;
     this.enabledCipherSuites = options.getEnabledCipherSuites();

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -28,6 +28,7 @@ import io.vertx.core.impl.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
+import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.net.impl.SocketDefaults;
 import io.vertx.core.streams.Pump;
 import org.junit.Assume;
@@ -612,7 +613,7 @@ public class HttpTest extends HttpTestBase {
     assertEquals(def.getMaxWebsocketFrameSize(), json.getMaxWebsocketFrameSize());
     assertEquals(def.getWebsocketSubProtocols(), json.getWebsocketSubProtocols());
     assertEquals(def.isCompressionSupported(), json.isCompressionSupported());
-    assertEquals(def.isClientAuthRequired(), json.isClientAuthRequired());
+    assertEquals(def.getClientAuth(), json.getClientAuth());
     assertEquals(def.getCrlPaths(), json.getCrlPaths());
     assertEquals(def.getCrlValues(), json.getCrlValues());
     assertEquals(def.getAcceptBacklog(), json.getAcceptBacklog());
@@ -2992,7 +2993,7 @@ public class HttpTest extends HttpTestBase {
     setOptions(serverOptions, getServerTrustOptions(serverTrust));
     setOptions(serverOptions, getServerCertOptions(serverCert));
     if (requireClientAuth) {
-      serverOptions.setClientAuthRequired(true);
+      serverOptions.setClientAuth(SSLHelper.ClientAuth.REQUIRED);
     }
     if (serverUsesCrl) {
       serverOptions.addCrlPath(findFileOnClasspath("tls/ca/crl.pem"));

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -28,7 +28,6 @@ import io.vertx.core.impl.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
-import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.net.impl.SocketDefaults;
 import io.vertx.core.streams.Pump;
 import org.junit.Assume;
@@ -613,7 +612,7 @@ public class HttpTest extends HttpTestBase {
     assertEquals(def.getMaxWebsocketFrameSize(), json.getMaxWebsocketFrameSize());
     assertEquals(def.getWebsocketSubProtocols(), json.getWebsocketSubProtocols());
     assertEquals(def.isCompressionSupported(), json.isCompressionSupported());
-    assertEquals(def.getClientAuth(), json.getClientAuth());
+    assertEquals(def.isClientAuthRequired(), json.isClientAuthRequired());
     assertEquals(def.getCrlPaths(), json.getCrlPaths());
     assertEquals(def.getCrlValues(), json.getCrlValues());
     assertEquals(def.getAcceptBacklog(), json.getAcceptBacklog());
@@ -2993,7 +2992,7 @@ public class HttpTest extends HttpTestBase {
     setOptions(serverOptions, getServerTrustOptions(serverTrust));
     setOptions(serverOptions, getServerCertOptions(serverCert));
     if (requireClientAuth) {
-      serverOptions.setClientAuth(SSLHelper.ClientAuth.REQUIRED);
+      serverOptions.setClientAuth(ClientAuth.REQUIRED);
     }
     if (serverUsesCrl) {
       serverOptions.addCrlPath(findFileOnClasspath("tls/ca/crl.pem"));

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -24,6 +24,7 @@ import io.vertx.core.impl.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
+import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.net.impl.SocketDefaults;
 import org.junit.Assume;
@@ -531,13 +532,13 @@ public class NetTest extends VertxTestBase {
   public void testDefaultServerOptionsJson() {
     NetServerOptions def = new NetServerOptions();
     NetServerOptions json = new NetServerOptions(new JsonObject());
-    assertEquals(def.isClientAuthRequired(), json.isClientAuthRequired());
+    assertEquals(def.getClientAuth(), json.getClientAuth());
     assertEquals(def.getCrlPaths(), json.getCrlPaths());
     assertEquals(def.getCrlValues(), json.getCrlValues());
     assertEquals(def.getAcceptBacklog(), json.getAcceptBacklog());
     assertEquals(def.getPort(), json.getPort());
     assertEquals(def.getHost(), json.getHost());
-    assertEquals(def.isClientAuthRequired(), json.isClientAuthRequired());
+    assertEquals(def.getClientAuth(), json.getClientAuth());
     assertEquals(def.getCrlPaths(), json.getCrlPaths());
     assertEquals(def.getCrlValues(), json.getCrlValues());
     assertEquals(def.getAcceptBacklog(), json.getAcceptBacklog());
@@ -1086,7 +1087,7 @@ public class NetTest extends VertxTestBase {
       options.setKeyStoreOptions(new JksOptions().setPath(findFileOnClasspath("tls/server-keystore.jks")).setPassword("wibble"));
     }
     if (requireClientAuth) {
-      options.setClientAuthRequired(true);
+      options.setClientAuth(SSLHelper.ClientAuth.REQUIRED);
     }
     for (String suite: enabledCipherSuites) {
       options.addEnabledCipherSuite(suite);

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -20,11 +20,11 @@ import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.impl.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
-import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.net.impl.SocketDefaults;
 import org.junit.Assume;
@@ -532,13 +532,13 @@ public class NetTest extends VertxTestBase {
   public void testDefaultServerOptionsJson() {
     NetServerOptions def = new NetServerOptions();
     NetServerOptions json = new NetServerOptions(new JsonObject());
-    assertEquals(def.getClientAuth(), json.getClientAuth());
+    assertEquals(def.isClientAuthRequired(), json.isClientAuthRequired());
     assertEquals(def.getCrlPaths(), json.getCrlPaths());
     assertEquals(def.getCrlValues(), json.getCrlValues());
     assertEquals(def.getAcceptBacklog(), json.getAcceptBacklog());
     assertEquals(def.getPort(), json.getPort());
     assertEquals(def.getHost(), json.getHost());
-    assertEquals(def.getClientAuth(), json.getClientAuth());
+    assertEquals(def.isClientAuthRequired(), json.isClientAuthRequired());
     assertEquals(def.getCrlPaths(), json.getCrlPaths());
     assertEquals(def.getCrlValues(), json.getCrlValues());
     assertEquals(def.getAcceptBacklog(), json.getAcceptBacklog());
@@ -1087,7 +1087,7 @@ public class NetTest extends VertxTestBase {
       options.setKeyStoreOptions(new JksOptions().setPath(findFileOnClasspath("tls/server-keystore.jks")).setPassword("wibble"));
     }
     if (requireClientAuth) {
-      options.setClientAuth(SSLHelper.ClientAuth.REQUIRED);
+      options.setClientAuth(ClientAuth.REQUIRED);
     }
     for (String suite: enabledCipherSuites) {
       options.addEnabledCipherSuite(suite);

--- a/src/test/java/io/vertx/test/core/WebsocketTest.java
+++ b/src/test/java/io/vertx/test/core/WebsocketTest.java
@@ -37,6 +37,7 @@ import io.vertx.core.http.WebSocketStream;
 import io.vertx.core.http.WebsocketVersion;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.streams.ReadStream;
 import org.junit.Test;
 
@@ -342,7 +343,7 @@ public class WebsocketTest extends VertxTestBase {
     setOptions(serverOptions, getServerTrustOptions(serverTrust));
     setOptions(serverOptions, getServerCertOptions(serverCert));
     if (requireClientAuth) {
-      serverOptions.setClientAuthRequired(true);
+      serverOptions.setClientAuth(SSLHelper.ClientAuth.REQUIRED);
     }
     if (serverUsesCrl) {
       serverOptions.addCrlPath(findFileOnClasspath("tls/ca/crl.pem"));

--- a/src/test/java/io/vertx/test/core/WebsocketTest.java
+++ b/src/test/java/io/vertx/test/core/WebsocketTest.java
@@ -23,21 +23,9 @@ import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.ServerWebSocket;
-import io.vertx.core.http.ServerWebSocketStream;
-import io.vertx.core.http.WebSocketBase;
-import io.vertx.core.http.WebSocketFrame;
-import io.vertx.core.http.WebSocketStream;
-import io.vertx.core.http.WebsocketVersion;
+import io.vertx.core.http.*;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.streams.ReadStream;
 import org.junit.Test;
 
@@ -343,7 +331,7 @@ public class WebsocketTest extends VertxTestBase {
     setOptions(serverOptions, getServerTrustOptions(serverTrust));
     setOptions(serverOptions, getServerCertOptions(serverCert));
     if (requireClientAuth) {
-      serverOptions.setClientAuth(SSLHelper.ClientAuth.REQUIRED);
+      serverOptions.setClientAuth(ClientAuth.REQUIRED);
     }
     if (serverUsesCrl) {
       serverOptions.addCrlPath(findFileOnClasspath("tls/ca/crl.pem"));


### PR DESCRIPTION
Signed-off-by: Manish Kumar <manishk@vmware.com>

Right now Vertx API(3.0.0) expose a boolean variable in HttpServerOptions to set the Client Auth, which in turn allows the certificate based auth. This doesn't allow to set the value to one of these NONE, REQUEST, REQUIRED, which would allow HTTP Server to make Client Auth as Optional.

I have done the necessary changes to set the enum value in HttpServerOptions. I have tested it and all works fine.

Please see more details here - https://groups.google.com/forum/#!topic/vertx/YtojWw0a0bU