### PR TITLE
Fix CLI test when the surefire jar name is too long

### DIFF
--- a/src/test/java/io/vertx/core/impl/launcher/VertxCommandLineInterfaceTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/VertxCommandLineInterfaceTest.java
@@ -159,7 +159,7 @@ public class VertxCommandLineInterfaceTest {
 
     assertThat(baos.toString())
         .contains("-o1 <opt>", " [-o2] ")
-        .contains("arg1 [arg2]")
+        .contains("arg1", "[arg2]")
         .contains("A command with options and arguments.") // Summary
         .contains("This is a complex command.") // Description
         .contains("-o1,--option1 <opt>") // Option


### PR DESCRIPTION
arg1 [arg2] may be cut on 2 lines if the surefire jar name (generated at runtime) is too long.

