### PR TITLE
Use netty epoll support if available

### DIFF
--- a/vertx-core/src/main/java/org/vertx/java/core/datagram/impl/DefaultDatagramSocket.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/datagram/impl/DefaultDatagramSocket.java
@@ -19,13 +19,12 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
-import io.netty.channel.socket.InternetProtocolFamily;
-import io.netty.channel.socket.nio.NioDatagramChannel;
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.buffer.Buffer;
 import org.vertx.java.core.datagram.DatagramSocket;
 import org.vertx.java.core.impl.DefaultFutureResult;
+import org.vertx.java.core.impl.NettySupport;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.net.impl.ConnectionBase;
 
@@ -379,18 +378,8 @@ public class DefaultDatagramSocket extends ConnectionBase
     return (DatagramChannel) channel;
   }
 
-  private static NioDatagramChannel createChannel(org.vertx.java.core.datagram.InternetProtocolFamily family) {
-    if (family == null) {
-      return new NioDatagramChannel();
-    }
-    switch (family) {
-      case IPv4:
-        return new NioDatagramChannel(InternetProtocolFamily.IPv4);
-      case IPv6:
-        return new NioDatagramChannel(InternetProtocolFamily.IPv6);
-      default:
-        return new NioDatagramChannel();
-    }
+  private static DatagramChannel createChannel(org.vertx.java.core.datagram.InternetProtocolFamily family) {
+    return NettySupport.datagramChannel(family);
   }
 
 

--- a/vertx-core/src/main/java/org/vertx/java/core/dns/impl/DefaultDnsClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/dns/impl/DefaultDnsClient.java
@@ -18,7 +18,6 @@ package org.vertx.java.core.dns.impl;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
 import io.netty.channel.socket.DatagramChannel;
-import io.netty.channel.socket.nio.NioDatagramChannel;
 import org.vertx.java.core.AsyncResult;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.dns.*;
@@ -29,6 +28,7 @@ import org.vertx.java.core.dns.impl.netty.decoder.record.MailExchangerRecord;
 import org.vertx.java.core.dns.impl.netty.decoder.record.ServiceRecord;
 import org.vertx.java.core.impl.DefaultContext;
 import org.vertx.java.core.impl.DefaultFutureResult;
+import org.vertx.java.core.impl.NettySupport;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.net.impl.PartialPooledByteBufAllocator;
 
@@ -58,7 +58,7 @@ public final class DefaultDnsClient implements DnsClient {
     this.vertx = vertx;
     bootstrap = new Bootstrap();
     bootstrap.group(actualCtx.getEventLoop());
-    bootstrap.channel(NioDatagramChannel.class);
+    bootstrap.channel(NettySupport.datagramChannel());
     bootstrap.option(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
     bootstrap.handler(new ChannelInitializer<DatagramChannel>() {
       @Override

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpClient.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpContentDecompressor;
@@ -48,6 +47,7 @@ import org.vertx.java.core.http.impl.ws.WebSocketFrameInternal;
 import org.vertx.java.core.impl.Closeable;
 import org.vertx.java.core.impl.DefaultContext;
 import org.vertx.java.core.impl.DefaultFutureResult;
+import org.vertx.java.core.impl.NettySupport;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.net.NetSocket;
 import org.vertx.java.core.net.impl.TCPSSLHelper;
@@ -721,7 +721,7 @@ public class DefaultHttpClient implements HttpClient {
       pool.addWorker(actualCtx.getEventLoop());
       bootstrap = new Bootstrap();
       bootstrap.group(pool);
-      bootstrap.channel(NioSocketChannel.class);
+      bootstrap.channel(NettySupport.channel());
       tcpHelper.checkSSL(vertx);
 
       bootstrap.handler(new ChannelInitializer<Channel>() {

--- a/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/http/impl/DefaultHttpServer.java
@@ -28,7 +28,6 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.ChannelGroupFutureListener;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -60,6 +59,7 @@ import org.vertx.java.core.http.impl.ws.WebSocketFrameInternal;
 import org.vertx.java.core.impl.Closeable;
 import org.vertx.java.core.impl.DefaultContext;
 import org.vertx.java.core.impl.DefaultFutureResult;
+import org.vertx.java.core.impl.NettySupport;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
@@ -184,7 +184,7 @@ public class DefaultHttpServer implements HttpServer, Closeable {
         serverChannelGroup = new DefaultChannelGroup("vertx-acceptor-channels", GlobalEventExecutor.INSTANCE);
         ServerBootstrap bootstrap = new ServerBootstrap();
         bootstrap.group(availableWorkers);
-        bootstrap.channel(NioServerSocketChannel.class);
+        bootstrap.channel(NettySupport.serverChannel());
         tcpHelper.applyConnectionOptions(bootstrap);
         tcpHelper.checkSSL(vertx);
         bootstrap.childHandler(new ChannelInitializer<Channel>() {

--- a/vertx-core/src/main/java/org/vertx/java/core/impl/VertxExecutorFactory.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/impl/VertxExecutorFactory.java
@@ -16,7 +16,6 @@
 package org.vertx.java.core.impl;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import org.vertx.java.core.impl.management.ManagementRegistry;
 
 import java.util.concurrent.ExecutorService;
@@ -49,7 +48,7 @@ public class VertxExecutorFactory {
   // The acceptor pools need to be fixed with a backing queue
 
   public static EventLoopGroup eventLoopGroup(String poolName) {
-    return new NioEventLoopGroup(eventLoopSize(), new VertxThreadFactory(poolName));
+    return NettySupport.eventLoopGroup(eventLoopSize(), new VertxThreadFactory(poolName));
   }
 
   public static int eventLoopSize() {

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetClient.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetClient.java
@@ -18,7 +18,6 @@ package org.vertx.java.core.net.impl;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.Future;
@@ -28,6 +27,7 @@ import org.vertx.java.core.Handler;
 import org.vertx.java.core.impl.Closeable;
 import org.vertx.java.core.impl.DefaultContext;
 import org.vertx.java.core.impl.DefaultFutureResult;
+import org.vertx.java.core.impl.NettySupport;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
@@ -318,7 +318,7 @@ public class DefaultNetClient implements NetClient {
 
       bootstrap = new Bootstrap();
       bootstrap.group(actualCtx.getEventLoop());
-      bootstrap.channel(NioSocketChannel.class);
+      bootstrap.channel(NettySupport.channel());
       bootstrap.handler(new ChannelInitializer<Channel>() {
         @Override
         protected void initChannel(Channel ch) throws Exception {

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetServer.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/DefaultNetServer.java
@@ -23,7 +23,6 @@ import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.ChannelGroupFutureListener;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.Future;
@@ -35,6 +34,7 @@ import org.vertx.java.core.VoidHandler;
 import org.vertx.java.core.impl.Closeable;
 import org.vertx.java.core.impl.DefaultContext;
 import org.vertx.java.core.impl.DefaultFutureResult;
+import org.vertx.java.core.impl.NettySupport;
 import org.vertx.java.core.impl.VertxInternal;
 import org.vertx.java.core.logging.Logger;
 import org.vertx.java.core.logging.impl.LoggerFactory;
@@ -118,7 +118,7 @@ public class DefaultNetServer implements NetServer, Closeable {
 
         ServerBootstrap bootstrap = new ServerBootstrap();
         bootstrap.group(availableWorkers);
-        bootstrap.channel(NioServerSocketChannel.class);
+        bootstrap.channel(NettySupport.serverChannel());
         tcpHelper.checkSSL(vertx);
 
         bootstrap.childHandler(new ChannelInitializer<Channel>() {


### PR DESCRIPTION
Use a NettySupport helper to use Epoll based implementations if available.
