### PR TITLE
Fix typos in documentation

### DIFF
--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -66,7 +66,7 @@ server.listen(8080, "myhost.com", res -> {
 
 === Getting notified of incoming requests
 
-To be notified when a request arrives you need to set a `link:../../apidocs/io/vertx/core/http/HttpServer.html#requestHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[requestHandler]`:
+To be notified when a request arrives you need to set a `link:../../apidocs/io/vertx/core/http/HttpServer.html#requestHandler-io.vertx.core.Handler-[requestHandler]`:
 
 [source,java]
 ----
@@ -237,7 +237,7 @@ request.endHandler(v -> {
 });
 ----
 
-This is such a common case, that Vert.x provides a `link:../../apidocs/io/vertx/core/http/HttpServerRequest.html#bodyHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[bodyHandler]` to do this
+This is such a common case, that Vert.x provides a `link:../../apidocs/io/vertx/core/http/HttpServerRequest.html#bodyHandler-io.vertx.core.Handler-[bodyHandler]` to do this
 for you. The body handler is called once when all the body has been received:
 
 [source,java]
@@ -286,7 +286,7 @@ server.requestHandler(request -> {
 Vert.x can also handle file uploads which are encoded in a multi-part request body.
 
 To receive file uploads you tell Vert.x to expect a multi-part form and set an
-`link:../../apidocs/io/vertx/core/http/HttpServerRequest.html#uploadHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[uploadHandler]` on the request.
+`link:../../apidocs/io/vertx/core/http/HttpServerRequest.html#uploadHandler-io.vertx.core.Handler-[uploadHandler]` on the request.
 
 This handler will be called once for every
 upload that arrives on the server.
@@ -601,7 +601,7 @@ To enable compression use can configure it with `link:../../apidocs/io/vertx/cor
 
 By default compression is not enabled.
 
-When HTTP compression is enabled the server will check if the client incldes an `Accept-Encoding` header which
+When HTTP compression is enabled the server will check if the client includes an `Accept-Encoding` header which
 includes the supported compressions. Commonly used are deflate and gzip. Both are supported by Vert.x.
 
 If such a header is found the server will automatically compress the body of the response with one of the supported
@@ -1061,7 +1061,7 @@ The idea here is it allows the server to authorise and accept/reject the request
 Sending large amounts of data if the request might not be accepted is a waste of bandwidth and ties up the server
 in reading data that it will just discard.
 
-Vert.x allows you to set a `link:../../apidocs/io/vertx/core/http/HttpClientRequest.html#continueHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[continueHandler]` on the
+Vert.x allows you to set a `link:../../apidocs/io/vertx/core/http/HttpClientRequest.html#continueHandler-io.vertx.core.Handler-[continueHandler]` on the
 client request object
 
 This will be called if the server sends back a `Status: 100 (Continue)` response to signify that it is ok to send
@@ -1230,7 +1230,7 @@ There are two ways of handling WebSockets on the server side.
 
 ===== WebSocket handler
 
-The first way involves providing a `link:../../apidocs/io/vertx/core/http/HttpServer.html#websocketHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[websocketHandler]`
+The first way involves providing a `link:../../apidocs/io/vertx/core/http/HttpServer.html#websocketHandler-io.vertx.core.Handler-[websocketHandler]`
 on the server instance.
 
 When a WebSocket connection is made to the server, the handler will be called, passing in an instance of
@@ -1279,8 +1279,8 @@ server.requestHandler(request -> {
 ===== The server WebSocket
 
 The `link:../../apidocs/io/vertx/core/http/ServerWebSocket.html[ServerWebSocket]` instance enables you to retrieve the `link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#headers--[headers]`,
-`link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#path--[path]` path}, `link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#query--[query]` and
-`link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#uri--[uri]` URI} of the HTTP request of the WebSocket handshake.
+`link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#path--[path]`, `link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#query--[query]` and
+`link:../../apidocs/io/vertx/core/http/ServerWebSocket.html#uri--[URI]` of the HTTP request of the WebSocket handshake.
 
 ==== WebSockets on the client
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1029,9 +1029,10 @@ examples:
 
 [source]
 ----
-vertx run MyVerticle.groovy --redeploy="**/*.groovy"
-vertx run MyVerticle.groovy --redeploy="**/*.groovy,**/*.rb"
-java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**/*.class" -cp ...
+vertx run MyVerticle.groovy --redeploy="**/*.groovy" --launcher-class=io.vertx.core.Launcher
+vertx run MyVerticle.groovy --redeploy="**/*.groovy,**/*.rb"  --launcher-class=io.vertx.core.Launcher
+java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**/*.class"  --launcher-class=io.vertx.core
+.Launcher -cp ...
 ----
 
 The redeployment process is implemented as follows. First your application is launched as a background application
@@ -1045,16 +1046,18 @@ several sets by separating them using a comma (`,`). Patterns are relative to th
 Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
 configured using `--java-opts`.
 
+The `--launcher-class` option determine with with _main_ class the application is launcher. It's generally
+`link:../../apidocs/io/vertx/core/Launcher.html[Launcher]`, but you have use you own _main_.
+
 The redeploy feature can be used in your IDE:
 
 * Eclipse - create a _Run_ configuration, using the `io.vertx.core.Launcher` class a _main class_. In the _Program
-arguments_ area (in the _Arguments_ tab), write `run your-verticle-fully-qualified-name --redeploy=\**/*.java`.
-You can also add other parameters. The redeployment works smoothly as Eclipse incrementally compiles your files on
-save.
+arguments_ area (in the _Arguments_ tab), write `run your-verticle-fully-qualified-name --redeploy=\**/*.java
+--launcher-class=io.vertx.core.Launcher`. You can also add other parameters. The redeployment works smoothly as
+Eclipse incrementally compiles your files on save.
 * IntelliJ - create a _Run_ configuration (_Application_), set the _Main class_ to `io.vertx.core.Launcher`. In
 the Program arguments write: `run your-verticle-fully-qualified-name --redeploy=\**/*.class
---launcher-class=io.vertx.core.Launcher`. As you can see, you need to set the `launcher-class` parameter because
-IntelliJ wraps your main class in its own class. To trigger the redeployment, you need to _make_ the project or
+--launcher-class=io.vertx.core.Launcher`. To trigger the redeployment, you need to _make_ the project or
 the module explicitly (_Build_ menu -> _Make project_).
 
 To debug your application, create your run configuration as a remote application and configure the debugger
@@ -1066,6 +1069,7 @@ You can also hook your build process in the redeploy cycle:
 [source]
 ----
 java –jar target/my-fat-jar.jar –redeploy="**/*.java" --on-redeploy="mvn package"
+java -jar build/libs/my-fat-jar.jar --redeploy="src/**/*.java" --on-redeploy='./gradlew shadowJar'
 ----
 
 The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -252,7 +252,7 @@ If you want to turn of these warnings or change the settings, you can do that in
 In a perfect world, there will be no war or hunger, all APIs will be written asynchronously and bunny rabbits will
 skip hand-in-hand with baby lambs across sunny green meadows.
 
-*But.. the real world is not like that. (Have you watched the news lately?)*
+*But... the real world is not like that. (Have you watched the news lately?)*
 
 Fact is, many, if not most libraries, especially in the JVM ecosystem have synchronous APIs and many of the methods are
 likely to block. A good example is the JDBC API - it's inherently synchronous, and no matter how hard it tries, Vert.x

--- a/src/main/asciidoc/java/net.adoc
+++ b/src/main/asciidoc/java/net.adoc
@@ -84,7 +84,7 @@ server.listen(0, "localhost", res -> {
 
 === Getting notified of incoming connections
 
-To be notified when a connection is made you need to set a `link:../../apidocs/io/vertx/core/net/NetServer.html#connectHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[connectHandler]`:
+To be notified when a connection is made you need to set a `link:../../apidocs/io/vertx/core/net/NetServer.html#connectHandler-io.vertx.core.Handler-[connectHandler]`:
 
 [source,java]
 ----
@@ -137,7 +137,7 @@ Write operations are asynchronous and may not occur until some time after the ca
 
 === Closed handler
 
-If you want to be notified when a socket is closed, you can set a `link:../../apidocs/io/vertx/core/net/NetSocket.html#closeHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[closeHandler]`
+If you want to be notified when a socket is closed, you can set a `link:../../apidocs/io/vertx/core/net/NetSocket.html#closeHandler-io.vertx.core.Handler-[closeHandler]`
 on it:
 
 [source,java]

--- a/src/main/asciidoc/java/override/verticles.adoc
+++ b/src/main/asciidoc/java/override/verticles.adoc
@@ -73,12 +73,12 @@ public class MyVerticle extends AbstractVerticle {
     // Do something
   }
 
-  public void stop(Future<Void> startFuture) {
+  public void stop(Future<Void> stopFuture) {
     obj.doSomethingThatTakesTime(res -> {
       if (res.succeeded()) {
-        startFuture.complete();
+        stopFuture.complete();
       } else {
-        startFuture.fail();
+        stopFuture.fail();
       }
     });
   }

--- a/src/main/asciidoc/java/parsetools.adoc
+++ b/src/main/asciidoc/java/parsetools.adoc
@@ -3,7 +3,7 @@
 The record parser allows you to easily parse protocols which are delimited by a sequence of bytes, or fixed
 size records.
 
-It transforms an sequence of input buffer to a sequence of buffer structured as configured (either
+It transforms a sequence of input buffer to a sequence of buffer structured as configured (either
 fixed size or separated records).
 
 For example, if you have a simple ASCII text protocol delimited by '\n' and the input is the following:

--- a/src/main/asciidoc/java/streams.adoc
+++ b/src/main/asciidoc/java/streams.adoc
@@ -101,7 +101,7 @@ server.connectHandler(sock -> {
 }).listen();
 ----
 
-And there we have it. The `link:../../apidocs/io/vertx/core/streams/WriteStream.html#drainHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[drainHandler]` event handler will
+And there we have it. The `link:../../apidocs/io/vertx/core/streams/WriteStream.html#drainHandler-io.vertx.core.Handler-[drainHandler]` event handler will
 get called when the write queue is ready to accept more data, this resumes the `NetSocket` that
 allows more data to be read.
 
@@ -134,7 +134,7 @@ Let's now look at the methods on `ReadStream` and `WriteStream` in more detail:
 
 Functions:
 
-- `link:../../apidocs/io/vertx/core/streams/ReadStream.html#handler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[handler]`:
+- `link:../../apidocs/io/vertx/core/streams/ReadStream.html#handler-io.vertx.core.Handler-[handler]`:
 set a handler which will receive items from the ReadStream.
 - `link:../../apidocs/io/vertx/core/streams/ReadStream.html#pause--[pause]`:
 pause the handler. When paused no items will be received in the handler.
@@ -142,7 +142,7 @@ pause the handler. When paused no items will be received in the handler.
 resume the handler. The handler will be called if any item arrives.
 - `link:../../apidocs/io/vertx/core/streams/ReadStream.html#exceptionHandler-io.vertx.core.Handler-[exceptionHandler]`:
 Will be called if an exception occurs on the ReadStream.
-- `link:../../apidocs/io/vertx/core/streams/ReadStream.html#endHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[endHandler]`:
+- `link:../../apidocs/io/vertx/core/streams/ReadStream.html#endHandler-io.vertx.core.Handler-[endHandler]`:
 Will be called when end of stream is reached. This might be when EOF is reached if the ReadStream represents a file,
 or when end of request is reached if it's an HTTP request, or when the connection is closed if it's a TCP socket.
 
@@ -166,7 +166,7 @@ represents the actual number of bytes written and not the number of buffers.
 returns `true` if the write queue is considered full.
 - `link:../../apidocs/io/vertx/core/streams/WriteStream.html#exceptionHandler-io.vertx.core.Handler-[exceptionHandler]`:
 Will be called if an exception occurs on the `WriteStream`.
-- `link:../../apidocs/io/vertx/core/streams/WriteStream.html#drainHandler-(@io.vertx.codegen.annotations.Nullable :: io.vertx.core.Handler)-[drainHandler]`:
+- `link:../../apidocs/io/vertx/core/streams/WriteStream.html#drainHandler-io.vertx.core.Handler-[drainHandler]`:
 The handler will be called if the `WriteStream` is considered no longer full.
 
 === Pump
@@ -183,4 +183,3 @@ This has the same meaning as `link:../../apidocs/io/vertx/core/streams/WriteStre
 A pump can be started and stopped multiple times.
 
 When a pump is first created it is _not_ started. You need to call the `start()` method to start it.
-<a href="mailto:julien@julienviet.com">Julien Viet</a>

--- a/src/main/java/docoverride/verticles/package-info.java
+++ b/src/main/java/docoverride/verticles/package-info.java
@@ -90,12 +90,12 @@
  *     // Do something
  *   }
  *
- *   public void stop(Future<Void> startFuture) {
+ *   public void stop(Future<Void> stopFuture) {
  *     obj.doSomethingThatTakesTime(res -> {
  *       if (res.succeeded()) {
- *         startFuture.complete();
+ *         stopFuture.complete();
  *       } else {
- *         startFuture.fail();
+ *         stopFuture.fail();
  *       }
  *     });
  *   }

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -508,7 +508,7 @@
  *
  * By default compression is not enabled.
  *
- * When HTTP compression is enabled the server will check if the client incldes an `Accept-Encoding` header which
+ * When HTTP compression is enabled the server will check if the client includes an `Accept-Encoding` header which
  * includes the supported compressions. Commonly used are deflate and gzip. Both are supported by Vert.x.
  *
  * If such a header is found the server will automatically compress the body of the response with one of the supported
@@ -1012,8 +1012,8 @@
  * ===== The server WebSocket
  *
  * The {@link io.vertx.core.http.ServerWebSocket} instance enables you to retrieve the {@link io.vertx.core.http.ServerWebSocket#headers() headers},
- * {@link io.vertx.core.http.ServerWebSocket#path()} path}, {@link io.vertx.core.http.ServerWebSocket#query() query} and
- * {@link io.vertx.core.http.ServerWebSocket#uri()} URI} of the HTTP request of the WebSocket handshake.
+ * {@link io.vertx.core.http.ServerWebSocket#path() path}, {@link io.vertx.core.http.ServerWebSocket#query() query} and
+ * {@link io.vertx.core.http.ServerWebSocket#uri() URI} of the HTTP request of the WebSocket handshake.
  *
  * ==== WebSockets on the client
  *

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -260,7 +260,7 @@
  * In a perfect world, there will be no war or hunger, all APIs will be written asynchronously and bunny rabbits will
  * skip hand-in-hand with baby lambs across sunny green meadows.
  *
- * *But.. the real world is not like that. (Have you watched the news lately?)*
+ * *But... the real world is not like that. (Have you watched the news lately?)*
  *
  * Fact is, many, if not most libraries, especially in the JVM ecosystem have synchronous APIs and many of the methods are
  * likely to block. A good example is the JDBC API - it's inherently synchronous, and no matter how hard it tries, Vert.x

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -984,9 +984,10 @@
  *
  * [source]
  * ----
- * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy"
- * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy,**&#47;*.rb"
- * java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**&#47;*.class" -cp ...
+ * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy" --launcher-class=io.vertx.core.Launcher
+ * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy,**&#47;*.rb"  --launcher-class=io.vertx.core.Launcher
+ * java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**&#47;*.class"  --launcher-class=io.vertx.core
+ * .Launcher -cp ...
  * ----
  *
  * The redeployment process is implemented as follows. First your application is launched as a background application
@@ -1000,16 +1001,18 @@
  * Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
  * configured using `--java-opts`.
  *
+ * The `--launcher-class` option determine with with _main_ class the application is launcher. It's generally
+ * {@link io.vertx.core.Launcher}, but you have use you own _main_.
+ *
  * The redeploy feature can be used in your IDE:
  *
  * * Eclipse - create a _Run_ configuration, using the `io.vertx.core.Launcher` class a _main class_. In the _Program
- * arguments_ area (in the _Arguments_ tab), write `run your-verticle-fully-qualified-name --redeploy=\**&#47;*.java`.
- * You can also add other parameters. The redeployment works smoothly as Eclipse incrementally compiles your files on
- * save.
+ * arguments_ area (in the _Arguments_ tab), write `run your-verticle-fully-qualified-name --redeploy=\**&#47;*.java
+ * --launcher-class=io.vertx.core.Launcher`. You can also add other parameters. The redeployment works smoothly as
+ * Eclipse incrementally compiles your files on save.
  * * IntelliJ - create a _Run_ configuration (_Application_), set the _Main class_ to `io.vertx.core.Launcher`. In
  * the Program arguments write: `run your-verticle-fully-qualified-name --redeploy=\**&#47;*.class
- * --launcher-class=io.vertx.core.Launcher`. As you can see, you need to set the `launcher-class` parameter because
- * IntelliJ wraps your main class in its own class. To trigger the redeployment, you need to _make_ the project or
+ * --launcher-class=io.vertx.core.Launcher`. To trigger the redeployment, you need to _make_ the project or
  * the module explicitly (_Build_ menu -> _Make project_).
  *
  * To debug your application, create your run configuration as a remote application and configure the debugger
@@ -1021,6 +1024,7 @@
  * [source]
  * ----
  * java –jar target/my-fat-jar.jar –redeploy="**&#47;*.java" --on-redeploy="mvn package"
+ * java -jar build/libs/my-fat-jar.jar --redeploy="src&#47;**&#47;*.java" --on-redeploy='./gradlew shadowJar'
  * ----
  *
  * The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the

--- a/src/main/java/io/vertx/core/parsetools/package-info.java
+++ b/src/main/java/io/vertx/core/parsetools/package-info.java
@@ -18,7 +18,7 @@
  * == Record Parser
  *
  * The record parser allows you to easily parse protocols which are delimited by a sequence of bytes, or fixed
- * size records. It transforms an sequence of input buffer to a sequence of buffer structured as configured (either
+ * size records. It transforms a sequence of input buffer to a sequence of buffer structured as configured (either
  * fixed size or separated records).
  *
  * For example, if you have a simple ASCII text protocol delimited by '\n' and the input is the following:

--- a/src/main/java/io/vertx/core/streams/package-info.java
+++ b/src/main/java/io/vertx/core/streams/package-info.java
@@ -155,8 +155,6 @@
  * A pump can be started and stopped multiple times.
  *
  * When a pump is first created it is _not_ started. You need to call the `start()` method to start it.
- *
- * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @Document(fileName = "streams.adoc")
 package io.vertx.core.streams;


### PR DESCRIPTION
This commit fixes:

* https://github.com/vert-x3/vert-x3.github.io/pull/3
* https://github.com/vert-x3/vert-x3.github.io/pull/4
* https://github.com/vert-x3/vert-x3.github.io/pull/6
* https://github.com/vert-x3/vert-x3.github.io/pull/7
* https://github.com/vert-x3/vert-x3.github.io/pull/8
* https://github.com/vert-x3/vert-x3.github.io/pull/9

It also regenerated the .adoc with the annotation fix in docgen.

