### PR TITLE
Fixed logging delegate name for Log4j

### DIFF
--- a/src/main/java/io/vertx/core/logging/Logger.java
+++ b/src/main/java/io/vertx/core/logging/Logger.java
@@ -28,7 +28,7 @@ import io.vertx.core.spi.logging.LogDelegate;
  * <p>
  * If you would prefer to use Log4J or SLF4J instead of JUL then you can set a system property called
  * {@code vertx.logger-delegate-factory-class-name} to the class name of the delegate for your logging system.
- * For Log4J the value is {@code io.vertx.core.logging.impl.Log4JLogDelegateFactory}, for SLF4J the value
+ * For Log4J the value is {@code io.vertx.core.logging.Log4jLogDelegateFactory}, for SLF4J the value
  * is {@code io.vertx.core.logging.SLF4JLogDelegateFactory}. You will need to ensure whatever jar files
  * required by your favourite log framework are on your classpath.
  *


### PR DESCRIPTION
The class name is wrong (I suppose it lasted from v2)