### PR TITLE
Add a callback invoked when the event bus is initialized. 

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -170,6 +170,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     eventBus.start(ar2 -> {
       if (ar2.succeeded()) {
         if (resultHandler != null) {
+          // If the metric provider wants to use the event bus, it cannot use it in its constructor as the event bus
+          // may not be initialized yet. We invokes the eventBusInitialized so it can starts using the event bus.
+          metrics.eventBusInitialized(eventBus);
           resultHandler.handle(Future.succeededFuture(this));
         }
       } else {

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -169,10 +169,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     eventBus.start(ar2 -> {
       if (ar2.succeeded()) {
+        // If the metric provider wants to use the event bus, it cannot use it in its constructor as the event bus
+        // may not be initialized yet. We invokes the eventBusInitialized so it can starts using the event bus.
+        metrics.eventBusInitialized(eventBus);
+
         if (resultHandler != null) {
-          // If the metric provider wants to use the event bus, it cannot use it in its constructor as the event bus
-          // may not be initialized yet. We invokes the eventBusInitialized so it can starts using the event bus.
-          metrics.eventBusInitialized(eventBus);
           resultHandler.handle(Future.succeededFuture(this));
         }
       } else {

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -341,7 +341,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       ServiceLoader<VertxMetricsFactory> factories = ServiceLoader.load(VertxMetricsFactory.class);
       if (factories.iterator().hasNext()) {
         VertxMetricsFactory factory = factories.iterator().next();
-        return factory.metrics(this, options);
+        VertxMetrics metrics = factory.metrics(this, options);
+        Objects.requireNonNull(metrics, "The metric instance created from " + factory + " cannot be null");
+        return metrics;
       } else {
         log.warn("Metrics has been set to enabled but no VertxMetricsFactory found on classpath");
       }

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -158,4 +158,15 @@ public interface VertxMetrics extends Metrics, Measured {
    * @return the datagram metrics SPI
    */
   DatagramSocketMetrics createMetrics(DatagramSocket socket, DatagramSocketOptions options);
+
+  /**
+   * Metrics cannot use the event bus in their constructor as the event bus is not yet initialized. When the event
+   * bus is initialized, this method is called with the event bus instance as parameter. By default, this method does
+   * nothing.
+   *
+   * @param bus the event bus
+   */
+  default void eventBusInitialized(EventBus bus) {
+    // Do nothing by default.
+  }
 }

--- a/src/test/java/io/vertx/test/core/MetricsTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsTest.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -71,6 +72,17 @@ public class MetricsTest extends VertxTestBase {
   public void testSendMessageInCluster() {
     startNodes(2);
     testBroadcastMessage(vertices[0], new Vertx[]{vertices[1]}, false, false, true);
+  }
+
+  @Test
+  public void testEventBusInitializedWithCluster() {
+    startNodes(1);
+    waitUntil(() -> FakeVertxMetrics.eventBus.get() != null);
+  }
+
+  @Test
+  public void testEventBusInitializedLocal() {
+    waitUntil(() -> FakeVertxMetrics.eventBus.get() != null);
   }
 
   @Test

--- a/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -37,10 +37,14 @@ import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.metrics.TCPMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
+
+  public static AtomicReference<EventBus> eventBus = new AtomicReference<>();
 
   public FakeVertxMetrics(Vertx vertx) {
     super(vertx);
@@ -139,4 +143,8 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     throw new UnsupportedOperationException();
   }
 
+  @Override
+  public void eventBusInitialized(EventBus bus) {
+    this.eventBus.set(bus);
+  }
 }


### PR DESCRIPTION
It avoids NPE in metric providers using the event bus.

They still can't use it in their constructor but are notified when the event bus is initialized.
This commit is related to https://github.com/vert-x3/vertx-hawkular-metrics/issues/4

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>