### PR TITLE
BZ480001: HandlerRegistration cancels timerID 0 in doUnregister

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -35,7 +35,7 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
   private final boolean replyHandler;
   private final boolean localOnly;
   private final Handler<AsyncResult<Message<T>>> asyncResultHandler;
-  private long timeoutID;
+  private long timeoutID = -1;
   private boolean registered;
   private Handler<Message<T>> handler;
   private AsyncResult<Void> result;

--- a/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -1275,5 +1275,29 @@ public class LocalEventBusTest extends EventBusTestBase {
     closeVertx();
     await();
   }
+
+  @Test
+  public void testHandlerRegistrationDoesNotCancelTimer0() throws Exception {
+    HandlerRegistration<String> handlerRegistration = new HandlerRegistration<String>(vertx, null, null, null, false,
+        false, null, -1);
+
+    AtomicBoolean timerFinished = new AtomicBoolean(false);
+
+    long tid1 = vertx.setTimer(1000, id -> {
+      timerFinished.set(true);
+    });
+
+    if (tid1 != 0) {
+      fail("timer id is not 0, the issue will not show");
+    }
+
+    handlerRegistration.unregister();
+
+    vertx.setTimer(2000, id2 -> {
+      assertTrue("timer did not finish", timerFinished.get());
+      testComplete();
+    });
+    await();
+  }
 }
 

--- a/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -1277,7 +1277,7 @@ public class LocalEventBusTest extends EventBusTestBase {
   }
 
   @Test
-  public void testHandlerRegistrationDoesNotCancelTimer0() throws Exception {
+  public void testConsumerUnregisterDoesNotCancelTimer0() throws Exception {
     AtomicBoolean timerFinished = new AtomicBoolean(false);
 
     long tid1 = vertx.setTimer(1000, id -> {

--- a/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -1278,9 +1278,6 @@ public class LocalEventBusTest extends EventBusTestBase {
 
   @Test
   public void testHandlerRegistrationDoesNotCancelTimer0() throws Exception {
-    HandlerRegistration<String> handlerRegistration = new HandlerRegistration<String>(vertx, null, null, null, false,
-        false, null, -1);
-
     AtomicBoolean timerFinished = new AtomicBoolean(false);
 
     long tid1 = vertx.setTimer(1000, id -> {
@@ -1291,7 +1288,7 @@ public class LocalEventBusTest extends EventBusTestBase {
       fail("timer id is not 0, the issue will not show");
     }
 
-    handlerRegistration.unregister();
+    eb.consumer(ADDRESS1).unregister();
 
     vertx.setTimer(2000, id2 -> {
       assertTrue("timer did not finish", timerFinished.get());


### PR DESCRIPTION
https://bugs.eclipse.org/bugs/show_bug.cgi?id=480001

