### PR TITLE
Extend Launcher documentation when `CLASSPATH` is set

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,30 @@
 = Cheatsheets
 
+[[DeliveryOptions]]
+== DeliveryOptions
+
+++++
+ Delivery options are used to configure message delivery.
+ <p>
+ Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
+ that you wish to send with the message.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[codecName]]`codecName`|`String`|
++++
+Set the codec name.
++++
+|[[sendTimeout]]`sendTimeout`|`Number (long)`|
++++
+Set the send timeout.
++++
+|===
+
 [[NetworkOptions]]
 == NetworkOptions
 
@@ -27,31 +52,6 @@ Set the TCP send buffer size
 |[[trafficClass]]`trafficClass`|`Number (int)`|
 +++
 Set the value of traffic class
-+++
-|===
-
-[[DeliveryOptions]]
-== DeliveryOptions
-
-++++
- Delivery options are used to configure message delivery.
- <p>
- Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
- that you wish to send with the message.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[codecName]]`codecName`|`String`|
-+++
-Set the codec name.
-+++
-|[[sendTimeout]]`sendTimeout`|`Number (long)`|
-+++
-Set the send timeout.
 +++
 |===
 
@@ -626,25 +626,6 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
-[[MetricsOptions]]
-== MetricsOptions
-
-++++
- Vert.x metrics base configuration, this class can be extended by provider implementations to configure
- those specific implementations.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[enabled]]`enabled`|`Boolean`|
-+++
-Set whether metrics will be enabled on the Vert.x instance.
-+++
-|===
-
 [[ClientOptionsBase]]
 == ClientOptionsBase
 
@@ -741,6 +722,25 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|===
+
+[[MetricsOptions]]
+== MetricsOptions
+
+++++
+ Vert.x metrics base configuration, this class can be extended by provider implementations to configure
+ those specific implementations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`enabled`|`Boolean`|
++++
+Set whether metrics will be enabled on the Vert.x instance.
 +++
 |===
 
@@ -1002,6 +1002,200 @@ Set the websocket subprotocols supported by the server.
 +++
 |===
 
