### PR TITLE
Use LinkedHashMap in copy() to preserve key ordering.

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -694,7 +694,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    * @return a copy of the object
    */
   public JsonObject copy() {
-    Map<String, Object> copiedMap = new HashMap<>(map.size());
+    Map<String, Object> copiedMap = new LinkedHashMap<>(map.size());
     for (Map.Entry<String, Object> entry: map.entrySet()) {
       Object val = entry.getValue();
       val = Json.checkAndCopy(val, true);


### PR DESCRIPTION
Right now we're losing key ordering when the JsonObject is copied (for instance when communicating on the event bus). LinkedHashMap should be used to maintain key ordering. It's a tiny change. :)