### PR TITLE
fixed non-null message for codec.name()

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/CodecManager.java
@@ -96,7 +96,7 @@ public class CodecManager {
 
   public void registerCodec(MessageCodec codec) {
     Objects.requireNonNull(codec, "codec");
-    Objects.requireNonNull(codec.name(), "code.name()");
+    Objects.requireNonNull(codec.name(), "codec.name()");
     checkSystemCodec(codec);
     if (userCodecMap.containsKey(codec.name())) {
       throw new IllegalStateException("Already a codec registered with name " + codec.name());
@@ -112,7 +112,7 @@ public class CodecManager {
   public <T> void registerDefaultCodec(Class<T> clazz, MessageCodec<T, ?> codec) {
     Objects.requireNonNull(clazz);
     Objects.requireNonNull(codec, "codec");
-    Objects.requireNonNull(codec.name(), "code.name()");
+    Objects.requireNonNull(codec.name(), "codec.name()");
     checkSystemCodec(codec);
     if (defaultCodecMap.containsKey(clazz)) {
       throw new IllegalStateException("Already a default codec registered for class " + clazz);


### PR DESCRIPTION
Just noticed this while browsing the source code :)

Changed `code.name()` to `codec.name()` in the message of the non-null check.