### PR TITLE
Changed FileResolver so it can handle nested fat jars

### DIFF
--- a/src/main/java/io/vertx/core/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/impl/FileResolver.java
@@ -19,6 +19,7 @@ package io.vertx.core.impl;
 import io.vertx.core.*;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -27,10 +28,10 @@ import java.net.URLDecoder;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Enumeration;
 import java.util.UUID;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
 
 /**
  * Sometimes the file resources of an application are bundled into jars, or are somewhere on the classpath but not
@@ -44,6 +45,7 @@ import java.util.zip.ZipFile;
  * There is one cache dir per Vert.x instance and they are deleted on Vert.x shutdown.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author <a href="https://github.com/rworsnop/">Rob Worsnop</a>
  */
 public class FileResolver {
 
@@ -114,7 +116,7 @@ public class FileResolver {
           case "file":
             return unpackFromFileURL(url, fileName, cl);
           case "jar":
-            return unpackFromJarURL(url, fileName);
+            return unpackFromJarURL(url, fileName, cl);
           case "bundle":
             return unpackFromBundleURL(url);
           default:
@@ -158,16 +160,22 @@ public class FileResolver {
     return cacheFile;
   }
 
-  private synchronized  File unpackFromJarURL(URL url, String fileName) {
+  private static ZipInputStream toZipInputStream(URL url, ClassLoader cl) throws IOException{
+    String[] breadcrumbs = url.getPath().substring(5).split(".jar!");
+    if (breadcrumbs.length == 2){
+      // Normal case. Jar is on file system and desired path is in there
+      return new ZipInputStream(new FileInputStream(breadcrumbs[0] + ".jar"));
+    } else{
+      // Jar of jars. Desired path is inside a jar that is itself inside another jar
+      // E.g., Spring Boot fat jar format: application.jar!/lib/dependency.jar!/webroot/hello.html
+      return new ZipInputStream(cl.getResourceAsStream(breadcrumbs[1].substring(1) + ".jar"));
+    }
+  }
 
-    String path = url.getPath();
-    String jarFile = path.substring(5, path.lastIndexOf(".jar!") + 4);
-
-    try {
-      ZipFile zip = new ZipFile(jarFile);
-      Enumeration<? extends ZipEntry> entries = zip.entries();
-      while (entries.hasMoreElements()) {
-        ZipEntry entry = entries.nextElement();
+  private synchronized  File unpackFromJarURL(URL url, String fileName, ClassLoader cl) {
+    try (ZipInputStream zip = toZipInputStream(url, cl)){
+      ZipEntry entry = zip.getNextEntry();
+      while (entry != null) {
         String name = entry.getName();
         if (name.startsWith(fileName)) {
           File file = new File(cacheDir, name);
@@ -176,16 +184,19 @@ public class FileResolver {
             file.mkdirs();
           } else {
             file.getParentFile().mkdirs();
-            try (InputStream is = zip.getInputStream(entry)) {
+            try {
               if (ENABLE_CACHING) {
-                Files.copy(is, file.toPath());
+                Files.copy(zip, file.toPath());
               } else {
-                Files.copy(is, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(zip, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
               }
             } catch (FileAlreadyExistsException ignore) {
+            } finally {
+              zip.closeEntry();
             }
           }
         }
+        entry = zip.getNextEntry();
       }
     } catch (IOException e) {
       throw new VertxException(e);
@@ -253,8 +264,5 @@ public class FileResolver {
       handler.handle(Future.succeededFuture());
     }
   }
-
-
-
 }
 

--- a/src/test/java/io/vertx/test/core/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/test/core/FileResolverTestBase.java
@@ -155,9 +155,9 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   public void testRecursivelyUnpack() throws Exception {
     File file = resolver.resolveFile(webRoot + "/subdir");
     assertTrue(file.exists());
-    File sub = new File(new File(file, "subdir2"), "subfile2.html");
+    File sub = new File(file, "subfile.html");
     assertTrue(sub.exists());
-    assertEquals("<html><body>subfile2</body></html>", readFile(sub));
+    assertEquals("<html><body>subfile</body></html>", readFile(sub));
   }
 
   @Test


### PR DESCRIPTION
For example, a resource we want to find in a Spring Boot fat jar might be here:
app.jar!/lib/dependency.jar!/webroot/hello.html

I modified unpackFromJarURL so that, in the case of a Spring Boot fat jar, it
opens the nested jar using getResourceAsStream.

Since we're not dealing with a File anymore, I switched to using ZipInputStream
instead of ZipFile.

I also spotted what looked like a copy/paste error in FileResolverTestBase:
testRecursivelyUnpack and testRecursivelyUnpack2 were the same.

This fixes [481623](https://bugs.eclipse.org/bugs/show_bug.cgi?id=481623)