### PR TITLE
Added bytesWritten to HttpServerResponse

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -372,7 +372,7 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler);
 
   /**
-   * @return the total number of bytes written for this response
+   * @return the total number of bytes written for the body of the response.
    */
   long bytesWritten();
 }

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -371,4 +371,8 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   @Fluent
   HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler);
 
+  /**
+   * @return the total number of bytes written for this response
+   */
+  long bytesWritten();
 }


### PR DESCRIPTION
Currently it is very difficult to write an access log containing the response size for a chunked response. By adding the bytesWritten method to HttpServerResponse it simplifies this tremendously.

Signed-off-by: Dave Sinclair <stampy88@yahoo.com>