### PR TITLE
Replace asciidoc attributes by docgen variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,9 @@
                 <compilerArgs>
                   <arg>-Adocgen.output=${asciidoc.dir}/java</arg>
                   <arg>-AoutputDirectory=${project.basedir}/src/main</arg>
+                  <arg>-Amaven.groupId=${project.groupId}</arg>
+                  <arg>-Amaven.artifactId=${project.artifactId}</arg>
+                  <arg>-Amaven.version=${project.version}</arg>
                 </compilerArgs>
                 <generatedSourcesDirectory>${generated.dir}</generatedSourcesDirectory>
               </configuration>
@@ -225,12 +228,6 @@
             <relativeBaseDir>true</relativeBaseDir>
             <backend>html</backend>
             <doctype>book</doctype>
-            <attributes>
-              <maven-groupId>${project.groupId}</maven-groupId>
-              <maven-artifactId>${project.artifactId}</maven-artifactId>
-              <maven-version>${project.version}</maven-version>
-              <examples-dir>${project.basedir}/src/main/java/examples</examples-dir>
-            </attributes>
           </configuration>
           <executions>
             <execution>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,30 @@
 = Cheatsheets
 
+[[DeliveryOptions]]
+== DeliveryOptions
+
+++++
+ Delivery options are used to configure message delivery.
+ <p>
+ Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
+ that you wish to send with the message.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[codecName]]`codecName`|`String`|
++++
+Set the codec name.
++++
+|[[sendTimeout]]`sendTimeout`|`Number (long)`|
++++
+Set the send timeout.
++++
+|===
+
 [[NetworkOptions]]
 == NetworkOptions
 
@@ -27,31 +52,6 @@ Set the TCP send buffer size
 |[[trafficClass]]`trafficClass`|`Number (int)`|
 +++
 Set the value of traffic class
-+++
-|===
-
-[[DeliveryOptions]]
-== DeliveryOptions
-
-++++
- Delivery options are used to configure message delivery.
- <p>
- Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
- that you wish to send with the message.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[codecName]]`codecName`|`String`|
-+++
-Set the codec name.
-+++
-|[[sendTimeout]]`sendTimeout`|`Number (long)`|
-+++
-Set the send timeout.
 +++
 |===
 
@@ -433,6 +433,20 @@ Set the store as a buffer
 +++
 |===
 
+[[TrustOptions]]
+== TrustOptions
+
+++++
+ Certification authority configuration options.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|===
+
 [[Option]]
 == Option
 
@@ -492,20 +506,6 @@ Sets the short name of this option.
 +++
 Sets whether or not this option can receive a value.
 +++
-|===
-
-[[TrustOptions]]
-== TrustOptions
-
-++++
- Certification authority configuration options.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
 |===
 
 [[NetServerOptions]]
@@ -615,25 +615,6 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
-[[MetricsOptions]]
-== MetricsOptions
-
-++++
- Vert.x metrics base configuration, this class can be extended by provider implementations to configure
- those specific implementations.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[enabled]]`enabled`|`Boolean`|
-+++
-Set whether metrics will be enabled on the Vert.x instance.
-+++
-|===
-
 [[ClientOptionsBase]]
 == ClientOptionsBase
 
@@ -733,6 +714,25 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
+[[MetricsOptions]]
+== MetricsOptions
+
+++++
+ Vert.x metrics base configuration, this class can be extended by provider implementations to configure
+ those specific implementations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`enabled`|`Boolean`|
++++
+Set whether metrics will be enabled on the Vert.x instance.
++++
+|===
+
 [[DeploymentOptions]]
 == DeploymentOptions
 
@@ -780,20 +780,6 @@ Set whether the verticle(s) should be deployed as a multi-threaded worker vertic
 +++
 Set whether the verticle(s) should be deployed as a worker verticle
 +++
-|===
-
-[[KeyCertOptions]]
-== KeyCertOptions
-
-++++
- Key/cert configuration options.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
 |===
 
 [[PemKeyCertOptions]]
@@ -864,6 +850,20 @@ Set the path to the key file
 +++
 Set the key a a buffer
 +++
+|===
+
+[[KeyCertOptions]]
+== KeyCertOptions
+
+++++
+ Key/cert configuration options.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
 |===
 
 [[HttpServerOptions]]
@@ -986,56 +986,6 @@ Set whether Netty pooled buffers are enabled
 |[[websocketSubProtocols]]`websocketSubProtocols`|`String`|
 +++
 Set the websocket subprotocols supported by the server.
-+++
-|===
-
-[[DatagramSocketOptions]]
-== DatagramSocketOptions
-
-++++
- Options used to configure a datagram socket.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[broadcast]]`broadcast`|`Boolean`|
-+++
-Set if the socket can receive broadcast packets
-+++
-|[[ipV6]]`ipV6`|`Boolean`|
-+++
-Set if IP v6 should be used
-+++
-|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
-+++
-Set if loopback mode is disabled
-+++
-|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
-+++
-Set the multicast network interface address
-+++
-|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
-+++
-Set the multicast ttl value
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
 +++
 |===
 
@@ -1171,6 +1121,56 @@ Set whether Netty pooled buffers are enabled
 |[[verifyHost]]`verifyHost`|`Boolean`|
 +++
 Set whether hostname verification is enabled
