### PR TITLE
Optionally specifying whether to fail on unknown properies

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -18,8 +18,10 @@ package io.vertx.core.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -72,12 +74,26 @@ public class Json {
   }
 
   public static <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
+    return decodeValue(str, clazz, true);
+  }
+
+  public static <T> T decodeValue(String str, Class<T> clazz, boolean failOnUnknownProperties) throws DecodeException {
+    ObjectReader reader = mapper.readerFor(clazz);
+
+    if (failOnUnknownProperties) {
+      reader = reader.with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    } else {
+      reader = reader.without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    T ret;
     try {
-      return mapper.readValue(str, clazz);
+      ret = reader.readValue(str);
     }
     catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage());
     }
+    return ret;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/io/vertx/test/core/JsonFailOnUnknownPropertyTest.java
+++ b/src/test/java/io/vertx/test/core/JsonFailOnUnknownPropertyTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * @author  Mike Whitlaw
+ */
+public class JsonFailOnUnknownPropertyTest {
+
+
+  private static class SourceClass {
+    private String str1;
+    private String str2;
+
+    public String getStr1() {
+      return str1;
+    }
+
+    public void setStr1(String str1) {
+      this.str1 = str1;
+    }
+
+    public SourceClass withStr1(String str1) {
+      this.setStr1(str1);
+      return this;
+    }
+
+    public String getStr2() {
+      return str2;
+    }
+
+    public void setStr2(String str2) {
+      this.str2 = str2;
+    }
+
+    public SourceClass withStr2(String str2) {
+      this.setStr2(str2);
+      return this;
+    }
+  }
+
+  private static class TargetClass {
+    private String str1;
+
+    public String getStr1() {
+      return str1;
+    }
+
+    public void setStr1(String str1) {
+      this.str1 = str1;
+    }
+    public TargetClass withStr1(String str1) {
+      this.setStr1(str1);
+      return this;
+    }
+
+  }
+
+  @Test
+  public void testDecodingJsonWithUnknownProperty() {
+    String sourceJsonStr = Json.encode(new SourceClass().withStr1("v1").withStr2("v2"));
+    TargetClass targetClass = Json.decodeValue(sourceJsonStr, TargetClass.class, false);
+    assertNotNull(targetClass);
+    assertEquals(targetClass.getStr1(), "v1");
+    SourceClass sourceClass = Json.decodeValue(sourceJsonStr, SourceClass.class, false);
+    assertNotNull(sourceClass);
+    assertEquals(sourceClass.getStr1(), "v1");
+    assertEquals(sourceClass.getStr2(), "v2");
+    SourceClass sourceClass2 = Json.decodeValue(sourceJsonStr, SourceClass.class);
+    assertNotNull(sourceClass2);
+    assertEquals(sourceClass2.getStr1(), "v1");
+    assertEquals(sourceClass2.getStr2(), "v2");
+  }
+
+  @Test
+  public void testDecodingJsonWithUnknownPropertyFail() {
+    String sourceJsonStr = Json.encode(new SourceClass().withStr1("v1").withStr2("v2"));
+    try {
+      Json.decodeValue(sourceJsonStr, TargetClass.class, true);
+      fail();
+    } catch (DecodeException e) {
+      // OK
+    }
+  }
+
+  @Test
+  public void testDecodingJsonWithUnknownPropertyFailByDefault() {
+    String sourceJsonStr = Json.encode(new SourceClass().withStr1("v1").withStr2("v2"));
+    try {
+      Json.decodeValue(sourceJsonStr, TargetClass.class);
+      fail();
+    } catch (DecodeException e) {
+      // OK
+    }
+  }
+
+
+
+
+}
+
+


### PR DESCRIPTION
Added overloaded version of Json.decode that supports specifying whether to fail on unknown properties in the source json string, defaulting to true.

Signed-off-by: Mike Whitlaw <mike.whitlaw@gmail.com>