### PR TITLE
Support for SSL/TLS protocol restrictions on SSL/TLS enabled servers

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -314,6 +314,10 @@ Add a CRL value
 +++
 Add an enabled cipher suite
 +++
+|[[enabledSecureTransportProtocols]]`enabledSecureTransportProtocols`|`Array of String`|
++++
+Add an enabled SSL/TLS protocols
++++
 |[[idleTimeout]]`idleTimeout`|`Number (int)`|
 +++
 Set the idle timeout, in seconds. zero means don't timeout.
@@ -547,6 +551,10 @@ Add a CRL value
 +++
 Add an enabled cipher suite
 +++
+|[[enabledSecureTransportProtocols]]`enabledSecureTransportProtocols`|`Array of String`|
++++
+Add an enabled SSL/TLS protocols
++++
 |[[host]]`host`|`String`|
 +++
 Set the host
@@ -622,25 +630,6 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
-[[MetricsOptions]]
-== MetricsOptions
-
-++++
- Vert.x metrics base configuration, this class can be extended by provider implementations to configure
- those specific implementations.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[enabled]]`enabled`|`Boolean`|
-+++
-Set whether metrics will be enabled on the Vert.x instance.
-+++
-|===
-
 [[ClientOptionsBase]]
 == ClientOptionsBase
 
