### PR TITLE
Make sure that request.handleException is called only once

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -319,7 +319,9 @@ class ClientConnection extends ConnectionBase {
     // Connection was closed - call exception handlers for any requests in the pipeline or one being currently written
     Exception e = new VertxException("Connection was closed");
     for (HttpClientRequestImpl req: requests) {
-      req.handleException(e);
+      if (req != currentRequest) {
+        req.handleException(e);
+      }
     }
     if (currentRequest != null) {
       currentRequest.handleException(e);


### PR DESCRIPTION
If the connection is broken before the entire request is written (POST/PUT), `requests` may contain `currentRequest`. This, sometimes, causes `request.handleException` to be called twice on the same request.

Signed-off-by: Testo Nakada <test1@doramail.com>