### PR TITLE
Do not remove system properties during the tearDown

### DIFF
--- a/src/main/java/io/vertx/core/spi/launcher/DefaultCommand.java
+++ b/src/main/java/io/vertx/core/spi/launcher/DefaultCommand.java
@@ -99,7 +99,7 @@ public abstract class DefaultCommand implements Command {
 
   @Override
   public void tearDown() throws CLIException {
-    unapplySystemProperties();
+    // Default implementation - does nothing.
   }
 
   /**
@@ -113,21 +113,6 @@ public abstract class DefaultCommand implements Command {
           String key = prop.substring(0, p);
           String val = prop.substring(p + 1);
           System.setProperty(key, val);
-        }
-      }
-    }
-  }
-
-  /**
-   * Un-sets the system properties specified by the user command line.
-   */
-  protected void unapplySystemProperties() {
-    if (systemProperties != null) {
-      for (String prop : systemProperties) {
-        int p = prop.indexOf('=');
-        if (p > 0) {
-          String key = prop.substring(0, p);
-          System.clearProperty(key);
         }
       }
     }

--- a/src/test/java/io/vertx/core/impl/launcher/DefaultCommandTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/DefaultCommandTest.java
@@ -60,8 +60,9 @@ public class DefaultCommandTest {
     assertThat(System.getProperty("x")).isEqualToIgnoringCase("y");
 
     command.tearDown();
-    assertThat(System.getProperty("foo")).isNull();
-    assertThat(System.getProperty("x")).isNull();
+    // System properties are not removed by the tearDown.
+    assertThat(System.getProperty("foo")).isEqualToIgnoringCase("bar");
+    assertThat(System.getProperty("x")).isEqualToIgnoringCase("y");
   }
 
 }


### PR DESCRIPTION
System properties should not be removed. Removing them introduce a race condition when the verticles are starting asynchronously (they may have been removed before, or still be there...).
