### PR TITLE
Add number of NIO loops created by Vert.x in the documentation.

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -362,8 +362,9 @@ with respect to concurrency, scaling and deployment.
 
 To use this model, you write your code as set of *verticles*.
 
-Verticles are chunks of code that get deployed and run by Vert.x. A Vert.x instance maintains N event loop threads
-(where N by default is core*2) by default. Verticles can be written in any of the languages that Vert.x supports
+Verticles are chunks of code that get deployed and run by Vert.x. Vert.x will create N event loops threads
+(where N by default is core*2) by default. When you deploy a verticle,
+it will be deployed on one of theses event loops. Verticles can be written in any of the languages that Vert.x supports
 and a single application can include verticles written in multiple languages.
 
 You can think of a verticle as a bit like an actor in the http://en.wikipedia.org/wiki/Actor_model[Actor Model].

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -362,10 +362,9 @@ with respect to concurrency, scaling and deployment.
 
 To use this model, you write your code as set of *verticles*.
 
-Verticles are chunks of code that get deployed and run by Vert.x. Vert.x will create N event loops threads
-(where N by default is core*2) by default. When you deploy a verticle,
-it will be deployed on one of theses event loops. Verticles can be written in any of the languages that Vert.x supports
-and a single application can include verticles written in multiple languages.
+Verticles are chunks of code that get deployed and
+run by Vert.x. Verticles can be written in any of the languages that Vert.x supports and a single application
+can include verticles written in multiple languages.
 
 You can think of a verticle as a bit like an actor in the http://en.wikipedia.org/wiki/Actor_model[Actor Model].
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -362,9 +362,10 @@ with respect to concurrency, scaling and deployment.
 
 To use this model, you write your code as set of *verticles*.
 
-Verticles are chunks of code that get deployed and
-run by Vert.x. Verticles can be written in any of the languages that Vert.x supports and a single application
-can include verticles written in multiple languages.
+Verticles are chunks of code that get deployed and run by Vert.x. Vert.x will create N event loops threads
+(where N by default is core*2) by default. When you deploy a verticle,
+it will be deployed on one of theses event loops. Verticles can be written in any of the languages that Vert.x supports
+and a single application can include verticles written in multiple languages.
 
 You can think of a verticle as a bit like an actor in the http://en.wikipedia.org/wiki/Actor_model[Actor Model].
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -362,9 +362,8 @@ with respect to concurrency, scaling and deployment.
 
 To use this model, you write your code as set of *verticles*.
 
-Verticles are chunks of code that get deployed and run by Vert.x. Vert.x will create N event loops threads
-(where N by default is core*2) by default. When you deploy a verticle,
-it will be deployed on one of theses event loops. Verticles can be written in any of the languages that Vert.x supports
+Verticles are chunks of code that get deployed and run by Vert.x. A Vert.x instance maintains N event loop threads
+(where N by default is core*2) by default. Verticles can be written in any of the languages that Vert.x supports
 and a single application can include verticles written in multiple languages.
 
 You can think of a verticle as a bit like an actor in the http://en.wikipedia.org/wiki/Actor_model[Actor Model].

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -333,9 +333,9 @@
  *
  * To use this model, you write your code as set of *verticles*.
  *
- * Verticles are chunks of code that get deployed and
- * run by Vert.x. Verticles can be written in any of the languages that Vert.x supports and a single application
- * can include verticles written in multiple languages.
+ * Verticles are chunks of code that get deployed and run by Vert.x. A Vert.x instance maintains N event loop threads
+ * (where N by default is core*2) by default. Verticles can be written in any of the languages that Vert.x supports
+ * and a single application can include verticles written in multiple languages.
  *
  * You can think of a verticle as a bit like an actor in the http://en.wikipedia.org/wiki/Actor_model[Actor Model].
  *


### PR DESCRIPTION
I was very weird to noticed in production to have a lot of eventloop threads. I did not noticed that in development because I have less cores. It should be written in documentation to avoid WTF moments :).

Signed-off-by: Guillaume Charhon <guillaume@databerries.com>