### PR TITLE
Fix thread safety issue for writePos variable

### DIFF
--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -170,7 +170,7 @@ public class AsyncFileImpl implements AsyncFile {
   }
 
   @Override
-  public AsyncFile write(Buffer buffer) {
+  public synchronized AsyncFile write(Buffer buffer) {
     int length = buffer.length();
     doWrite(buffer, writePos, null);
     writePos += length;


### PR DESCRIPTION
writePos variable was touched outside the synchronization block. This may cause a file corruption if the writes are done from various threads.

Signed-off-by: Testo Nakada <test1@doramail.com>