### PR TITLE
Provide response size to bodyEndHandler on HttpServerResponse

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -362,13 +362,13 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
 
   /**
    * Provide a handler that will be called just before the last part of the body is written to the wire
-   * and the response is ended.<p>
+   * and the response is ended. The parameter to the handler will be the full size of the response.<p>
    * This provides a hook allowing you to do any more operations before this occurs.
    *
    * @param handler  the handler
    * @return a reference to this, so the API can be used fluently
    */
   @Fluent
-  HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler);
+  HttpServerResponse bodyEndHandler(@Nullable Handler<Long> handler);
 
 }


### PR DESCRIPTION
Currently it is very difficult to write an access log containing the response size for a chunked response. By adding the response size as the parameter to the bodyEndHandler it simplifies this tremendously. Will have a subsequent PR for vertx-web if this is merged.