### PR TITLE
Launcher process redeploy

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1016,6 +1016,57 @@ The `start`, `stop` and `list` command are also available from the `vertx` tool.
 
 The set of commands is extensible, refer to the <<Extending the vert.x Launcher>> section.
 
+=== Live Redeploy
+
+When developing it may be convenient to automatically redeploy your application upon file changes. The `vertx`
+command line tool and more generally the `link:../../apidocs/io/vertx/core/Launcher.html[Launcher]` class offers this feature. Here are some
+examples:
+
+[source]
+----
+vertx run MyVerticle.groovy --redeploy="**/*.groovy"
+vertx run MyVerticle.groovy --redeploy="**/*.groovy,**/*.rb"
+java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**/*.class" -cp ...
+----
+
+The redeployment process is implemented as follows. First your application is launched as a background application
+(with the `start` command). On matching file changes, the process is stopped and the application is restarted.
+This way avoids leaks.
+
+To enable the live redeploy, pass the `--redeploy` option to the `run` command. The `--redeploy` indicates the
+set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and `?`). You can specify
+several sets by separating them using a comma (`,`). Patterns are relative to the current working directory.
+
+Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
+configured using `--java-opts`.
+
+The redeploy feature can be used in your IDE:
+
+* Eclipse - create a _Run_ configuration, using the `io.vertx.core.Launcher` class a _main class_. In the _Program
+arguments_ area (in the _Arguments_ tab), write `run your-verticle-fully-qualified-name --redeploy=\**/*.java`.
+You can also add other parameters. The redeployment works smoothly as Eclipse incrementally compiles your files on
+save.
+* IntelliJ - create a _Run_ configuration (_Application_), set the _Main class_ to `io.vertx.core.Launcher`. In
+the Program arguments write: `run your-verticle-fully-qualified-name --redeploy=\**/*.class
+--launcher-class=io.vertx.core.Launcher`. As you can see, you need to set the `launcher-class` parameter because
+IntelliJ wraps your main class in its own class. To trigger the redeployment, you need to _make_ the project or
+the module explicitly (_Build_ menu -> _Make project_).
+
+To debug your application, create your run configuration as a remote application and configure the debugger
+using `--java-opts`. However, don’t forget to re-plug the debugger after every redeployment as a new process is
+created every time.
+
+You can also hook your build process in the redeploy cycle:
+
+[source]
+----
+java –jar target/my-fat-jar.jar –redeploy="**/*.java" --on-redeploy="mvn package"
+----
+
+The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
+restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
+or `grunt` to update your resources.
+
 == Cluster Managers
 
 In Vert.x a cluster manager is used for various functions including:

