### PR TITLE
Added support for respecting the Connection header in Http client connections.

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -116,7 +116,8 @@ public abstract class ConnectionManager {
 
     // Called when the response has ended
     public synchronized void responseEnded(ClientConnection conn) {
-      if (pipelining || keepAlive) {
+      // If keepAlive and we weren't ask by the server to close
+      if (keepAlive && ! conn.isForceClose()) {
         Waiter waiter = getNextWaiter();
         if (waiter != null) {
           waiter.context.runOnContext(v -> waiter.handler.handle(conn));


### PR DESCRIPTION
This PR re-adds handling of the Connection: close and HTTP/1.0 missing Connection: keep-alive from the server, that was originally addressed in 2.1.

At one point in the diff you'll see I collapsed an if check against keepalive and pipelining, since you can't create a request with pipelining enabled  and keepalive disables it felt the check against pipelining was redundant.

I also added support for respecting the request Connection header, at least in the case of HTTP/1.1.  It is possible that the client knows that it won't be reusing the connection and it is 'polite' for it to indicate that to the server rather than have it close the connection on idle timeout.   In the HTTP/1.0 case the HttpClientRequestImpl forces the Connection header when keepalive is enabled so it's not possible to force a close from the client side in that case.

See #1213 and #876 