### PR TITLE
Fix typo in documentation about logging backend

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1121,7 +1121,7 @@ If you don't want Vert.x to use JUL for it's own logging you can configure it to
 Log4J or SLF4J.
 
 To do this you should set a system property called `vertx.logger-delegate-factory-class-name` with the name of a Java
-class which implements the interface `link:../../apidocs/io/vertx/core/logging/LoggerFactory.html[LoggerFactory]`. We provide pre-built implementations for
+class which implements the interface `link:../../apidocs/io/vertx/core/spi/logging/LogDelegateFactory.html[LogDelegateFactory]`. We provide pre-built implementations for
 Log4J and SLF4J with the class names `io.vertx.core.logging.Log4jLogDelegateFactory` and `io.vertx.core.logging.SLF4JLogDelegateFactory`
 respectively. If you want to use these implementations you should also make sure the relevant Log4J or SLF4J jars
 are on your classpath.

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1076,7 +1076,7 @@
  * Log4J or SLF4J.
  *
  * To do this you should set a system property called `vertx.logger-delegate-factory-class-name` with the name of a Java
- * class which implements the interface {@link io.vertx.core.logging.LoggerFactory}. We provide pre-built implementations for
+ * class which implements the interface {@link io.vertx.core.spi.logging.LogDelegateFactory}. We provide pre-built implementations for
  * Log4J and SLF4J with the class names `io.vertx.core.logging.Log4jLogDelegateFactory` and `io.vertx.core.logging.SLF4JLogDelegateFactory`
  * respectively. If you want to use these implementations you should also make sure the relevant Log4J or SLF4J jars
  * are on your classpath.


### PR DESCRIPTION
Fix issue reported in https://github.com/vert-x3/vertx-web-site/issues/118 (Typo in the class name to implement to change the logging backend)