--- a/src/main/java/io/vertx/core/cli/Argument.java
+++ b/src/main/java/io/vertx/core/cli/Argument.java
@@ -112,7 +112,7 @@ public class Argument {
   }
 
   /**
-   * @return the arg name, {@link null} if not defined.
+   * @return the arg name, {@code null} if not defined.
    */
   public String getArgName() {
     return argName;
@@ -121,7 +121,7 @@ public class Argument {
   /**
    * Sets the argument name of this {@link Argument}.
    *
-   * @param argName the argument name, must not be {@link null}
+   * @param argName the argument name, must not be {@code null}
    * @return the current {@link Argument} instance
    */
   public Argument setArgName(String argName) {
@@ -131,7 +131,7 @@ public class Argument {
   }
 
   /**
-   * @return the description, {@link null} if not defined.
+   * @return the description, {@code null} if not defined.
    */
   public String getDescription() {
     return description;
@@ -207,7 +207,7 @@ public class Argument {
   }
 
   /**
-   * @return the argument default value, {@link null} if not specified.
+   * @return the argument default value, {@code null} if not specified.
    */
   public String getDefaultValue() {
     return defaultValue;

--- a/src/main/java/io/vertx/core/cli/CLI.java
+++ b/src/main/java/io/vertx/core/cli/CLI.java
@@ -49,7 +49,7 @@ public interface CLI {
   /**
    * Creates an instance of {@link CLI} using the default implementation.
    *
-   * @param name the name of the CLI (must not be {@link null})
+   * @param name the name of the CLI (must not be {@code null})
    * @return the created instance of {@link CLI}
    */
   static CLI create(String name) {
@@ -148,7 +148,7 @@ public interface CLI {
   /**
    * Adds an option.
    *
-   * @param option the option, must not be {@link null}.
+   * @param option the option, must not be {@code null}.
    * @return the current {@link CLI} instance
    */
   @Fluent
@@ -158,7 +158,7 @@ public interface CLI {
    * Adds a set of options. Unlike {@link #setOptions(List)}}, this method does not remove the existing options.
    * The given list is appended to the existing list.
    *
-   * @param options the options, must not be {@link null}
+   * @param options the options, must not be {@code null}
    * @return the current {@link CLI} instance
    */
   @Fluent
@@ -167,7 +167,7 @@ public interface CLI {
   /**
    * Sets the list of arguments.
    *
-   * @param options the list of options, must not be {@link null}
+   * @param options the list of options, must not be {@code null}
    * @return the current {@link CLI} instance
    */
   @Fluent
@@ -183,7 +183,7 @@ public interface CLI {
   /**
    * Adds an argument.
    *
-   * @param arg the argument, must not be {@link null}
+   * @param arg the argument, must not be {@code null}
    * @return the current {@link CLI} instance
    */
   @Fluent
@@ -193,7 +193,7 @@ public interface CLI {
    * Adds a set of arguments. Unlike {@link #setArguments(List)}, this method does not remove the existing arguments.
    * The given list is appended to the existing list.
    *
-   * @param args the arguments, must not be {@link null}
+   * @param args the arguments, must not be {@code null}
    * @return the current {@link CLI} instance
    */
   @Fluent
@@ -202,7 +202,7 @@ public interface CLI {
   /**
    * Sets the list of arguments.
    *
-   * @param args the list of arguments, must not be {@link null}
+   * @param args the list of arguments, must not be {@code null}
    * @return the current {@link CLI} instance
    */
   @Fluent
@@ -211,16 +211,16 @@ public interface CLI {
   /**
    * Gets an {@link Option} based on its name (short name, long name or argument name).
    *
-   * @param name the name, must not be {@link null}
-   * @return the {@link Option}, {@link null} if not found
+   * @param name the name, must not be {@code null}
+   * @return the {@link Option}, {@code null} if not found
    */
   Option getOption(String name);
 
   /**
    * Gets an {@link Argument} based on its name (argument name).
    *
-   * @param name the name of the argument, must not be {@link null}
-   * @return the {@link Argument}, {@link null} if not found.
+   * @param name the name of the argument, must not be {@code null}
+   * @return the {@link Argument}, {@code null} if not found.
    */
   Argument getArgument(String name);
 
@@ -228,7 +228,7 @@ public interface CLI {
    * Gets an {@link Argument} based on its index.
    *
    * @param index the index, must be positive or zero.
-   * @return the {@link Argument}, {@link null} if not found.
+   * @return the {@link Argument}, {@code null} if not found.
    */
   Argument getArgument(int index);
 

--- a/src/main/java/io/vertx/core/cli/CommandLine.java
+++ b/src/main/java/io/vertx/core/cli/CommandLine.java
@@ -121,7 +121,7 @@ public interface CommandLine {
    * Gets the raw value of the given option. Raw values are the values as given in the user command line.
    *
    * @param option the option
-   * @return the value, {@link null} if none.
+   * @return the value, {@code null} if none.
    */
   String getRawValueForOption(Option option);
 
@@ -137,7 +137,7 @@ public interface CommandLine {
    * Gets the raw value of the given argument. Raw values are the values as given in the user command line.
    *
    * @param arg the argument
-   * @return the value, {@link null} if none.
+   * @return the value, {@code null} if none.
    */
   String getRawValueForArgument(Argument arg);
 

--- a/src/main/java/io/vertx/core/cli/InvalidValueException.java
+++ b/src/main/java/io/vertx/core/cli/InvalidValueException.java
@@ -69,7 +69,7 @@ public class InvalidValueException extends CLIException {
   }
 
   /**
-   * @return the option, may be {@link null} if the exception is about an argument.
+   * @return the option, may be {@code null} if the exception is about an argument.
    */
   public Option getOption() {
     return option;
@@ -83,7 +83,7 @@ public class InvalidValueException extends CLIException {
   }
 
   /**
-   * @return the argument, may be {@link null} if the exception is about an option.
+   * @return the argument, may be {@code null} if the exception is about an option.
    */
   public Argument getArgument() {
     return argument;

--- a/src/main/java/io/vertx/core/cli/MissingValueException.java
+++ b/src/main/java/io/vertx/core/cli/MissingValueException.java
@@ -51,14 +51,14 @@ public class MissingValueException extends CLIException {
   }
 
   /**
-   * @return the option, may be {@link null} if the exception is about an argument.
+   * @return the option, may be {@code null} if the exception is about an argument.
    */
   public Option getOption() {
     return option;
   }
 
   /**
-   * @return the argument, may be {@link null} if the exception is about an option.
+   * @return the argument, may be {@code null} if the exception is about an option.
    */
   public Argument getArgument() {
     return argument;

--- a/src/main/java/io/vertx/core/cli/Option.java
+++ b/src/main/java/io/vertx/core/cli/Option.java
@@ -225,7 +225,7 @@ public class Option {
   /**
    * Sets te arg name for this option.
    *
-   * @param argName the arg name, must not be {@link null}
+   * @param argName the arg name, must not be {@code null}
    * @return the current {@link Option} instance
    */
   public Option setArgName(String argName) {

--- a/src/main/java/io/vertx/core/cli/TypedArgument.java
+++ b/src/main/java/io/vertx/core/cli/TypedArgument.java
@@ -55,7 +55,7 @@ public class TypedArgument<T> extends Argument {
   }
 
   /**
-   * @return the argument type, cannot be {@link null} for valid argument.
+   * @return the argument type, cannot be {@code null} for valid argument.
    */
   public Class<T> getType() {
     return type;

--- a/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
@@ -268,6 +268,13 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
   }
 
   protected String getCommandLinePrefix() {
+    // Check whether `vertx.cli.usage.prefix` is set, if so use it. This system property let scripts configure the value
+    // displayed by the usage, even if they are calling java.
+    String sysProp = System.getProperty("vertx.cli.usage.prefix");
+    if (sysProp != null) {
+      return sysProp;
+    }
+
     String jar = CommandLineUtils.getJar();
     if (jar != null) {
       return "java -jar " + jar;

--- a/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
@@ -1,0 +1,376 @@
+/*
+ *  Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl.launcher.commands;
+
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * Utility methods to test path matching. This is used by the {@link Watcher} to determeine whether or not a file
+ * triggers a redeployment.
+ *
+ * @author Clement Escoffier <clement@apache.org>
+ */
+public final class FileSelector {
+
+  /**
+   * When the pattern starts with a {@link File#separator}, {@code str} has to start with a {@link File#separator}.
+   *
+   * @return {@code true} when @{code str} starts with a {@link File#separator}, and {@code pattern} starts with a
+   * {@link File#separator}.
+   */
+  private static boolean separatorPatternStartSlashMismatch(String pattern, String str, String separator) {
+    return str.startsWith(separator) != pattern.startsWith(separator);
+  }
+
+  /**
+   * Tests whether or not a given path matches a given pattern.
+   *
+   * @param pattern The pattern to match against. Must not be
+   *                {@code null}.
+   * @param str     The path to match, as a String. Must not be
+   *                {@code null}.
+   * @return {@code true} if the pattern matches against the string,
+   * or {@code false} otherwise.
+   */
+  public static boolean matchPath(String pattern, String str) {
+    return matchPath(pattern, str, true);
+  }
+
+  /**
+   * Tests whether or not a given path matches a given pattern.
+   *
+   * @param pattern         The pattern to match against. Must not be
+   *                        {@code null}.
+   * @param str             The path to match, as a String. Must not be
+   *                        {@code null}.
+   * @param isCaseSensitive Whether or not matching should be performed
+   *                        case sensitively.
+   * @return {@code true} if the pattern matches against the string,
+   * or {@code false} otherwise.
+   */
+  public static boolean matchPath(String pattern, String str, boolean isCaseSensitive) {
+    return matchPath(pattern, str, File.separator, isCaseSensitive);
+  }
+
+  protected static boolean matchPath(String pattern, String str, String separator, boolean isCaseSensitive) {
+    return matchPathPattern(pattern, str, separator, isCaseSensitive);
+  }
+
+  private static boolean matchPathPattern(String pattern, String str, String separator, boolean isCaseSensitive) {
+    if (separatorPatternStartSlashMismatch(pattern, str, separator)) {
+      return false;
+    }
+    String[] patDirs = tokenizePathToString(pattern, separator);
+    String[] strDirs = tokenizePathToString(str, separator);
+    return matchPathPattern(patDirs, strDirs, isCaseSensitive);
+
+  }
+
+  private static boolean matchPathPattern(String[] patDirs, String[] strDirs, boolean isCaseSensitive) {
+    int patIdxStart = 0;
+    int patIdxEnd = patDirs.length - 1;
+    int strIdxStart = 0;
+    int strIdxEnd = strDirs.length - 1;
+
+    // up to first '**'
+    while (patIdxStart <= patIdxEnd && strIdxStart <= strIdxEnd) {
+      String patDir = patDirs[patIdxStart];
+      if (patDir.equals("**")) {
+        break;
+      }
+      if (!match(patDir, strDirs[strIdxStart], isCaseSensitive)) {
+        return false;
+      }
+      patIdxStart++;
+      strIdxStart++;
+    }
+    if (strIdxStart > strIdxEnd) {
+      // String is exhausted
+      for (int i = patIdxStart; i <= patIdxEnd; i++) {
+        if (!patDirs[i].equals("**")) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      if (patIdxStart > patIdxEnd) {
+        // String not exhausted, but pattern is. Failure.
+        return false;
+      }
+    }
+
+    // up to last '**'
+    while (patIdxStart <= patIdxEnd && strIdxStart <= strIdxEnd) {
+      String patDir = patDirs[patIdxEnd];
+      if (patDir.equals("**")) {
+        break;
+      }
+      if (!match(patDir, strDirs[strIdxEnd], isCaseSensitive)) {
+        return false;
+      }
+      patIdxEnd--;
+      strIdxEnd--;
+    }
+    if (strIdxStart > strIdxEnd) {
+      // String is exhausted
+      for (int i = patIdxStart; i <= patIdxEnd; i++) {
+        if (!patDirs[i].equals("**")) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    while (patIdxStart != patIdxEnd && strIdxStart <= strIdxEnd) {
+      int patIdxTmp = -1;
+      for (int i = patIdxStart + 1; i <= patIdxEnd; i++) {
+        if (patDirs[i].equals("**")) {
+          patIdxTmp = i;
+          break;
+        }
+      }
+      if (patIdxTmp == patIdxStart + 1) {
+        // '**/**' situation, so skip one
+        patIdxStart++;
+        continue;
+      }
+      // Find the pattern between padIdxStart & padIdxTmp in str between
+      // strIdxStart & strIdxEnd
+      int patLength = (patIdxTmp - patIdxStart - 1);
+      int strLength = (strIdxEnd - strIdxStart + 1);
+      int foundIdx = -1;
+      strLoop:
+      for (int i = 0; i <= strLength - patLength; i++) {
+        for (int j = 0; j < patLength; j++) {
+          String subPat = patDirs[patIdxStart + j + 1];
+          String subStr = strDirs[strIdxStart + i + j];
+          if (!match(subPat, subStr, isCaseSensitive)) {
+            continue strLoop;
+          }
+        }
+
+        foundIdx = strIdxStart + i;
+        break;
+      }
+
+      if (foundIdx == -1) {
+        return false;
+      }
+
+      patIdxStart = patIdxTmp;
+      strIdxStart = foundIdx + patLength;
+    }
+
+    for (int i = patIdxStart; i <= patIdxEnd; i++) {
+      if (!patDirs[i].equals("**")) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Tests whether or not a string matches against a pattern.
+   * The pattern may contain two special characters:<br>
+   * '*' means zero or more characters<br>
+   * '?' means one and only one character
+   *
+   * @param pattern The pattern to match against.
+   *                Must not be{@code null}.
+   * @param str     The string which must be matched against the pattern.
+   *                Must not be{@code null}.
+   * @return {@code true} if the string matches against the pattern,
+   * or {@code false} otherwise.
+   */
+  public static boolean match(String pattern, String str) {
+    return match(pattern, str, true);
+  }
+
+  /**
+   * Tests whether or not a string matches against a pattern.
+   * The pattern may contain two special characters:<br>
+   * '*' means zero or more characters<br>
+   * '?' means one and only one character
+   *
+   * @param pattern         The pattern to match against.
+   *                        Must not be{@code null}.
+   * @param str             The string which must be matched against the pattern.
+   *                        Must not be{@code null}.
+   * @param isCaseSensitive Whether or not matching should be performed
+   *                        case sensitively.
+   * @return {@code true} if the string matches against the pattern,
+   * or {@code false} otherwise.
+   */
+  public static boolean match(String pattern, String str, boolean isCaseSensitive) {
+    char[] patArr = pattern.toCharArray();
+    char[] strArr = str.toCharArray();
+    return match(patArr, strArr, isCaseSensitive);
+  }
+
+  private static boolean match(char[] patArr, char[] strArr, boolean isCaseSensitive) {
+    int patIdxStart = 0;
+    int patIdxEnd = patArr.length - 1;
+    int strIdxStart = 0;
+    int strIdxEnd = strArr.length - 1;
+    char ch;
+
+    boolean containsStar = false;
+    for (char aPatArr : patArr) {
+      if (aPatArr == '*') {
+        containsStar = true;
+        break;
+      }
+    }
+
+    if (!containsStar) {
+      // No '*'s, so we make a shortcut
+      if (patIdxEnd != strIdxEnd) {
+        return false; // Pattern and string do not have the same size
+      }
+      for (int i = 0; i <= patIdxEnd; i++) {
+        ch = patArr[i];
+        if (ch != '?' && !equals(ch, strArr[i], isCaseSensitive)) {
+          return false; // Character mismatch
+        }
+      }
+      return true; // String matches against pattern
+    }
+
+    if (patIdxEnd == 0) {
+      return true; // Pattern contains only '*', which matches anything
+    }
+
+    // Process characters before first star
+    while ((ch = patArr[patIdxStart]) != '*' && strIdxStart <= strIdxEnd) {
+      if (ch != '?' && !equals(ch, strArr[strIdxStart], isCaseSensitive)) {
+        return false; // Character mismatch
+      }
+      patIdxStart++;
+      strIdxStart++;
+    }
+    if (strIdxStart > strIdxEnd) {
+      // All characters in the string are used. Check if only '*'s are
+      // left in the pattern. If so, we succeeded. Otherwise failure.
+      for (int i = patIdxStart; i <= patIdxEnd; i++) {
+        if (patArr[i] != '*') {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    // Process characters after last star
+    while ((ch = patArr[patIdxEnd]) != '*' && strIdxStart <= strIdxEnd) {
+      if (ch != '?' && !equals(ch, strArr[strIdxEnd], isCaseSensitive)) {
+        return false; // Character mismatch
+      }
+      patIdxEnd--;
+      strIdxEnd--;
+    }
+    if (strIdxStart > strIdxEnd) {
+      // All characters in the string are used. Check if only '*'s are
+      // left in the pattern. If so, we succeeded. Otherwise failure.
+      for (int i = patIdxStart; i <= patIdxEnd; i++) {
+        if (patArr[i] != '*') {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    // process pattern between stars. padIdxStart and patIdxEnd point
+    // always to a '*'.
+    while (patIdxStart != patIdxEnd && strIdxStart <= strIdxEnd) {
+      int patIdxTmp = -1;
+      for (int i = patIdxStart + 1; i <= patIdxEnd; i++) {
+        if (patArr[i] == '*') {
+          patIdxTmp = i;
+          break;
+        }
+      }
+      if (patIdxTmp == patIdxStart + 1) {
+        // Two stars next to each other, skip the first one.
+        patIdxStart++;
+        continue;
+      }
+      // Find the pattern between padIdxStart & padIdxTmp in str between
+      // strIdxStart & strIdxEnd
+      int patLength = (patIdxTmp - patIdxStart - 1);
+      int strLength = (strIdxEnd - strIdxStart + 1);
+      int foundIdx = -1;
+      strLoop:
+      for (int i = 0; i <= strLength - patLength; i++) {
+        for (int j = 0; j < patLength; j++) {
+          ch = patArr[patIdxStart + j + 1];
+          if (ch != '?' && !equals(ch, strArr[strIdxStart + i + j], isCaseSensitive)) {
+            continue strLoop;
+          }
+        }
+
+        foundIdx = strIdxStart + i;
+        break;
+      }
+
+      if (foundIdx == -1) {
+        return false;
+      }
+
+      patIdxStart = patIdxTmp;
+      strIdxStart = foundIdx + patLength;
+    }
+
+    // All characters in the string are used. Check if only '*'s are left
+    // in the pattern. If so, we succeeded. Otherwise failure.
+    for (int i = patIdxStart; i <= patIdxEnd; i++) {
+      if (patArr[i] != '*') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Tests whether two characters are equal.
+   */
+  private static boolean equals(char c1, char c2, boolean isCaseSensitive) {
+    if (c1 == c2) {
+      return true;
+    }
+    if (!isCaseSensitive) {
+      // NOTE: Try both upper case and lower case as done by String.equalsIgnoreCase()
+      if (Character.toUpperCase(c1) == Character.toUpperCase(c2)
+          || Character.toLowerCase(c1) == Character.toLowerCase(c2)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String[] tokenizePathToString(String path, String separator) {
+    List<String> ret = new ArrayList<>();
+    StringTokenizer st = new StringTokenizer(path, separator);
+    while (st.hasMoreTokens()) {
+      ret.add(st.nextToken());
+    }
+    return ret.toArray(new String[ret.size()]);
+  }
+}

--- a/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/FileSelector.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 /**
- * Utility methods to test path matching. This is used by the {@link Watcher} to determeine whether or not a file
+ * Utility methods to test path matching. This is used by the {@link Watcher} to determine whether or not a file
  * triggers a redeployment.
  *
  * @author Clement Escoffier <clement@apache.org>
@@ -268,14 +268,7 @@ public final class FileSelector {
       strIdxStart++;
     }
     if (strIdxStart > strIdxEnd) {
-      // All characters in the string are used. Check if only '*'s are
-      // left in the pattern. If so, we succeeded. Otherwise failure.
-      for (int i = patIdxStart; i <= patIdxEnd; i++) {
-        if (patArr[i] != '*') {
-          return false;
-        }
-      }
-      return true;
+      return checkOnlyStartsLeft(patArr, patIdxStart, patIdxEnd);
     }
 
     // Process characters after last star
@@ -289,12 +282,7 @@ public final class FileSelector {
     if (strIdxStart > strIdxEnd) {
       // All characters in the string are used. Check if only '*'s are
       // left in the pattern. If so, we succeeded. Otherwise failure.
-      for (int i = patIdxStart; i <= patIdxEnd; i++) {
-        if (patArr[i] != '*') {
-          return false;
-        }
-      }
-      return true;
+      return checkOnlyStartsLeft(patArr, patIdxStart, patIdxEnd);
     }
 
     // process pattern between stars. padIdxStart and patIdxEnd point
@@ -340,6 +328,12 @@ public final class FileSelector {
 
     // All characters in the string are used. Check if only '*'s are left
     // in the pattern. If so, we succeeded. Otherwise failure.
+    return checkOnlyStartsLeft(patArr, patIdxStart, patIdxEnd);
+  }
+
+  private static boolean checkOnlyStartsLeft(char[] patArr, int patIdxStart, int patIdxEnd) {
+    // All characters in the string are used. Check if only '*'s are
+    // left in the pattern. If so, we succeeded. Otherwise failure.
     for (int i = patIdxStart; i <= patIdxEnd; i++) {
       if (patArr[i] != '*') {
         return false;

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -214,7 +214,7 @@ public class RunCommand extends BareCommand {
     watcher.watch();
   }
 
-  private void stopBackgroundApplication(Handler<Void> onCompletion) {
+  protected void stopBackgroundApplication(Handler<Void> onCompletion) {
     executionContext.execute("stop", vertxApplicationBackgroundId);
     if (onCompletion != null) {
       onCompletion.handle(null);

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -224,7 +224,9 @@ public class RunCommand extends BareCommand {
   protected void startAsBackgroundApplication(Handler<Void> onCompletion) {
     // We need to copy all options and arguments.
     List<String> args = new ArrayList<>();
-    args.add("--vertx.id=" + vertxApplicationBackgroundId);
+    // Pre-prend the command.
+    args.add("run");
+    args.add("--vertx-id=" + vertxApplicationBackgroundId);
     args.addAll(executionContext.commandLine().allArguments());
     // No need to add the main-verticle as it's part of the allArguments list.
     if (cluster) {

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StartCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StartCommand.java
@@ -90,7 +90,6 @@ public class StartCommand extends DefaultCommand {
     this.redirect = redirect;
   }
 
-
   /**
    * Starts the application in background.
    */
@@ -112,6 +111,7 @@ public class StartCommand extends DefaultCommand {
     } else {
       // probably a `vertx` command line usage, or in IDE.
       ExecUtils.addArgument(cmd, CommandLineUtils.getFirstSegmentOfCommand());
+      ExecUtils.addArgument(cmd, "run");
     }
 
     getArguments().stream().forEach(arg -> ExecUtils.addArgument(cmd, arg));

--- a/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
@@ -1,0 +1,303 @@
+/*
+ *  Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl.launcher.commands;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+
+/**
+ * A file alteration monitor based on a {@link WatchService} and watching files matching a set of includes patterns.
+ * These patterns are Ant patterns (can use {@literal **, * or ?}). This class takes 2 {@link Handler} as parameter
+ * and orchestrate the redeployment method when a matching file is modified (created, updated or deleted). Users have
+ * the possibility to execute a shell command during the redeployment. On a file change, the {@code undeploy}
+ * {@link Handler} is called, followed by the execution of the user command. Then the {@code deploy} {@link Handler}
+ * is invoked.
+ * <p/>
+ * The watcher watches all files from the current directory and sub-directories.
+ *
+ * @author Clement Escoffier <clement@apache.org>
+ */
+public class Watcher implements Runnable {
+
+  protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+  private final List<String> includes;
+  private final File root;
+  private final Handler<Handler<Void>> deploy;
+  private final Handler<Handler<Void>> undeploy;
+  private final String cmd;
+
+  private WatchService service;
+  private volatile boolean closed;
+
+  private Map<WatchKey, File> keyToFile = new HashMap<>();
+
+  /**
+   * Creates a new {@link Watcher}.
+   *
+   * @param root              the root directory
+   * @param includes          the list of include patterns, should not be {@code null} or empty
+   * @param deploy            the function called when deployment is required
+   * @param undeploy          the function called when un-deployment is required
+   * @param onRedeployCommand an optional command executed after the un-deployment and before the deployment
+   */
+  public Watcher(File root, List<String> includes, Handler<Handler<Void>> deploy, Handler<Handler<Void>> undeploy,
+                 String onRedeployCommand) {
+    this.root = root;
+    this.includes = includes;
+    this.deploy = deploy;
+    this.undeploy = undeploy;
+    this.cmd = onRedeployCommand;
+  }
+
+  /**
+   * Checks whether the given file matches one of the {@link #includes} patterns.
+   *
+   * @param file the file
+   * @return {@code true} if the file matches at least one pattern, {@code false} otherwise.
+   */
+  protected boolean match(File file) {
+    // Compute relative path.
+    if (!file.getAbsolutePath().startsWith(root.getAbsolutePath())) {
+      return false;
+    }
+    String rel = file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1);
+    for (String include : includes) {
+      if (FileSelector.matchPath(include, rel)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Starts watching. The watch processing is made in another thread started in this method.
+   *
+   * @return the current watcher.
+   */
+  public Watcher watch() {
+    try {
+      service = FileSystems.getDefault().newWatchService();
+    } catch (IOException e) {
+      log.error("Cannot initialize the watcher", e);
+      return this;
+    }
+
+    try {
+      registerAll(root.toPath());
+    } catch (IOException e) {
+      log.error("Cannot register current directory into the watcher service", e);
+      return this;
+    }
+
+    new Thread(this).start();
+    log.info("Starting the vert.x application in redeploy mode");
+    deploy.handle(null);
+
+    return this;
+  }
+
+  /**
+   * Stops watching. This method stops the underlying {@link WatchService}.
+   */
+  public void close() {
+    log.info("Stopping redeployment");
+    closed = true;
+    if (service != null) {
+      try {
+        service.close();
+      } catch (IOException e) {
+        log.error("Cannot stop the watcher service", e);
+      }
+    }
+    // Un-deploy application on close.
+    undeploy.handle(null);
+  }
+
+  /**
+   * The watching thread runnable method.
+   */
+  @Override
+  public void run() {
+    try {
+      while (!closed) {
+        WatchKey key;
+        try {
+          key = service.poll(10, TimeUnit.MILLISECONDS);
+        } catch (ClosedWatchServiceException | InterruptedException e) {
+          // Closing the watch mode.
+          return;
+        }
+        if (key != null) {
+          for (WatchEvent<?> event : key.pollEvents()) {
+            // get event type
+            WatchEvent.Kind<?> kind = event.kind();
+
+            // get file object
+            @SuppressWarnings("unchecked")
+            WatchEvent<Path> ev = (WatchEvent<Path>) event;
+            Path fileName = ev.context();
+            File theFile = new File(keyToFile.get(key), fileName.toFile().getName());
+
+            if (kind == ENTRY_CREATE) {
+              if (theFile.isDirectory()) {
+                // A new directory is created, the WatchService is not very nice with this, we need to register it.
+                try {
+                  final WatchKey newKey = register(theFile.toPath());
+                  keyToFile.put(newKey, theFile);
+                } catch (IOException e) {
+                  log.error("Cannot register directory " + theFile.getAbsolutePath());
+                }
+              } else {
+                if (match(theFile)) {
+                  trigger(theFile);
+                }
+              }
+            } else if (kind == ENTRY_DELETE) {
+              if (theFile.isDirectory()) {
+                // If it is a directory, check whether or not it was registered, if it does, unregister it.
+                // Notice that it does not trigger events for deleted sub-files files.
+                removeDirectory(theFile);
+              } else {
+                if (match(theFile)) {
+                  trigger(theFile);
+                }
+              }
+            } else if (kind == ENTRY_MODIFY) {
+              if (!theFile.isDirectory()) {
+                if (match(theFile)) {
+                  trigger(theFile);
+                }
+              }
+            }
+          }
+          // IMPORTANT: The key must be reset after processed
+          key.reset();
+        }
+      }
+    } catch (Throwable e) {
+      log.error("An error have been encountered while watching resources - leaving the redeploy mode", e);
+    }
+  }
+
+  /**
+   * Redeployment process.
+   *
+   * @param theFile the file having triggered the redeployment.
+   */
+  private void trigger(File theFile) {
+    log.info("Trigger redeploy after a change of " + theFile.getAbsolutePath());
+    // 1)
+    undeploy.handle(v1 -> {
+      // 2)
+      executeUserCommand(v2 -> {
+        // 3)
+        deploy.handle(v3 -> log.info("Redeployment done"));
+      });
+    });
+
+
+  }
+
+  private void executeUserCommand(Handler<Void> onCompletion) {
+    if (cmd != null) {
+      try {
+        List<String> command = new ArrayList<>();
+        if (ExecUtils.isWindows()) {
+          ExecUtils.addArgument(command, cmd);
+        } else {
+          ExecUtils.addArgument(command, "sh");
+          ExecUtils.addArgument(command, "-c");
+          ExecUtils.addArgument(command, cmd);
+        }
+
+        final Process process = new ProcessBuilder(command)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .start();
+
+        process.waitFor();
+      } catch (Throwable e) {
+        System.err.println("Error while executing the onRedeploy command : '" + cmd + "'");
+        e.printStackTrace();
+      }
+    }
+    onCompletion.handle(null);
+  }
+
+  private void removeDirectory(File theFile) {
+    for (Map.Entry<WatchKey, File> entry : keyToFile.entrySet()) {
+      if (entry.getValue().getAbsolutePath().equals(theFile.getAbsolutePath())) {
+        keyToFile.remove(entry.getKey());
+        return;
+      }
+    }
+  }
+
+  /**
+   * Traverses the directory tree to register all directories in the watch service.
+   *
+   * @param root the root
+   * @throws IOException cannot traverse the tree
+   */
+  private void registerAll(final Path root) throws IOException {
+    // register directory and sub-directories
+    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+          throws IOException {
+        final WatchKey key = register(dir);
+        keyToFile.put(key, dir.toFile());
+        return FileVisitResult.CONTINUE;
+      }
+    });
+  }
+
+  /**
+   * Registers a directory into the {@link WatchService}. We listen for all events (creation, deletion and
+   * modification). To increase reactivity we also pass the sensitivity modifier to 'high' (OpenJDK and Oracle JVM
+   * only).
+   *
+   * @param dir the directory
+   * @return the watch key
+   * @throws IOException if it cannot be registered.
+   */
+  private WatchKey register(Path dir) throws IOException {
+    try {
+      // Detect whether or not the Sensitivity modifier is available. It not a class not found exception is thrown
+      this.getClass().getClassLoader().loadClass("com.sun.nio.file.SensitivityWatchEventModifier");
+      return dir.register(service, new WatchEvent.Kind[]{ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY},
+          SensitivityWatchEventModifier.HIGH);
+    } catch (ClassNotFoundException e) {
+      return dir.register(service, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
@@ -167,12 +167,15 @@ public class Watcher implements Runnable {
             Path fileName = ev.context();
             File theFile = new File(keyToFile.get(key), fileName.toFile().getName());
 
+            log.debug("Watcher ~> " + kind + " " + theFile.getAbsolutePath());
+
             if (kind == ENTRY_CREATE) {
               if (theFile.isDirectory()) {
                 // A new directory is created, the WatchService is not very nice with this, we need to register it.
                 try {
                   final WatchKey newKey = register(theFile.toPath());
                   keyToFile.put(newKey, theFile);
+                  log.debug("Watcher ~> new directory added to watch list :" + theFile.getAbsolutePath());
                 } catch (IOException e) {
                   log.error("Cannot register directory " + theFile.getAbsolutePath());
                 }

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -971,6 +971,57 @@
  *
  * The set of commands is extensible, refer to the <<Extending the vert.x Launcher>> section.
  *
+ * === Live Redeploy
+ *
+ * When developing it may be convenient to automatically redeploy your application upon file changes. The `vertx`
+ * command line tool and more generally the {@link io.vertx.core.Launcher} class offers this feature. Here are some
+ * examples:
+ *
+ * [source]
+ * ----
+ * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy"
+ * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy,**&#47;*.rb"
+ * java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**&#47;*.class" -cp ...
+ * ----
+ *
+ * The redeployment process is implemented as follows. First your application is launched as a background application
+ * (with the `start` command). On matching file changes, the process is stopped and the application is restarted.
+ * This way avoids leaks.
+ *
+ * To enable the live redeploy, pass the `--redeploy` option to the `run` command. The `--redeploy` indicates the
+ * set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and `?`). You can specify
+ * several sets by separating them using a comma (`,`). Patterns are relative to the current working directory.
+ *
+ * Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
+ * configured using `--java-opts`.
+ *
+ * The redeploy feature can be used in your IDE:
+ *
+ * * Eclipse - create a _Run_ configuration, using the `io.vertx.core.Launcher` class a _main class_. In the _Program
+ * arguments_ area (in the _Arguments_ tab), write `run your-verticle-fully-qualified-name --redeploy=\**&#47;*.java`.
+ * You can also add other parameters. The redeployment works smoothly as Eclipse incrementally compiles your files on
+ * save.
+ * * IntelliJ - create a _Run_ configuration (_Application_), set the _Main class_ to `io.vertx.core.Launcher`. In
+ * the Program arguments write: `run your-verticle-fully-qualified-name --redeploy=\**&#47;*.class
+ * --launcher-class=io.vertx.core.Launcher`. As you can see, you need to set the `launcher-class` parameter because
+ * IntelliJ wraps your main class in its own class. To trigger the redeployment, you need to _make_ the project or
+ * the module explicitly (_Build_ menu -> _Make project_).
+ *
+ * To debug your application, create your run configuration as a remote application and configure the debugger
+ * using `--java-opts`. However, don’t forget to re-plug the debugger after every redeployment as a new process is
+ * created every time.
+ *
+ * You can also hook your build process in the redeploy cycle:
+ *
+ * [source]
+ * ----
+ * java –jar target/my-fat-jar.jar –redeploy="**&#47;*.java" --on-redeploy="mvn package"
+ * ----
+ *
+ * The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
+ * restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
+ * or `grunt` to update your resources.
+ *
  * == Cluster Managers
  *
  * In Vert.x a cluster manager is used for various functions including:

--- a/src/test/java/io/vertx/core/impl/launcher/commands/FileSelectorTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/FileSelectorTest.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl.launcher.commands;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class FileSelectorTest {
+
+  @Test
+  public void test() {
+    String separator = File.separator;
+    assertThat(FileSelector.matchPath("**" + separator + "*.js", "foo.js")).isTrue();
+    assertThat(FileSelector.matchPath("**" + separator + "*.js", "target" + separator + "foo.js")).isTrue();
+    assertThat(FileSelector.matchPath("**" + separator + "*.js", "src/main" + separator + "js" + separator + "foo.js")).isTrue();
+    assertThat(FileSelector.matchPath("**" + separator + "*.js", "src" + separator + "main" + separator + "js" + separator + "dir" + separator + "foo.js")).isTrue();
+
+    assertThat(FileSelector.matchPath("*" + separator + "*.js", "src" + separator + "main" + separator + "js" + separator + "dir" + separator + "foo.js")).isFalse();
+    assertThat(FileSelector.matchPath("*" + separator + "*.js", "src" + separator + "js" + separator + "foo.js")).isFalse();
+    assertThat(FileSelector.matchPath("*" + separator + "*.js", "src" + separator + "foo.js")).isTrue();
+    assertThat(FileSelector.matchPath("*" + separator + "*.js", "foo.js")).isFalse();
+
+    assertThat(FileSelector.matchPath("*.js", "foo.js")).isTrue();
+    assertThat(FileSelector.matchPath("*.js", "foo" + separator + "foo.js")).isFalse();
+
+    assertThat(FileSelector.matchPath("*.?s", "foo.js")).isTrue();
+    assertThat(FileSelector.matchPath("*.?s", "foo.s")).isFalse();
+    assertThat(FileSelector.matchPath("*.?s", "foo.ajs")).isFalse();
+
+    assertThat(FileSelector.match("not" + separator + "*" + separator + "something.js", "foo" + separator + "bar" + separator + "something.js")).isFalse();
+    assertThat(FileSelector.match("**" + separator + "not" + separator + "something.js", "foo" + separator + "bar" + separator + "something.js")).isFalse();
+  }
+
+  @Test
+  public void testMatchPath_DefaultFileSeparator() {
+    String separator = File.separator;
+
+    // Pattern and target start with file separator
+    assertTrue(FileSelector.matchPath(separator + "*" + separator + "a.txt", separator + "b" + separator
+        + "a.txt"));
+    // Pattern starts with file separator, target doesn't
+    assertFalse(FileSelector.matchPath(separator + "*" + separator + "a.txt", "b" + separator + "a.txt"));
+    // Pattern doesn't start with file separator, target does
+    assertFalse(FileSelector.matchPath("*" + separator + "a.txt", separator + "b" + separator + "a.txt"));
+    // Pattern and target don't start with file separator
+    assertTrue(FileSelector.matchPath("*" + separator + "a.txt", "b" + separator + "a.txt"));
+  }
+
+  @Test
+  public void testMatchPath_UnixFileSeparator() {
+    String separator = "/";
+
+    // Pattern and target start with file separator
+    assertTrue(FileSelector.matchPath(separator + "*" + separator + "a.txt", separator + "b" + separator
+        + "a.txt", separator, false));
+    // Pattern starts with file separator, target doesn't
+    assertFalse(FileSelector.matchPath(separator + "*" + separator + "a.txt", "b" + separator + "a.txt",
+        separator, false));
+    // Pattern doesn't start with file separator, target does
+    assertFalse(FileSelector.matchPath("*" + separator + "a.txt", separator + "b" + separator + "a.txt",
+        separator, false));
+    // Pattern and target don't start with file separator
+    assertTrue(FileSelector.matchPath("*" + separator + "a.txt", "b" + separator + "a.txt", separator, false));
+  }
+
+  @Test
+  public void testMatchPath_WindowsFileSeparator() {
+    String separator = "\\";
+
+    // Pattern and target start with file separator
+    assertTrue(FileSelector.matchPath(separator + "*" + separator + "a.txt", separator + "b" + separator
+        + "a.txt", separator, false));
+    // Pattern starts with file separator, target doesn't
+    assertFalse(FileSelector.matchPath(separator + "*" + separator + "a.txt", "b" + separator + "a.txt",
+        separator, false));
+    // Pattern doesn't start with file separator, target does
+    assertFalse(FileSelector.matchPath("*" + separator + "a.txt", separator + "b" + separator + "a.txt",
+        separator, false));
+    // Pattern and target don't start with file separator
+    assertTrue(FileSelector.matchPath("*" + separator + "a.txt", "b" + separator + "a.txt", separator, false));
+  }
+
+
+}

--- a/src/test/java/io/vertx/core/impl/launcher/commands/HttpTestVerticle.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/HttpTestVerticle.java
@@ -24,13 +24,15 @@ public class HttpTestVerticle extends AbstractVerticle {
 
   @Override
   public void start() throws Exception {
-    vertx.createHttpServer().requestHandler(request-> {
+    long time = System.nanoTime();
+    vertx.createHttpServer().requestHandler(request -> {
       JsonObject json = new JsonObject();
       json
           .put("clustered", vertx.isClustered())
           .put("metrics", vertx.isMetricsEnabled())
           .put("id", System.getProperty("vertx.id", "no id"))
-          .put("conf", config());
+          .put("conf", config())
+          .put("startTime", time);
 
       if (System.getProperty("foo") != null) {
         json.put("foo", System.getProperty("foo"));

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
@@ -32,9 +32,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class RedeployTest extends CommandTestBase {
 
-  @Before
-  public void setUp() throws IOException {
-    super.setUp();
+  private void waitForTermination() {
+    waitUntil(() -> {
+      try {
+        RunCommandTest.getHttpCode();
+        return false;
+      } catch (IOException e) {
+        return true;
+      }
+    });
   }
 
   @After
@@ -47,9 +53,12 @@ public class RedeployTest extends CommandTestBase {
       close(vertx);
 
       run.stopBackgroundApplication(null);
+      run.shutdownRedeployment();
     }
 
     FakeClusterManager.reset();
+
+    waitForTermination();
   }
 
   @Test

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.impl.launcher.commands;
+
+import io.vertx.core.Launcher;
+import io.vertx.core.Vertx;
+import io.vertx.test.fakecluster.FakeClusterManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Check the redeployment behavior.
+ */
+public class RedeployTest extends CommandTestBase {
+
+  @Before
+  public void setUp() throws IOException {
+    super.setUp();
+  }
+
+  @After
+  public void tearDown() throws InterruptedException {
+    super.tearDown();
+
+    final RunCommand run = (RunCommand) cli.getExistingCommandInstance("run");
+    if (run != null) {
+      Vertx vertx = run.vertx;
+      close(vertx);
+
+      run.stopBackgroundApplication(null);
+    }
+
+    FakeClusterManager.reset();
+  }
+
+  @Test
+  public void testStartingApplicationInRedeployMode() {
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**/*.txt",
+        "--launcher-class=" + Launcher.class.getName()
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+  }
+
+  @Test
+  public void testStartingApplicationInRedeployModeWithCluster() throws IOException {
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**/*.txt",
+        "--launcher-class=" + Launcher.class.getName(),
+        "--cluster"
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+    assertThat(RunCommandTest.getContent().getBoolean("clustered")).isTrue();
+  }
+
+  @Test
+  public void testRedeployment() throws IOException {
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**/*.txt",
+        "--launcher-class=" + Launcher.class.getName(),
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+    long start1 = RunCommandTest.getContent().getLong("startTime");
+
+    File file = new File("target/test-classes/foo.txt");
+    if (file.exists()) {
+      file.delete();
+    }
+    file.createNewFile();
+
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200 && start1 != RunCommandTest.getContent().getLong("startTime");
+      } catch (IOException e) {
+        return false;
+      }
+    });
+  }
+
+}

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
@@ -34,6 +34,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class WatcherTest extends CommandTestBase {
 
+  // Note about sleep time - the watcher service is not very reliable and depends on the file system. So to be sure
+  // we catch the change, we need to wait. 2 seconds seems to be ok.
+
   private Watcher watcher;
   private AtomicInteger deploy;
   private AtomicInteger undeploy;
@@ -50,14 +53,12 @@ public class WatcherTest extends CommandTestBase {
 
     watcher = new Watcher(root, Collections.singletonList("**/*.txt"),
         next -> {
-          System.out.println("deploy");
           deploy.incrementAndGet();
           if (next != null) {
             next.handle(null);
           }
         },
         next -> {
-          System.out.println("undeploy");
           undeploy.incrementAndGet();
           if (next != null) {
             next.handle(null);
@@ -95,7 +96,7 @@ public class WatcherTest extends CommandTestBase {
     File file = new File(root, "foo.nope");
     file.createNewFile();
 
-    Thread.sleep(1000);
+    Thread.sleep(2000);
     assertThat(undeploy.get()).isEqualTo(0);
     assertThat(deploy.get()).isEqualTo(1);
   }
@@ -111,7 +112,7 @@ public class WatcherTest extends CommandTestBase {
     waitUntil(() -> deploy.get() == 1);
 
     // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
-    Thread.sleep(1000);
+    Thread.sleep(2000);
     // Simulate a 'touch'
     file.setLastModified(System.currentTimeMillis());
 
@@ -130,7 +131,7 @@ public class WatcherTest extends CommandTestBase {
     waitUntil(() -> deploy.get() == 1);
 
     // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
-    Thread.sleep(1000);
+    Thread.sleep(2000);
     file.delete();
 
     // undeployment followed by redeployment
@@ -141,14 +142,14 @@ public class WatcherTest extends CommandTestBase {
   public void testFileAdditionInDirectory() throws IOException, InterruptedException {
     watcher.watch();
     // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
-    Thread.sleep(1000);
+    Thread.sleep(2000);
 
     // Initial deployment
     waitUntil(() -> deploy.get() == 1);
 
     File newDir = new File(root, "directory");
     newDir.mkdir();
-    Thread.sleep(1000);
+    Thread.sleep(2000);
     File file = new File(newDir, "foo.txt");
     file.createNewFile();
 

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl.launcher.commands;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test the watching service behavior.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class WatcherTest extends CommandTestBase {
+
+  private Watcher watcher;
+  private AtomicInteger deploy;
+  private AtomicInteger undeploy;
+  private File root;
+
+  @Before
+  public void prepare() {
+    root = new File("target/junk/watcher");
+    deleteRecursive(root);
+    root.mkdirs();
+
+    deploy = new AtomicInteger();
+    undeploy = new AtomicInteger();
+
+    watcher = new Watcher(root, Collections.singletonList("**/*.txt"),
+        next -> {
+          System.out.println("deploy");
+          deploy.incrementAndGet();
+          if (next != null) {
+            next.handle(null);
+          }
+        },
+        next -> {
+          System.out.println("undeploy");
+          undeploy.incrementAndGet();
+          if (next != null) {
+            next.handle(null);
+          }
+        },
+        null);
+  }
+
+  @After
+  public void close() {
+    watcher.close();
+  }
+
+  @Test
+  public void testFileAddition() throws IOException {
+    watcher.watch();
+
+    // Initial deployment
+    waitUntil(() -> deploy.get() == 1);
+
+    File file = new File(root, "foo.txt");
+    file.createNewFile();
+
+    // undeployment followed by redeployment
+    waitUntil(() -> undeploy.get() == 1 && deploy.get() == 2);
+  }
+
+  @Test
+  public void testWithANonMatchingFile() throws IOException, InterruptedException {
+    watcher.watch();
+
+    // Initial deployment
+    waitUntil(() -> deploy.get() == 1);
+
+    File file = new File(root, "foo.nope");
+    file.createNewFile();
+
+    Thread.sleep(1000);
+    assertThat(undeploy.get()).isEqualTo(0);
+    assertThat(deploy.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void testFileModification() throws IOException, InterruptedException {
+    File file = new File(root, "foo.txt");
+    file.createNewFile();
+
+    watcher.watch();
+
+    // Initial deployment
+    waitUntil(() -> deploy.get() == 1);
+
+    // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
+    Thread.sleep(1000);
+    // Simulate a 'touch'
+    file.setLastModified(System.currentTimeMillis());
+
+    // undeployment followed by redeployment
+    waitUntil(() -> undeploy.get() == 1 && deploy.get() == 2);
+  }
+
+  @Test
+  public void testFileDeletion() throws IOException, InterruptedException {
+    File file = new File(root, "foo.txt");
+    file.createNewFile();
+
+    watcher.watch();
+
+    // Initial deployment
+    waitUntil(() -> deploy.get() == 1);
+
+    // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
+    Thread.sleep(1000);
+    file.delete();
+
+    // undeployment followed by redeployment
+    waitUntil(() -> undeploy.get() == 1 && deploy.get() == 2);
+  }
+
+  @Test
+  public void testFileAdditionInDirectory() throws IOException, InterruptedException {
+    watcher.watch();
+    // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
+    Thread.sleep(1000);
+
+    // Initial deployment
+    waitUntil(() -> deploy.get() == 1);
+
+    File newDir = new File(root, "directory");
+    newDir.mkdir();
+    Thread.sleep(1000);
+    File file = new File(newDir, "foo.txt");
+    file.createNewFile();
+
+    // undeployment followed by redeployment
+    waitUntil(() -> undeploy.get() == 1 && deploy.get() == 2);
+  }
+
+  public static boolean deleteRecursive(File path) {
+    if (!path.exists()) {
+      return false;
+    }
+    boolean ret = true;
+    if (path.isDirectory()) {
+      File[] files = path.listFiles();
+      if (files != null) {
+        for (File f : files) {
+          ret = ret && deleteRecursive(f);
+        }
+      }
+    }
+    return ret && path.delete();
+  }
+
+}

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
@@ -139,7 +139,7 @@ public class WatcherTest extends CommandTestBase {
   }
 
   @Test
-  public void testFileAdditionInDirectory() throws IOException, InterruptedException {
+  public void testFileAdditionAndModificationInDirectory() throws IOException, InterruptedException {
     watcher.watch();
     // Wait until the file monitoring is set up (ugly, but I don't know any way to detect this).
     Thread.sleep(2000);
@@ -155,6 +155,18 @@ public class WatcherTest extends CommandTestBase {
 
     // undeployment followed by redeployment
     waitUntil(() -> undeploy.get() == 1 && deploy.get() == 2);
+
+    // Update file
+    // Simulate a 'touch'
+    file.setLastModified(System.currentTimeMillis());
+
+    // undeployment followed by redeployment
+    waitUntil(() -> undeploy.get() == 2 && deploy.get() == 3);
+
+    // delete directory
+    deleteRecursive(newDir);
+
+    waitUntil(() -> undeploy.get() == 2 && deploy.get() == 3);
   }
 
   public static boolean deleteRecursive(File path) {


### PR DESCRIPTION
This PR adds the _redeploy_ feature to the `run` command.

It's a process-based redeploy: the application is started in background and restarted on file change. The set of watched file is configured in the command line (`--redeploy=...`).

