### PR TITLE
CLI redeploy improvements (termination, on-redeploy)

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1065,12 +1065,20 @@ You can also hook your build process in the redeploy cycle:
 
 [source]
 ----
-java –jar target/my-fat-jar.jar –redeploy="**/*.java" --onRedeploy="mvn package"
+java –jar target/my-fat-jar.jar –redeploy="**/*.java" --on-redeploy="mvn package"
 ----
 
-The "onRedeploy" option specifies a command invoked after the shutdown of the application and before the
+The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
 restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
 or `grunt` to update your resources.
+
+The redeploy feature also supports the following settings:
+
+* `redeploy-scan-period` : the file system check period (in milliseconds), 250ms by default
+* `redeploy-grace-period` : the amount of time (in milliseconds) to wait between 2 re-deployments, 1000ms by default
+* `redeploy-termination-period` : the amount of time to wait after having stopped the application (before
+launching user command). This is useful on Windows, where the process is not killed immediately. The time is given
+in milliseconds. 0 ms by default.
 
 == Cluster Managers
 

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -140,11 +140,19 @@ public class RunCommand extends BareCommand {
     this.redeploy = redeploy;
   }
 
+  /**
+   * Sets the user command executed during redeployment.
+   * @param command the on redeploy command
+   * @deprecated Use 'on-redeploy' instead. It will be removed in vert.x 3.3
+   */
   @Option(longName = "onRedeploy", argName = "cmd")
-  @Description("Optional shell command executed when a redeployment is triggered")
+  @Description("Optional shell command executed when a redeployment is triggered (deprecated - will be removed in 3" +
+      ".3, use 'on-redeploy' instead")
   @Hidden
   @Deprecated
   public void setOnRedeployCommandOld(String command) {
+    out.println("[WARNING] the 'onRedeploy' option is deprecated, and will be removed in vert.x 3.3. Use " +
+        "'on-redeploy' instead.");
     setOnRedeployCommand(command);
   }
 

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -141,6 +141,14 @@ public class RunCommand extends BareCommand {
 
   @Option(longName = "onRedeploy", argName = "cmd")
   @Description("Optional shell command executed when a redeployment is triggered")
+  @Hidden
+  @Deprecated
+  public void setOnRedeployCommandOld(String command) {
+    setOnRedeployCommand(command);
+  }
+
+  @Option(longName = "on-redeploy", argName = "cmd")
+  @Description("Optional shell command executed when a redeployment is triggered")
   public void setOnRedeployCommand(String command) {
     this.onRedeployCommand = command;
   }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
@@ -280,7 +280,7 @@ public class Watcher implements Runnable {
 
         process.waitFor();
       } catch (Throwable e) {
-        System.err.println("Error while executing the onRedeploy command : '" + cmd + "'");
+        System.err.println("Error while executing the on-redeploy command : '" + cmd + "'");
         e.printStackTrace();
       }
     }

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1020,12 +1020,20 @@
  *
  * [source]
  * ----
- * java –jar target/my-fat-jar.jar –redeploy="**&#47;*.java" --onRedeploy="mvn package"
+ * java –jar target/my-fat-jar.jar –redeploy="**&#47;*.java" --on-redeploy="mvn package"
  * ----
  *
- * The "onRedeploy" option specifies a command invoked after the shutdown of the application and before the
+ * The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
  * restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
  * or `grunt` to update your resources.
+ *
+ * The redeploy feature also supports the following settings:
+ *
+ * * `redeploy-scan-period` : the file system check period (in milliseconds), 250ms by default
+ * * `redeploy-grace-period` : the amount of time (in milliseconds) to wait between 2 re-deployments, 1000ms by default
+ * * `redeploy-termination-period` : the amount of time to wait after having stopped the application (before
+ * launching user command). This is useful on Windows, where the process is not killed immediately. The time is given
+ * in milliseconds. 0 ms by default.
  *
  * == Cluster Managers
  *

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
@@ -81,7 +81,8 @@ public class RedeployTest extends CommandTestBase {
     cli.dispatch(new Launcher(), new String[]{"run",
         HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
         "--launcher-class=" + Launcher.class.getName(),
-        "--cluster"
+        "--cluster",
+        ExecUtils.isWindows() ? "--redeploy-termination-period=3000" : ""
     });
     waitUntil(() -> {
       try {
@@ -89,7 +90,7 @@ public class RedeployTest extends CommandTestBase {
       } catch (IOException e) {
         return false;
       }
-    });
+    }, 20000);
     assertThat(RunCommandTest.getContent().getBoolean("clustered")).isTrue();
   }
 
@@ -98,6 +99,7 @@ public class RedeployTest extends CommandTestBase {
     cli.dispatch(new Launcher(), new String[]{"run",
         HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
         "--launcher-class=" + Launcher.class.getName(),
+        ExecUtils.isWindows() ? "--redeploy-termination-period=3000" : ""
     });
     waitUntil(() -> {
       try {
@@ -120,7 +122,7 @@ public class RedeployTest extends CommandTestBase {
       } catch (IOException e) {
         return false;
       }
-    });
+    }, 20000);
   }
 
 }


### PR DESCRIPTION
* Add termination period to redeploy (mainly for windows 10)
* Rename onRedeploy to on-redeploy (still support the previous option)
