### PR TITLE
Add details about the application 

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/ListCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ListCommand.java
@@ -43,6 +43,10 @@ public class ListCommand extends DefaultCommand {
 
   private final static Pattern PS = Pattern.compile("-Dvertx.id=(.*)\\s*");
 
+  private final static Pattern FAT_JAR_EXTRACTION = Pattern.compile("-jar (\\S*)");
+
+  private final static Pattern VERTICLE_EXTRACTION = Pattern.compile("run (\\S*)");
+
   // Note about stack traces - the stack trace are printed on the stream passed to the command.
 
   /**
@@ -98,7 +102,9 @@ public class ListCommand extends DefaultCommand {
     while ((line = reader.readLine()) != null) {
       final Matcher matcher = PS.matcher(line);
       if (matcher.find()) {
-        out.println(matcher.group(1));
+        String id = matcher.group(1);
+        String details = extractApplicationDetails(line);
+        out.println(id + "\t" + details);
         none = false;
       }
     }
@@ -107,5 +113,25 @@ public class ListCommand extends DefaultCommand {
     if (none) {
       out.println("No vert.x application found.");
     }
+  }
+
+  /**
+   * Tries to extract the fat jar name of the verticle name. It's a best-effort approach looking at the name of the
+   * jar or to the verticle name from the command line. If not found, no details are returned (empty string).
+   *
+   * @return the details, empty if it cannot be extracted.
+   */
+  protected static String extractApplicationDetails(String line) {
+    Matcher matcher = FAT_JAR_EXTRACTION.matcher(line);
+    if (matcher.find()) {
+      return matcher.group(1);
+    } else {
+      matcher = VERTICLE_EXTRACTION.matcher(line);
+      if (matcher.find()) {
+        return matcher.group(1);
+      }
+    }
+    // No details.
+    return "";
   }
 }

--- a/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
@@ -58,10 +58,11 @@ public class StartStopListCommandsTest extends CommandTestBase {
     output.reset();
     cli.dispatch(new String[]{"list"});
     assertThat(output.toString()).hasLineCount(2);
+    assertThat(output.toString()).contains("\t" + HttpTestVerticle.class.getName());
 
     // Extract id.
     String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1];
+    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     output.reset();
     cli.dispatch(new String[]{"stop", id});
     assertThat(output.toString())
@@ -99,7 +100,7 @@ public class StartStopListCommandsTest extends CommandTestBase {
 
     // Extract id.
     String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1];
+    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     output.reset();
     cli.dispatch(new String[]{"stop", id});
     assertThat(output.toString())
@@ -154,7 +155,7 @@ public class StartStopListCommandsTest extends CommandTestBase {
 
     // Extract id.
     String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1];
+    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     assertThat(id).isEqualToIgnoringCase("hello");
     output.reset();
     cli.dispatch(new String[]{"stop", id});
@@ -190,7 +191,7 @@ public class StartStopListCommandsTest extends CommandTestBase {
 
     // Extract id.
     String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1];
+    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     assertThat(id).isEqualToIgnoringCase("hello");
     output.reset();
     cli.dispatch(new String[]{"stop", id});
@@ -226,7 +227,7 @@ public class StartStopListCommandsTest extends CommandTestBase {
 
     // Extract id.
     String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1];
+    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     assertThat(id).isEqualToIgnoringCase("hello");
     output.reset();
     cli.dispatch(new String[]{"stop", id});
@@ -248,6 +249,24 @@ public class StartStopListCommandsTest extends CommandTestBase {
   private int getHttpCode() throws IOException {
     return ((HttpURLConnection) new URL("http://localhost:8080")
         .openConnection()).getResponseCode();
+  }
+
+  @Test
+  public void testFatJarExtraction() {
+    String command = "java -jar fat.jar -Dvertx.id=xxx --cluster";
+    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("fat.jar");
+
+    command = "java -jar bin/fat.jar -Dvertx.id=xxx --cluster";
+    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("bin/fat.jar");
+
+    command = "java foo bar -Dvertx.id=xxx --cluster";
+    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("");
+  }
+
+  @Test
+  public void testVerticleExtraction() {
+    String command = "vertx run verticle test1 -Dvertx.id=xxx --cluster";
+    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("verticle");
   }
 
 }


### PR DESCRIPTION
It adds the name of the fat jar or the verticle that was deployed:


vertx list
```
Listing vert.x applications...
hello	io.vertx.core.impl.launcher.commands.HttpTestVerticle
bae935ad-3df4-4e7d-bd15-3bd1d29ca1cc	io.vertx.core.impl.launcher.commands.HttpTestVerticle
35f291c6-bae3-4f5b-9df6-aa1c552be4ce	io.vertx.core.impl.launcher.commands.HttpTestVerticle2
```