### PR TITLE
Add support for bundleresource and bundleentry urls in the FileResolver

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -756,32 +756,37 @@ or Eclipse Equinox. The bundle exports `io.vertx.core*`.
 
 However, the bundle has some dependencies on Jackson and Netty. To get the vert.x core bundle resolved deploy:
 
-* Jackson Annotation [2.5.0,3)
-* Jackson Core [2.5.0,3)
-* Jackson Databind [2.5.0,3)
-* Netty Buffer [4.0.27,5)
-* Netty Codec [4.0.27,5)
-* Netty Codec/Socks [4.0.27,5)
-* Netty Codec/Common [4.0.27,5)
-* Netty Codec/Handler [4.0.27,5)
-* Netty Codec/Transport [4.0.27,5)
+* Jackson Annotation [2.6.0,3)
+* Jackson Core [2.6.2,3)
+* Jackson Databind [2.6.2,3)
+* Netty Buffer [4.0.31,5)
+* Netty Codec [4.0.31,5)
+* Netty Codec/Socks [4.0.31,5)
+* Netty Codec/Common [4.0.31,5)
+* Netty Codec/Handler [4.0.31,5)
+* Netty Codec/Transport [4.0.31,5)
 
-Here is a working deployment on Apache Felix 4.6.1:
+Here is a working deployment on Apache Felix 5.2.0:
 
 [source]
 ----
-  14|Active     |    1|Jackson-annotations (2.5.3)
-  15|Active     |    1|Jackson-core (2.5.3)
-  16|Active     |    1|jackson-databind (2.5.3)
-  17|Active     |    1|Netty/Buffer (4.0.27.Final)
-  18|Active     |    1|Netty/Codec (4.0.27.Final)
-  19|Active     |    1|Netty/Codec/HTTP (4.0.27.Final)
-  20|Active     |    1|Netty/Codec/Socks (4.0.27.Final)
-  21|Active     |    1|Netty/Common (4.0.27.Final)
-  22|Active     |    1|Netty/Handler (4.0.27.Final)
-  23|Active     |    1|Netty/Transport (4.0.27.Final)
-  25|Active     |    1|Vert.x Core (3.0.0.SNAPSHOT)
+14|Active     |    1|Jackson-annotations (2.6.0)
+15|Active     |    1|Jackson-core (2.6.2)
+16|Active     |    1|jackson-databind (2.6.2)
+18|Active     |    1|Netty/Buffer (4.0.31.Final)
+19|Active     |    1|Netty/Codec (4.0.31.Final)
+20|Active     |    1|Netty/Codec/HTTP (4.0.31.Final)
+21|Active     |    1|Netty/Codec/Socks (4.0.31.Final)
+22|Active     |    1|Netty/Common (4.0.31.Final)
+23|Active     |    1|Netty/Handler (4.0.31.Final)
+24|Active     |    1|Netty/Transport (4.0.31.Final)
+25|Active     |    1|Netty/Transport/SCTP (4.0.31.Final)
+26|Active     |    1|Vert.x Core (3.1.0)
 ----
+
+On Equinox, you may want to disable the `ContextFinder` with the following framework property:
+`eclipse.bundle.setTCCL=false`
+
 
 == The 'vertx' command line
 

