### PR TITLE
Handle exception on callbacks

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -318,7 +318,11 @@ public class HttpClientRequestImpl implements HttpClientRequest {
 
   synchronized void handleDrained() {
     if (drainHandler != null) {
-      drainHandler.handle(null);
+      try {
+        drainHandler.handle(null);
+      } catch (Throwable t) {
+        handleException(t);
+      }
     }
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -202,7 +202,11 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
       }
       bytesRead += data.length();
       if (dataHandler != null) {
-        dataHandler.handle(data);
+        try {
+          dataHandler.handle(data);
+        } catch (Throwable t) {
+          handleException(t);
+        }
       }
     }
   }
@@ -218,7 +222,11 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
       this.trailer = trailer;
       trailers = new HeadersAdaptor(trailer.trailingHeaders());
       if (endHandler != null) {
-        endHandler.handle(null);
+        try {
+          endHandler.handle(null);
+        } catch (Throwable t) {
+          handleException(t);
+        }
       }
     }
   }


### PR DESCRIPTION
Ensure exceptions from the drainHandler in HttpClientRequestImpl and dataHandler and endHandler in HttpClientResponseImpl bubble up through the exceptionHandler. Currently if an exception is thrown during that processing, it is not propagated back to the exceptionHandler.