### PR TITLE
Fix default classloader in command lookup

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
+++ b/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
@@ -33,10 +33,11 @@ public class ServiceCommandFactoryLoader implements CommandFactoryLookup {
   private ServiceLoader<CommandFactory> loader;
 
   /**
-   * Creates a new instance of {@link ServiceCommandFactoryLoader} using the default classloader.
+   * Creates a new instance of {@link ServiceCommandFactoryLoader} using the classloader having loaded the
+   * {@link ServiceCommandFactoryLoader} class.
    */
   public ServiceCommandFactoryLoader() {
-    this.loader = ServiceLoader.load(CommandFactory.class, null);
+    this.loader = ServiceLoader.load(CommandFactory.class, getClass().getClassLoader());
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
@@ -95,10 +95,10 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
 
   /**
    * Creates a new {@link VertxCommandLauncher} using the default {@link ServiceCommandFactoryLoader}. It uses the
-   * classloader having loaded {@link VertxCommandLauncher}.
+   * classloader having loaded {@link ServiceCommandFactoryLoader}.
    */
   public VertxCommandLauncher() {
-    this(Collections.singletonList(new ServiceCommandFactoryLoader(VertxCommandLauncher.class.getClassLoader())));
+    this(Collections.singletonList(new ServiceCommandFactoryLoader()));
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
@@ -94,10 +94,11 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
   }
 
   /**
-   * Creates a new {@link VertxCommandLauncher} using the default {@link ServiceCommandFactoryLoader}.
+   * Creates a new {@link VertxCommandLauncher} using the default {@link ServiceCommandFactoryLoader}. It uses the
+   * classloader having loaded {@link VertxCommandLauncher}.
    */
   public VertxCommandLauncher() {
-    this(Collections.singletonList(new ServiceCommandFactoryLoader()));
+    this(Collections.singletonList(new ServiceCommandFactoryLoader(VertxCommandLauncher.class.getClassLoader())));
   }
 
   /**

--- a/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
@@ -19,11 +19,14 @@ import io.vertx.core.cli.CLI;
 import io.vertx.core.spi.launcher.CommandFactory;
 import org.junit.Test;
 
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 
@@ -48,5 +51,22 @@ public class ServiceCommandLoaderTest {
       }
     }
     fail("Cannot find '" + name + "' in " + clis.stream().map(CLI::getName).collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testNoCommandsWhenLoadedFromEmptyClassloader() {
+    ClassLoader classLoader = new URLClassLoader(new URL[0], null);
+    loader = new ServiceCommandFactoryLoader(classLoader);
+    assertThat(loader.lookup()).isEmpty();
+  }
+
+
+  @Test
+  public void testCommandsWhenUsingClassloaderHierarchy() {
+    ClassLoader classLoader = new URLClassLoader(new URL[0], ServiceCommandLoaderTest.class.getClassLoader());
+    loader = new ServiceCommandFactoryLoader(classLoader);
+    Collection<CommandFactory<?>> commands = loader.lookup();
+    ensureCommand(commands, "Hello");
+    ensureCommand(commands, "Bye");
   }
 }


### PR DESCRIPTION
This allows the launcher to find commands when launched using the maven exec plugin.