### PR TITLE
Add the number of default event loop threads created by Vert.x

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -362,9 +362,10 @@ with respect to concurrency, scaling and deployment.
 
 To use this model, you write your code as set of *verticles*.
 
-Verticles are chunks of code that get deployed and
-run by Vert.x. Verticles can be written in any of the languages that Vert.x supports and a single application
-can include verticles written in multiple languages.
+Verticles are chunks of code that get deployed and run by Vert.x. Vert.x will create N event loops threads
+(where N by default is core*2) by default. When you deploy a verticle,
+it will be deployed on one of theses event loops. Verticles can be written in any of the languages that Vert.x supports
+and a single application can include verticles written in multiple languages.
 
 You can think of a verticle as a bit like an actor in the http://en.wikipedia.org/wiki/Actor_model[Actor Model].
 


### PR DESCRIPTION
It was very weird to notice that in production with a machine having a lot of cores that I got many java threads (which does not occur in development with less cores).