### PR TITLE
Handle Netty Http Decoder failures

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -276,7 +276,11 @@ class ClientConnection extends ConnectionBase {
     }
     HttpClientResponseImpl nResp = new HttpClientResponseImpl(requestForResponse, this, resp);
     currentResponse = nResp;
-    requestForResponse.handleResponse(nResp);
+    if(resp.getDecoderResult().isFailure()) {
+      handleException(resp.getDecoderResult().cause());
+    } else {
+      requestForResponse.handleResponse(nResp);
+    }
   }
 
   void handleResponseChunk(Buffer buff) {


### PR DESCRIPTION
Vert.X does not handle the Netty Decoder result, do for exemple when an HttpClientResponse headers contains more than 8192 bytes of data the response is handled normally but no data is sent to the attached handler and the request is "frozen" (endHandler not called, exception not thrown).