### PR TITLE
Use current class loader instead of system class loader.

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
+++ b/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
@@ -36,7 +36,7 @@ public class ServiceCommandFactoryLoader implements CommandFactoryLookup {
    * Creates a new instance of {@link ServiceCommandFactoryLoader} using the default classloader.
    */
   public ServiceCommandFactoryLoader() {
-    this.loader = ServiceLoader.load(CommandFactory.class, null);
+    this.loader = ServiceLoader.load(CommandFactory.class, getClass().getClassLoader());
   }
 
   /**


### PR DESCRIPTION
This pull request comes from this discussion on the Vert.x Google group:
https://groups.google.com/d/topic/vertx-dev/KNvBvJLSt7s/discussion

I copied the relevant part here:

I'm trying to use the maven Exec plugin to start Vert.x from my IDE.

Here's the configuration:
```xml
<build>
    <plugins>
        <plugin>
            <groupId>org.codehaus.mojo</groupId>
            <artifactId>exec-maven-plugin</artifactId>
            <version>1.4.0</version>
            <executions>
                <execution><goals><goal>java</goal></goals></execution>
            </executions>
            <configuration>
                <mainClass>io.vertx.core.Launcher</mainClass>
                <arguments>
                    <argument>run</argument>
                    <argument>service:myVerticle</argument>
                </arguments>
            </configuration>
        </plugin>
    </plugins>
</build> 
```
This doesn't work and Vert.x fail to start with the error message:
The command 'run' is not a valid command.

Basically what happened is that the ServiceLoader cannot load the different commands from the io.vertx.core.spi.launcher.CommandFactory ressource.

I think this is somehow a class loader issue: VertxCommandLauncher creates a ServiceCommandFactoryLoader instance without a specified  class loader. This ends up using the system class loader. If I specified the current class loader of ServiceCommandFactoryLoader it works fine.

Signed-off-by: Michel Guillet <michel@melusyn.com>