@@ -668,6 +657,10 @@ Add a CRL value
 |[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
 +++
 Add an enabled cipher suite
++++
+|[[enabledSecureTransportProtocols]]`enabledSecureTransportProtocols`|`Array of String`|
++++
+Add an enabled SSL/TLS protocols
 +++
 |[[idleTimeout]]`idleTimeout`|`Number (int)`|
 +++
@@ -737,6 +730,25 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|===
+
+[[MetricsOptions]]
+== MetricsOptions
+
+++++
+ Vert.x metrics base configuration, this class can be extended by provider implementations to configure
+ those specific implementations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`enabled`|`Boolean`|
++++
+Set whether metrics will be enabled on the Vert.x instance.
 +++
 |===
 
@@ -898,6 +910,10 @@ Add a CRL value
 |[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
 +++
 Add an enabled cipher suite
++++
+|[[enabledSecureTransportProtocols]]`enabledSecureTransportProtocols`|`Array of String`|
++++
+Add an enabled SSL/TLS protocols
 +++
 |[[handle100ContinueAutomatically]]`handle100ContinueAutomatically`|`Boolean`|
 +++
@@ -1084,6 +1100,10 @@ Set the default port to be used by this client in requests if none is provided w
 +++
 Add an enabled cipher suite
 +++
+|[[enabledSecureTransportProtocols]]`enabledSecureTransportProtocols`|`Array of String`|
++++
+Add an enabled SSL/TLS protocols
++++
 |[[idleTimeout]]`idleTimeout`|`Number (int)`|
 +++
 Set the idle timeout, in seconds. zero means don't timeout.
@@ -1265,6 +1285,10 @@ Add a CRL value
 |[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
 +++
 Add an enabled cipher suite
++++
+|[[enabledSecureTransportProtocols]]`enabledSecureTransportProtocols`|`Array of String`|
++++
+Add an enabled SSL/TLS protocols
 +++
 |[[idleTimeout]]`idleTimeout`|`Number (int)`|
 +++

--- a/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/net/TCPSSLOptionsConverter.java
@@ -45,6 +45,12 @@ public class TCPSSLOptionsConverter {
           obj.addEnabledCipherSuite((String)item);
       });
     }
+    if (json.getValue("enabledSecureTransportProtocols") instanceof JsonArray) {
+      json.getJsonArray("enabledSecureTransportProtocols").forEach(item -> {
+        if (item instanceof String)
+          obj.addEnabledSecureTransportProtocol((String)item);
+      });
+    }
     if (json.getValue("idleTimeout") instanceof Number) {
       obj.setIdleTimeout(((Number)json.getValue("idleTimeout")).intValue());
     }
@@ -101,6 +107,13 @@ public class TCPSSLOptionsConverter {
     if (obj.getEnabledCipherSuites() != null) {
       json.put("enabledCipherSuites", new JsonArray(
           obj.getEnabledCipherSuites().
+              stream().
+              map(item -> item).
+              collect(java.util.stream.Collectors.toList())));
+    }
+    if (obj.getEnabledSecureTransportProtocols() != null) {
+      json.put("enabledSecureTransportProtocols", new JsonArray(
+          obj.getEnabledSecureTransportProtocols().
               stream().
               map(item -> item).
               collect(java.util.stream.Collectors.toList())));

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -21,8 +21,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.ClientOptionsBase;
 import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
 
 /**
@@ -248,6 +248,12 @@ public class HttpClientOptions extends ClientOptionsBase {
   @Override
   public HttpClientOptions addEnabledCipherSuite(String suite) {
     super.addEnabledCipherSuite(suite);
+    return this;
+  }
+
+  @Override
+  public HttpClientOptions addEnabledSecureTransportProtocol(final String protocol) {
+    super.addEnabledSecureTransportProtocol(protocol);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -217,6 +217,12 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
+  public HttpServerOptions addEnabledSecureTransportProtocol(final String protocol) {
+    super.addEnabledSecureTransportProtocol(protocol);
+    return this;
+  }
+
+  @Override
   public HttpServerOptions addCrlPath(String crlPath) throws NullPointerException {
     return (HttpServerOptions) super.addCrlPath(crlPath);
   }

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -175,6 +175,12 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions addEnabledSecureTransportProtocol(final String protocol) {
+    super.addEnabledSecureTransportProtocol(protocol);
+    return this;
+  }
+
+  @Override
   public NetClientOptions addCrlPath(String crlPath) throws NullPointerException {
     return (NetClientOptions) super.addCrlPath(crlPath);
   }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -187,6 +187,12 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
+  public NetServerOptions addEnabledSecureTransportProtocol(final String protocol) {
+    super.addEnabledSecureTransportProtocol(protocol);
+    return this;
+  }
+
+  @Override
   public NetServerOptions addCrlPath(String crlPath) throws NullPointerException {
     return (NetServerOptions) super.addCrlPath(crlPath);
   }

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -16,11 +16,15 @@
 
 package io.vertx.core.net;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-
-import java.util.*;
 
 /**
  * Base class. TCP and SSL related options
@@ -71,6 +75,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   private Set<String> enabledCipherSuites = new HashSet<>();
   private ArrayList<String> crlPaths;
   private ArrayList<Buffer> crlValues;
+  private Set<String> enabledSecureTransportProtocols = new HashSet<>();
 
   /**
    * Default constructor
@@ -98,6 +103,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     this.enabledCipherSuites = other.getEnabledCipherSuites() == null ? new HashSet<>() : new HashSet<>(other.getEnabledCipherSuites());
     this.crlPaths = new ArrayList<>(other.getCrlPaths());
     this.crlValues = new ArrayList<>(other.getCrlValues());
+    this.enabledSecureTransportProtocols = other.getEnabledSecureTransportProtocols() == null ? new HashSet<>() : new HashSet<>(other.getEnabledSecureTransportProtocols());
   }
 
   /**
@@ -375,6 +381,25 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     return this;
   }
 
+  /**
+   * Add an enabled SSL/TLS protocols
+   *
+   * @param protocol  the SSL/TLS protocol do enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions addEnabledSecureTransportProtocol(String protocol) {
+    enabledSecureTransportProtocols.add(protocol);
+    return this;
+  }
+
+  /**
+   * Returns the enabled SSL/TLS protocols
+   * @return the enabled protocols
+   */
+  public Set<String> getEnabledSecureTransportProtocols() {
+    return enabledSecureTransportProtocols;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -395,6 +420,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
       return false;
     if (keyCertOptions != null ? !keyCertOptions.equals(that.keyCertOptions) : that.keyCertOptions != null) return false;
     if (trustOptions != null ? !trustOptions.equals(that.trustOptions) : that.trustOptions != null) return false;
+    if (!enabledSecureTransportProtocols.equals(that.enabledSecureTransportProtocols)) return false;
 
     return true;
   }
@@ -413,6 +439,8 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     result = 31 * result + (enabledCipherSuites != null ? enabledCipherSuites.hashCode() : 0);
     result = 31 * result + (crlPaths != null ? crlPaths.hashCode() : 0);
     result = 31 * result + (crlValues != null ? crlValues.hashCode() : 0);
+    result = 31 * result + (enabledSecureTransportProtocols != null ? enabledSecureTransportProtocols
+        .hashCode() : 0);
     return result;
   }
 }

--- a/src/test/asciidoc/dataobjects.adoc
+++ b/src/test/asciidoc/dataobjects.adoc
@@ -1,5 +1,19 @@
 = Cheatsheets
 
+[[NoConverterDataObject]]
+== NoConverterDataObject
+
+++++
+ @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|===
+
 [[ChildInheritingDataObject]]
 == ChildInheritingDataObject
 
@@ -14,20 +28,6 @@
 ^|Name | Type ^| Description
 |[[childProperty]]`childProperty`|`String`|-
 |[[parentProperty]]`parentProperty`|`String`|-
-|===
-
-[[NoConverterDataObject]]
-== NoConverterDataObject
-
-++++
- @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
 |===
 
 [[ParentDataObject]]


### PR DESCRIPTION
Hey!

I haven't found a way to restrict the SSL/TLS protocol on SSL/TLS enabled servers, so i've added the ability to restrict them (did i miss something in either my implementation or any existent code to achieve what i needed?).

To complement a bit, this is one of the requirements for us, at my company, to be able to use vert.x, along with secure channels (eventbus traffic - i see that an issue was recently opened, great!!) and some other security related ones.

Sorry if i messed up, dunno if docs were intended to be part of the commit, i've run `mvn clean package` prior to the commit. 
I's my first contribution though, looking forward to review/comments! :)

Cheers!
