### PR TITLE
Fixed SLF4JLogDelegateTest on windows platform due to CR/LF inconsistency

### DIFF
--- a/src/test/java/io/vertx/core/logging/SLF4JLogDelegateTest.java
+++ b/src/test/java/io/vertx/core/logging/SLF4JLogDelegateTest.java
@@ -39,6 +39,7 @@ import static junit.framework.TestCase.assertEquals;
  */
 public class SLF4JLogDelegateTest {
 
+  public static final String LINE_SEPARATOR = System.lineSeparator();
 
   @BeforeClass
   public static void initialize() throws IOException {
@@ -56,30 +57,30 @@ public class SLF4JLogDelegateTest {
     Logger logger = LoggerFactory.getLogger("my-slf4j-logger");
 
     String result = record(() -> logger.info("hello"));
-    assertEquals("[main] INFO my-slf4j-logger - hello\n", result);
+    assertEquals("[main] INFO my-slf4j-logger - hello"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.info("exception", new NullPointerException()));
-    assertTrue(result.contains("[main] INFO my-slf4j-logger - exception\n"));
+    assertTrue(result.contains("[main] INFO my-slf4j-logger - exception"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.NullPointerException"));
 
     result = record(() -> logger.info("hello {} and {}", "Paulo", "Julien"));
-    assertEquals("[main] INFO my-slf4j-logger - hello Paulo and Julien\n", result);
+    assertEquals("[main] INFO my-slf4j-logger - hello Paulo and Julien"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.info("hello {}", "vert.x"));
-    assertEquals("[main] INFO my-slf4j-logger - hello vert.x\n", result);
+    assertEquals("[main] INFO my-slf4j-logger - hello vert.x"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.info("hello {} - {}", "vert.x"));
-    assertEquals("[main] INFO my-slf4j-logger - hello vert.x - {}\n", result);
+    assertEquals("[main] INFO my-slf4j-logger - hello vert.x - {}"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.info("hello {}", "vert.x", "foo"));
-    assertEquals("[main] INFO my-slf4j-logger - hello vert.x\n", result);
+    assertEquals("[main] INFO my-slf4j-logger - hello vert.x"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.info("{}, an exception has been thrown", new IllegalStateException(), "Luke"));
-    assertTrue(result.contains("[main] INFO my-slf4j-logger - Luke, an exception has been thrown\n"));
+    assertTrue(result.contains("[main] INFO my-slf4j-logger - Luke, an exception has been thrown"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.IllegalStateException"));
 
     result = record(() -> logger.info("{}, an exception has been thrown", "Luke", new IllegalStateException()));
-    assertTrue(result.contains("[main] INFO my-slf4j-logger - Luke, an exception has been thrown\n"));
+    assertTrue(result.contains("[main] INFO my-slf4j-logger - Luke, an exception has been thrown"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.IllegalStateException"));
   }
 
@@ -87,30 +88,30 @@ public class SLF4JLogDelegateTest {
   public void testError() {
     Logger logger = LoggerFactory.getLogger("my-slf4j-logger");
     String result = record(() -> logger.error("hello"));
-    assertEquals("[main] ERROR my-slf4j-logger - hello\n", result);
+    assertEquals("[main] ERROR my-slf4j-logger - hello"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.error("exception", new NullPointerException()));
-    assertTrue(result.contains("[main] ERROR my-slf4j-logger - exception\n"));
+    assertTrue(result.contains("[main] ERROR my-slf4j-logger - exception"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.NullPointerException"));
 
     result = record(() -> logger.error("hello {} and {}", "Paulo", "Julien"));
-    assertEquals("[main] ERROR my-slf4j-logger - hello Paulo and Julien\n", result);
+    assertEquals("[main] ERROR my-slf4j-logger - hello Paulo and Julien"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.error("hello {}", "vert.x"));
-    assertEquals("[main] ERROR my-slf4j-logger - hello vert.x\n", result);
+    assertEquals("[main] ERROR my-slf4j-logger - hello vert.x"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.error("hello {} - {}", "vert.x"));
-    assertEquals("[main] ERROR my-slf4j-logger - hello vert.x - {}\n", result);
+    assertEquals("[main] ERROR my-slf4j-logger - hello vert.x - {}"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.error("hello {}", "vert.x", "foo"));
-    assertEquals("[main] ERROR my-slf4j-logger - hello vert.x\n", result);
+    assertEquals("[main] ERROR my-slf4j-logger - hello vert.x"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.error("{}, an exception has been thrown", new IllegalStateException(), "Luke"));
-    assertTrue(result.contains("[main] ERROR my-slf4j-logger - Luke, an exception has been thrown\n"));
+    assertTrue(result.contains("[main] ERROR my-slf4j-logger - Luke, an exception has been thrown"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.IllegalStateException"));
 
     result = record(() -> logger.error("{}, an exception has been thrown", "Luke", new IllegalStateException()));
-    assertTrue(result.contains("[main] ERROR my-slf4j-logger - Luke, an exception has been thrown\n"));
+    assertTrue(result.contains("[main] ERROR my-slf4j-logger - Luke, an exception has been thrown"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.IllegalStateException"));
   }
 
@@ -119,30 +120,30 @@ public class SLF4JLogDelegateTest {
     Logger logger = LoggerFactory.getLogger("my-slf4j-logger");
 
     String result = record(() -> logger.warn("hello"));
-    assertEquals("[main] WARN my-slf4j-logger - hello\n", result);
+    assertEquals("[main] WARN my-slf4j-logger - hello"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.warn("exception", new NullPointerException()));
-    assertTrue(result.contains("[main] WARN my-slf4j-logger - exception\n"));
+    assertTrue(result.contains("[main] WARN my-slf4j-logger - exception"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.NullPointerException"));
 
     result = record(() -> logger.warn("hello {} and {}", "Paulo", "Julien"));
-    assertEquals("[main] WARN my-slf4j-logger - hello Paulo and Julien\n", result);
+    assertEquals("[main] WARN my-slf4j-logger - hello Paulo and Julien"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.warn("hello {}", "vert.x"));
-    assertEquals("[main] WARN my-slf4j-logger - hello vert.x\n", result);
+    assertEquals("[main] WARN my-slf4j-logger - hello vert.x"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.warn("hello {} - {}", "vert.x"));
-    assertEquals("[main] WARN my-slf4j-logger - hello vert.x - {}\n", result);
+    assertEquals("[main] WARN my-slf4j-logger - hello vert.x - {}"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.warn("hello {}", "vert.x", "foo"));
-    assertEquals("[main] WARN my-slf4j-logger - hello vert.x\n", result);
+    assertEquals("[main] WARN my-slf4j-logger - hello vert.x"+ LINE_SEPARATOR, result);
 
     result = record(() -> logger.warn("{}, an exception has been thrown", new IllegalStateException(), "Luke"));
-    assertTrue(result.contains("[main] WARN my-slf4j-logger - Luke, an exception has been thrown\n"));
+    assertTrue(result.contains("[main] WARN my-slf4j-logger - Luke, an exception has been thrown"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.IllegalStateException"));
 
     result = record(() -> logger.warn("{}, an exception has been thrown", "Luke", new IllegalStateException()));
-    assertTrue(result.contains("[main] WARN my-slf4j-logger - Luke, an exception has been thrown\n"));
+    assertTrue(result.contains("[main] WARN my-slf4j-logger - Luke, an exception has been thrown"+ LINE_SEPARATOR));
     assertTrue(result.contains("java.lang.IllegalStateException"));
   }
 


### PR DESCRIPTION
Logger tests was failing on windows platform. Error with line end characters.