--- a/src/main/java/io/vertx/core/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/impl/FileResolver.java
@@ -115,7 +115,9 @@ public class FileResolver {
             return unpackFromFileURL(url, fileName, cl);
           case "jar":
             return unpackFromJarURL(url, fileName);
-          case "bundle":
+          case "bundle": // Apache Felix, Knopflerfish
+          case "bundleentry": // Equinox
+          case "bundleresource": // Equinox
             return unpackFromBundleURL(url);
           default:
             throw new IllegalStateException("Invalid url protocol: " + prot);
@@ -195,9 +197,9 @@ public class FileResolver {
   }
 
   /**
-   * bundle:// urls are used by OSGi implementations to refer to a file contained in a bundle, or in a fragment. There
-   * is not much we can do to get the file from it, except reading it from the url. This method copies the files by
-   * reading it from the url.
+   * bundle:/, bundleresource:/ and bundleentry:/ urls are used by OSGi implementations to refer to a file
+   * contained in a bundle, or in a fragment. There is not much we can do to get the file from it, except
+   * reading it from the url. This method copies the files by reading it from the url.
    *
    * @param url      the url
    * @return the extracted file

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -711,32 +711,37 @@
  *
  * However, the bundle has some dependencies on Jackson and Netty. To get the vert.x core bundle resolved deploy:
  *
- * * Jackson Annotation [2.5.0,3)
- * * Jackson Core [2.5.0,3)
- * * Jackson Databind [2.5.0,3)
- * * Netty Buffer [4.0.27,5)
- * * Netty Codec [4.0.27,5)
- * * Netty Codec/Socks [4.0.27,5)
- * * Netty Codec/Common [4.0.27,5)
- * * Netty Codec/Handler [4.0.27,5)
- * * Netty Codec/Transport [4.0.27,5)
+ * * Jackson Annotation [2.6.0,3)
+ * * Jackson Core [2.6.2,3)
+ * * Jackson Databind [2.6.2,3)
+ * * Netty Buffer [4.0.31,5)
+ * * Netty Codec [4.0.31,5)
+ * * Netty Codec/Socks [4.0.31,5)
+ * * Netty Codec/Common [4.0.31,5)
+ * * Netty Codec/Handler [4.0.31,5)
+ * * Netty Codec/Transport [4.0.31,5)
  *
- * Here is a working deployment on Apache Felix 4.6.1:
+ * Here is a working deployment on Apache Felix 5.2.0:
  *
  *[source]
  *----
- *   14|Active     |    1|Jackson-annotations (2.5.3)
- *   15|Active     |    1|Jackson-core (2.5.3)
- *   16|Active     |    1|jackson-databind (2.5.3)
- *   17|Active     |    1|Netty/Buffer (4.0.27.Final)
- *   18|Active     |    1|Netty/Codec (4.0.27.Final)
- *   19|Active     |    1|Netty/Codec/HTTP (4.0.27.Final)
- *   20|Active     |    1|Netty/Codec/Socks (4.0.27.Final)
- *   21|Active     |    1|Netty/Common (4.0.27.Final)
- *   22|Active     |    1|Netty/Handler (4.0.27.Final)
- *   23|Active     |    1|Netty/Transport (4.0.27.Final)
- *   25|Active     |    1|Vert.x Core (3.0.0.SNAPSHOT)
+ * 14|Active     |    1|Jackson-annotations (2.6.0)
+ * 15|Active     |    1|Jackson-core (2.6.2)
+ * 16|Active     |    1|jackson-databind (2.6.2)
+ * 18|Active     |    1|Netty/Buffer (4.0.31.Final)
+ * 19|Active     |    1|Netty/Codec (4.0.31.Final)
+ * 20|Active     |    1|Netty/Codec/HTTP (4.0.31.Final)
+ * 21|Active     |    1|Netty/Codec/Socks (4.0.31.Final)
+ * 22|Active     |    1|Netty/Common (4.0.31.Final)
+ * 23|Active     |    1|Netty/Handler (4.0.31.Final)
+ * 24|Active     |    1|Netty/Transport (4.0.31.Final)
+ * 25|Active     |    1|Netty/Transport/SCTP (4.0.31.Final)
+ * 26|Active     |    1|Vert.x Core (3.1.0)
  *----
+ *
+ * On Equinox, you may want to disable the `ContextFinder` with the following framework property:
+ * `eclipse.bundle.setTCCL=false`
+ *
  *
  * == The 'vertx' command line
  *


### PR DESCRIPTION
Fix https://github.com/vert-x3/issues/issues/69.

Add support for bundleentry: and  bundleresource: protocols (used by equinox)
Update OSGi documentation (especially how to disable the context finder)
