### PR TITLE
Fix #1211

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -364,7 +364,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
     synchronized (conn) {
       if (decoder != null) {
         try {
-          decoder.offer(new DefaultHttpContent(data.getByteBuf().duplicate()));
+          decoder.offer(new DefaultHttpContent(data.getByteBuf()));
         } catch (HttpPostRequestDecoder.ErrorDataDecoderException e) {
           handleException(e);
         }


### PR DESCRIPTION
Remove the useless call to duplicate(). The buffer is already a copy.