+[[HttpClientOptions]]
+== HttpClientOptions
+
+++++
+ Options describing how an link will make connections.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[connectTimeout]]`connectTimeout`|`Number (int)`|
++++
+Set the connect timeout
++++
+|[[crlPaths]]`crlPaths`|`Array of String`|
++++
+Add a CRL path
++++
+|[[crlValues]]`crlValues`|`Array of Buffer`|
++++
+Add a CRL value
++++
+|[[defaultHost]]`defaultHost`|`String`|
++++
+Set the default host name to be used by this client in requests if none is provided when making the request.
++++
+|[[defaultPort]]`defaultPort`|`Number (int)`|
++++
+Set the default port to be used by this client in requests if none is provided when making the request.
++++
+|[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
++++
+Add an enabled cipher suite
++++
+|[[idleTimeout]]`idleTimeout`|`Number (int)`|
++++
+Set the idle timeout, in seconds. zero means don't timeout.
+ This determines if a connection will timeout and be closed if no data is received within the timeout.
++++
+|[[keepAlive]]`keepAlive`|`Boolean`|
++++
+Set whether keep alive is enabled on the client
++++
+|[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
++++
+Set the key/cert options in jks format, aka Java keystore.
++++
+|[[maxChunkSize]]`maxChunkSize`|`Number (int)`|
++++
+Set the maximum HTTP chunk size
++++
+|[[maxPoolSize]]`maxPoolSize`|`Number (int)`|
++++
+Set the maximum pool size for connections
++++
+|[[maxWaitQueueSize]]`maxWaitQueueSize`|`Number (int)`|
++++
+Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in
+ a ConnectionPoolTooBusyException.  If the value is set to a negative number then the queue will be unbounded.
++++
+|[[maxWebsocketFrameSize]]`maxWebsocketFrameSize`|`Number (int)`|
++++
+Set the max websocket frame size
++++
+|[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|
++++
+Set the key/cert store options in pem format.
++++
+|[[pemTrustOptions]]`pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|
++++
+Set the trust options in pem format
++++
+|[[pfxKeyCertOptions]]`pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
++++
+Set the key/cert options in pfx format.
++++
+|[[pfxTrustOptions]]`pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
++++
+Set the trust options in pfx format
++++
+|[[pipelining]]`pipelining`|`Boolean`|
++++
+Set whether pipe-lining is enabled on the client
++++
+|[[protocolVersion]]`protocolVersion`|`link:enums.html#HttpVersion[HttpVersion]`|
++++
+Set the protocol version.
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[soLinger]]`soLinger`|`Number (int)`|
++++
+Set whether SO_linger keep alive is enabled
++++
+|[[ssl]]`ssl`|`Boolean`|
++++
+Set whether SSL/TLS is enabled
++++
+|[[tcpKeepAlive]]`tcpKeepAlive`|`Boolean`|
++++
+Set whether TCP keep alive is enabled
++++
+|[[tcpNoDelay]]`tcpNoDelay`|`Boolean`|
++++
+Set whether TCP no delay is enabled
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
++++
+|[[trustAll]]`trustAll`|`Boolean`|
++++
+Set whether all server certificates should be trusted
++++
+|[[trustStoreOptions]]`trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
++++
+Set the trust options in jks format, aka Java trustore
++++
+|[[tryUseCompression]]`tryUseCompression`|`Boolean`|
++++
+Set whether compression is enabled
++++
+|[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
++++
+Set whether Netty pooled buffers are enabled
++++
+|[[verifyHost]]`verifyHost`|`Boolean`|
++++
+Set whether hostname verification is enabled
++++
+|===
+
+[[DatagramSocketOptions]]
+== DatagramSocketOptions
+
+++++
+ Options used to configure a datagram socket.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[broadcast]]`broadcast`|`Boolean`|
++++
+Set if the socket can receive broadcast packets
++++
+|[[ipV6]]`ipV6`|`Boolean`|
++++
+Set if IP v6 should be used
++++
+|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
++++
+Set if loopback mode is disabled
++++
+|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
++++
+Set the multicast network interface address
++++
+|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
++++
+Set the multicast ttl value
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
++++
+|===
+
 [[EventBusOptions]]
 == EventBusOptions
 
@@ -1148,200 +1342,6 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
-+++
-|===
-
-[[DatagramSocketOptions]]
-== DatagramSocketOptions
-
-++++
- Options used to configure a datagram socket.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[broadcast]]`broadcast`|`Boolean`|
-+++
-Set if the socket can receive broadcast packets
-+++
-|[[ipV6]]`ipV6`|`Boolean`|
-+++
-Set if IP v6 should be used
-+++
-|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
-+++
-Set if loopback mode is disabled
-+++
-|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
-+++
-Set the multicast network interface address
-+++
-|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
-+++
-Set the multicast ttl value
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
-+++
-|===
-
-[[HttpClientOptions]]
-== HttpClientOptions
-
-++++
- Options describing how an link will make connections.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[connectTimeout]]`connectTimeout`|`Number (int)`|
-+++
-Set the connect timeout
-+++
-|[[crlPaths]]`crlPaths`|`Array of String`|
-+++
-Add a CRL path
-+++
-|[[crlValues]]`crlValues`|`Array of Buffer`|
-+++
-Add a CRL value
-+++
-|[[defaultHost]]`defaultHost`|`String`|
-+++
-Set the default host name to be used by this client in requests if none is provided when making the request.
-+++
-|[[defaultPort]]`defaultPort`|`Number (int)`|
-+++
-Set the default port to be used by this client in requests if none is provided when making the request.
-+++
-|[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
-+++
-Add an enabled cipher suite
-+++
-|[[idleTimeout]]`idleTimeout`|`Number (int)`|
-+++
-Set the idle timeout, in seconds. zero means don't timeout.
- This determines if a connection will timeout and be closed if no data is received within the timeout.
-+++
-|[[keepAlive]]`keepAlive`|`Boolean`|
-+++
-Set whether keep alive is enabled on the client
-+++
-|[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
-+++
-Set the key/cert options in jks format, aka Java keystore.
-+++
-|[[maxChunkSize]]`maxChunkSize`|`Number (int)`|
-+++
-Set the maximum HTTP chunk size
-+++
-|[[maxPoolSize]]`maxPoolSize`|`Number (int)`|
-+++
-Set the maximum pool size for connections
-+++
-|[[maxWaitQueueSize]]`maxWaitQueueSize`|`Number (int)`|
-+++
-Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in
- a ConnectionPoolTooBusyException.  If the value is set to a negative number then the queue will be unbounded.
-+++
-|[[maxWebsocketFrameSize]]`maxWebsocketFrameSize`|`Number (int)`|
-+++
-Set the max websocket frame size
-+++
-|[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|
-+++
-Set the key/cert store options in pem format.
-+++
-|[[pemTrustOptions]]`pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|
-+++
-Set the trust options in pem format
-+++
-|[[pfxKeyCertOptions]]`pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
-+++
-Set the key/cert options in pfx format.
-+++
-|[[pfxTrustOptions]]`pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
-+++
-Set the trust options in pfx format
-+++
-|[[pipelining]]`pipelining`|`Boolean`|
-+++
-Set whether pipe-lining is enabled on the client
-+++
-|[[protocolVersion]]`protocolVersion`|`link:enums.html#HttpVersion[HttpVersion]`|
-+++
-Set the protocol version.
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[soLinger]]`soLinger`|`Number (int)`|
-+++
-Set whether SO_linger keep alive is enabled
-+++
-|[[ssl]]`ssl`|`Boolean`|
-+++
-Set whether SSL/TLS is enabled
-+++
-|[[tcpKeepAlive]]`tcpKeepAlive`|`Boolean`|
-+++
-Set whether TCP keep alive is enabled
-+++
-|[[tcpNoDelay]]`tcpNoDelay`|`Boolean`|
-+++
-Set whether TCP no delay is enabled
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
-+++
-|[[trustAll]]`trustAll`|`Boolean`|
-+++
-Set whether all server certificates should be trusted
-+++
-|[[trustStoreOptions]]`trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
-+++
-Set the trust options in jks format, aka Java trustore
-+++
-|[[tryUseCompression]]`tryUseCompression`|`Boolean`|
-+++
-Set whether compression is enabled
-+++
-|[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
-+++
-Set whether Netty pooled buffers are enabled
-+++
-|[[verifyHost]]`verifyHost`|`Boolean`|
-+++
-Set whether hostname verification is enabled
 +++
 |===
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1079,6 +1079,10 @@ The `start`, `stop` and `list` command are also available from the `vertx` tool.
 
  If option values contain spaces, don't forget to wrap the value between `""` (double-quotes).
 
+ As the `start` command spawns a new process, the java options passed to the JVM are not propagated, so you **must**
+ use `java-opts` to configure the JVM (`-X`, `-D`...). If you use the `CLASSPATH` environment variable, be sure it
+ contains all the required jars (vertx-core, your jars and all the dependencies).
+
 The set of commands is extensible, refer to the <<Extending the vert.x Launcher>> section.
 
 === Live Redeploy

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1003,6 +1003,10 @@
  *
  *  If option values contain spaces, don't forget to wrap the value between {@code ""} (double-quotes).
  *
+ *  As the `start` command spawns a new process, the java options passed to the JVM are not propagated, so you **must**
+ *  use `java-opts` to configure the JVM (`-X`, `-D`...). If you use the `CLASSPATH` environment variable, be sure it
+ *  contains all the required jars (vertx-core, your jars and all the dependencies).
+ *
  * The set of commands is extensible, refer to the <<Extending the vert.x Launcher>> section.
  *
  * === Live Redeploy

--- a/src/test/asciidoc/dataobjects.adoc
+++ b/src/test/asciidoc/dataobjects.adoc
@@ -30,21 +30,6 @@
 ^|Name | Type ^| Description
 |===
 
-[[ParentDataObject]]
-== ParentDataObject
-
-++++
- @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[parentProperty]]`parentProperty`|`String`|-
-|===
-
 [[TestDataObject]]
 == TestDataObject
 
@@ -120,6 +105,21 @@
 |[[stringValue]]`stringValue`|`String`|-
 |[[stringValueMap]]`stringValueMap`|`String`|-
 |[[stringValues]]`stringValues`|`Array of String`|-
+|===
+
+[[ParentDataObject]]
+== ParentDataObject
+
+++++
+ @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[parentProperty]]`parentProperty`|`String`|-
 |===
 
 [[AggregatedDataObject]]


### PR DESCRIPTION
Fix issue reported in https://github.com/vert-x3/issues/issues/104

Extend Launcher documentation to indicate that the `CLASSPATH` env var (if set) must contain vert.x core.