++++
+|===
+
+[[DatagramSocketOptions]]
+== DatagramSocketOptions
+
+++++
+ Options used to configure a datagram socket.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[broadcast]]`broadcast`|`Boolean`|
++++
+Set if the socket can receive broadcast packets
++++
+|[[ipV6]]`ipV6`|`Boolean`|
++++
+Set if IP v6 should be used
++++
+|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
++++
+Set if loopback mode is disabled
++++
+|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
++++
+Set the multicast network interface address
++++
+|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
++++
+Set the multicast ttl value
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
 +++
 |===
 

--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -70,7 +70,30 @@ methods:
 
 [source, java]
 ----
-include::{examples-dir}/cli/AnnotatedCli.java[tags=content]
+@Name("some-name")
+@Summary("some short summary.")
+@Description("some long description")
+public class AnnotatedCli {
+
+  private boolean flag;
+  private String name;
+  private String arg;
+
+ @Option(shortName = "f", flag = true)
+ public void setFlag(boolean flag) {
+   this.flag = flag;
+ }
+
+ @Option(longName = "name")
+ public void setName(String name) {
+   this.name = name;
+ }
+
+ @Argument(index = 0)
+ public void setArg(String arg) {
+  this.arg = arg;
+ }
+}
 ----
 
 Once annotated, you can define the `link:../../apidocs/io/vertx/core/cli/CLI.html[CLI]` and inject the values using:

--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -6,9 +6,9 @@ project descriptor to access the Vert.x Core API:
 [source,xml,subs="+attributes"]
 ----
 <dependency>
-  <groupId>{maven-groupId}</groupId>
-  <artifactId>{maven-artifactId}</artifactId>
-  <version>{maven-version}</version>
+  <groupId>io.vertx</groupId>
+  <artifactId>vertx-core</artifactId>
+  <version>3.1.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -16,5 +16,5 @@ project descriptor to access the Vert.x Core API:
 
 [source,groovy,subs="+attributes"]
 ----
-compile {maven-groupId}:{maven-artifactId}:{maven-version}
+compile io.vertx:vertx-core:3.1.0-SNAPSHOT
 ----

--- a/src/main/java/docoverride/dependencies/package-info.java
+++ b/src/main/java/docoverride/dependencies/package-info.java
@@ -23,9 +23,9 @@
  * [source,xml,subs="+attributes"]
  * ----
  * <dependency>
- *   <groupId>{maven-groupId}</groupId>
- *   <artifactId>{maven-artifactId}</artifactId>
- *   <version>{maven-version}</version>
+ *   <groupId>${maven.groupId}</groupId>
+ *   <artifactId>${maven.artifactId}</artifactId>
+ *   <version>${maven.version}</version>
  * </dependency>
  * ----
  *
@@ -33,7 +33,7 @@
  *
  * [source,groovy,subs="+attributes"]
  * ----
- * compile {maven-groupId}:{maven-artifactId}:{maven-version}
+ * compile ${maven.groupId}:${maven.artifactId}:${maven.version}
  * ----
  */
 @Document(fileName = "override/dependencies.adoc")

--- a/src/main/java/io/vertx/core/cli/annotations/package-info.java
+++ b/src/main/java/io/vertx/core/cli/annotations/package-info.java
@@ -62,7 +62,30 @@
  *
  * [source, java]
  * ----
- * include::{examples-dir}/cli/AnnotatedCli.java[tags=content]
+ * &#64;Name("some-name")
+ * &#64;Summary("some short summary.")
+ * &#64;Description("some long description")
+ * public class AnnotatedCli {
+ *
+ *   private boolean flag;
+ *   private String name;
+ *   private String arg;
+ *
+ *  &#64;Option(shortName = "f", flag = true)
+ *  public void setFlag(boolean flag) {
+ *    this.flag = flag;
+ *  }
+ *
+ *  &#64;Option(longName = "name")
+ *  public void setName(String name) {
+ *    this.name = name;
+ *  }
+ *
+ *  &#64;Argument(index = 0)
+ *  public void setArg(String arg) {
+ *   this.arg = arg;
+ *  }
+ * }
  * ----
  *
  * Once annotated, you can define the {@link io.vertx.core.cli.CLI} and inject the values using:

--- a/src/test/asciidoc/dataobjects.adoc
+++ b/src/test/asciidoc/dataobjects.adoc
@@ -30,21 +30,6 @@
 ^|Name | Type ^| Description
 |===
 
-[[ParentDataObject]]
-== ParentDataObject
-
-++++
- @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[parentProperty]]`parentProperty`|`String`|-
-|===
-
 [[TestDataObject]]
 == TestDataObject
 
@@ -127,6 +112,21 @@
 |[[stringValue]]`stringValue`|`String`|-
 |[[stringValueMap]]`stringValueMap`|`String`|-
 |[[stringValues]]`stringValues`|`Array of String`|-
+|===
+
+[[ParentDataObject]]
+== ParentDataObject
+
+++++
+ @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[parentProperty]]`parentProperty`|`String`|-
 |===
 
 [[AggregatedDataObject]]


### PR DESCRIPTION
It avoids the issue when the asciidoc files are rendered to html in a different project.

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>