### PR TITLE
Fix missing pass logging arguments on slf4j delegate

### DIFF
--- a/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
@@ -157,7 +157,7 @@ public class SLF4JLogDelegate implements LogDelegate {
 
     if (logger instanceof LocationAwareLogger) {
       LocationAwareLogger l = (LocationAwareLogger) logger;
-      l.log(null, FQCN, level, msg, null, t);
+      l.log(null, FQCN, level, msg, params, t);
     } else {
       switch (level) {
         case TRACE_INT:


### PR DESCRIPTION
Why don't you pass log params(arguments) on slf4j?