### PR TITLE
Deserialize JsonObject in a JsonArray consistently when clustered

### DIFF
--- a/src/test/java/io/vertx/test/core/JsonArrayTest.java
+++ b/src/test/java/io/vertx/test/core/JsonArrayTest.java
@@ -1029,12 +1029,14 @@ public class JsonArrayTest {
 
   @Test
   public void testClusterSerializable() {
-    jsonArray.add("foo").add(123);
+    JsonObject obj = new JsonObject().put("quux", "wibble");
+    jsonArray.add("foo").add(123).add(obj);
     Buffer buff = Buffer.buffer();
     jsonArray.writeToBuffer(buff);
     JsonArray deserialized = new JsonArray();
     deserialized.readFromBuffer(0, buff);
     assertEquals(jsonArray, deserialized);
+    assertEquals(obj, deserialized.getList().get(2));
   }
 
   @Test


### PR DESCRIPTION
This appears to solve [issue 1349](https://github.com/eclipse/vert.x/issues/1349) but I am not sure if this is the most elegant solution to the problem.

Running the test with the first commit shows the issue of the `JsonObject` turning into a `LinkedHashMap` after deserialization.

The fix explicitly creates a JsonObject when we get an untyped object on deserialization. All other paths fallback to the existing default behavior using the `UntypedObjectDeserializer.deserialize`.
