### PR TITLE
Replace the WatcherService by a home-made FS scanner

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
@@ -24,6 +24,7 @@ import io.vertx.core.spi.launcher.CommandFactoryLookup;
 import io.vertx.core.spi.launcher.ExecutionContext;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.URL;
 import java.util.*;
@@ -384,15 +385,18 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
     try {
       Enumeration<URL> resources = RunCommand.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
       while (resources.hasMoreElements()) {
-        Manifest manifest = new Manifest(resources.nextElement().openStream());
+        InputStream stream = resources.nextElement().openStream();
+        Manifest manifest = new Manifest(stream);
         Attributes attributes = manifest.getMainAttributes();
         String mainClass = attributes.getValue("Main-Class");
         if (main.getClass().getName().equals(mainClass)) {
           String command = attributes.getValue("Main-Command");
           if (command != null) {
+            stream.close();
             return command;
           }
         }
+        stream.close();
       }
     } catch (IOException e) {
       throw new IllegalStateException(e.getMessage());
@@ -414,15 +418,18 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
     try {
       Enumeration<URL> resources = RunCommand.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
       while (resources.hasMoreElements()) {
-        Manifest manifest = new Manifest(resources.nextElement().openStream());
+        InputStream stream = resources.nextElement().openStream();
+        Manifest manifest = new Manifest(stream);
         Attributes attributes = manifest.getMainAttributes();
         String mainClass = attributes.getValue("Main-Class");
         if (main != null && main.getClass().getName().equals(mainClass)) {
           String theMainVerticle = attributes.getValue("Main-Verticle");
           if (theMainVerticle != null) {
+            stream.close();
             return theMainVerticle;
           }
         }
+        stream.close();
       }
     } catch (IOException e) {
       throw new IllegalStateException(e.getMessage());

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -58,6 +58,8 @@ public class RunCommand extends BareCommand {
   protected String vertxApplicationBackgroundId;
   protected String onRedeployCommand;
   protected Watcher watcher;
+  private long redeployScanPeriod;
+  private long redeployGracePeriod;
 
   /**
    * Enables / disables the high-availability.
@@ -142,6 +144,22 @@ public class RunCommand extends BareCommand {
     this.onRedeployCommand = command;
   }
 
+  @Option(longName = "redeploy-scan-period", argName = "period")
+  @Description("When redeploy is enabled, this option configures the file system scanning period to detect file " +
+      "changes. The time is given in milliseconds. 250 ms by default.")
+  @DefaultValue("250")
+  public void setRedeployScanPeriod(long period) {
+    this.redeployScanPeriod = period;
+  }
+
+  @Option(longName = "redeploy-grace-period", argName = "period")
+  @Description("When redeploy is enabled, this option configures the grace period between 2 redeployments. The time " +
+      "is given in milliseconds. 1000 ms by default.")
+  @DefaultValue("1000")
+  public void setRedeployGracePeriod(long period) {
+    this.redeployGracePeriod = period;
+  }
+
   /**
    * Validates the command line parameters.
    *
@@ -220,7 +238,9 @@ public class RunCommand extends BareCommand {
     watcher = new Watcher(getCwd(), redeploy,
         this::startAsBackgroundApplication,  // On deploy
         this::stopBackgroundApplication, // On undeploy
-        onRedeployCommand); // In between command
+        onRedeployCommand, // In between command
+        redeployGracePeriod, // The redeploy grace period
+        redeployScanPeriod); // The redeploy scan period
 
     // Close the watcher when the JVM is terminating.
     // Notice that the vert.x finalizer is not registered when we run in redeploy mode.

--- a/src/test/java/io/vertx/core/cli/impl/CLIConfiguratorTest.java
+++ b/src/test/java/io/vertx/core/cli/impl/CLIConfiguratorTest.java
@@ -18,8 +18,8 @@ package io.vertx.core.cli.impl;
 
 import io.vertx.core.cli.*;
 import io.vertx.core.cli.Option;
-import io.vertx.core.cli.annotations.*;
 import io.vertx.core.cli.annotations.Argument;
+import io.vertx.core.cli.annotations.*;
 import io.vertx.core.cli.converters.*;
 import org.junit.Test;
 
@@ -54,12 +54,11 @@ public class CLIConfiguratorTest {
     CLI command = CLIConfigurator.define(HelloClI.class);
     StringBuilder builder = new StringBuilder();
     command.usage(builder);
-    assertThat(builder).isEqualToIgnoringCase("Usage: hello -n <name>\n" +
-        "\n" +
-        "A command saying hello.\n" +
-        "\n" +
-        "A simple cli to wish you a good day. Pass your name with `--name`\n\n" +
-        " -n,--name <name>   your name\n");
+    assertThat(builder)
+        .containsIgnoringCase("Usage: hello -n <name>")
+        .containsIgnoringCase("A command saying hello.")
+        .containsIgnoringCase("A simple cli to wish you a good day. Pass your name with `--name`")
+        .containsIgnoringCase(" -n,--name <name>   your name");
   }
 
   @Test

--- a/src/test/java/io/vertx/core/cli/impl/DefaultParserTest.java
+++ b/src/test/java/io/vertx/core/cli/impl/DefaultParserTest.java
@@ -53,7 +53,7 @@ public class DefaultParserTest {
 
     StringBuilder usage = new StringBuilder();
     cli.usage(usage);
-    assertThat(usage).startsWith("Usage: test [-f <value>]\n");
+    assertThat(usage).startsWith("Usage: test [-f <value>]");
     assertThat(usage).contains("-f,--file <value>");
   }
 
@@ -73,7 +73,7 @@ public class DefaultParserTest {
 
     StringBuilder usage = new StringBuilder();
     cli.usage(usage);
-    assertThat(usage).startsWith("Usage: test [-f <value>]\n");
+    assertThat(usage).startsWith("Usage: test [-f <value>]");
   }
 
   @Test

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
@@ -64,7 +64,7 @@ public class RedeployTest extends CommandTestBase {
   @Test
   public void testStartingApplicationInRedeployMode() {
     cli.dispatch(new Launcher(), new String[]{"run",
-        HttpTestVerticle.class.getName(), "--redeploy=**/*.txt",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
         "--launcher-class=" + Launcher.class.getName()
     });
     waitUntil(() -> {
@@ -79,7 +79,7 @@ public class RedeployTest extends CommandTestBase {
   @Test
   public void testStartingApplicationInRedeployModeWithCluster() throws IOException {
     cli.dispatch(new Launcher(), new String[]{"run",
-        HttpTestVerticle.class.getName(), "--redeploy=**/*.txt",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
         "--launcher-class=" + Launcher.class.getName(),
         "--cluster"
     });
@@ -96,7 +96,7 @@ public class RedeployTest extends CommandTestBase {
   @Test
   public void testRedeployment() throws IOException {
     cli.dispatch(new Launcher(), new String[]{"run",
-        HttpTestVerticle.class.getName(), "--redeploy=**/*.txt",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
         "--launcher-class=" + Launcher.class.getName(),
     });
     waitUntil(() -> {

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RunCommandTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RunCommandTest.java
@@ -169,7 +169,7 @@ public class RunCommandTest extends CommandTestBase {
   }
 
   @Test
-  public void testWithCOnfProvidedInline() throws IOException {
+  public void testWithConfProvidedInline() throws IOException {
     setManifest("MANIFEST-Launcher-Http-Verticle.MF");
     cli.dispatch(new Launcher(), new String[] {"--conf={\"name\":\"vertx\"}"});
     waitUntil(() -> {
@@ -183,7 +183,7 @@ public class RunCommandTest extends CommandTestBase {
   }
 
   @Test
-  public void testWithCOnfProvidedAsFile() throws IOException {
+  public void testWithConfProvidedAsFile() throws IOException {
     setManifest("MANIFEST-Launcher-Http-Verticle.MF");
     cli.dispatch(new Launcher(), new String[] {"--conf", "target/test-classes/conf.json"});
     waitUntil(() -> {

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
@@ -51,7 +51,7 @@ public class WatcherTest extends CommandTestBase {
     deploy = new AtomicInteger();
     undeploy = new AtomicInteger();
 
-    watcher = new Watcher(root, Collections.singletonList("**/*.txt"),
+    watcher = new Watcher(root, Collections.singletonList("**" + File.separator + "*.txt"),
         next -> {
           deploy.incrementAndGet();
           if (next != null) {


### PR DESCRIPTION
Replace the WatcherService by the scanner used in the previous version of vert.x and avoiding quite some issues on linux (ulimit), and on windows (bad latency).

Also fixed a couple of issues in test to make them work on Windows.