### PR TITLE
Support command set in the manifest without main verticle.

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,30 @@
 = Cheatsheets
 
+[[DeliveryOptions]]
+== DeliveryOptions
+
+++++
+ Delivery options are used to configure message delivery.
+ <p>
+ Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
+ that you wish to send with the message.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[codecName]]`codecName`|`String`|
++++
+Set the codec name.
++++
+|[[sendTimeout]]`sendTimeout`|`Number (long)`|
++++
+Set the send timeout.
++++
+|===
+
 [[NetworkOptions]]
 == NetworkOptions
 
@@ -27,31 +52,6 @@ Set the TCP send buffer size
 |[[trafficClass]]`trafficClass`|`Number (int)`|
 +++
 Set the value of traffic class
-+++
-|===
-
-[[DeliveryOptions]]
-== DeliveryOptions
-
-++++
- Delivery options are used to configure message delivery.
- <p>
- Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
- that you wish to send with the message.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[codecName]]`codecName`|`String`|
-+++
-Set the codec name.
-+++
-|[[sendTimeout]]`sendTimeout`|`Number (long)`|
-+++
-Set the send timeout.
 +++
 |===
 
@@ -626,25 +626,6 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
-[[MetricsOptions]]
-== MetricsOptions
-
-++++
- Vert.x metrics base configuration, this class can be extended by provider implementations to configure
- those specific implementations.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[enabled]]`enabled`|`Boolean`|
-+++
-Set whether metrics will be enabled on the Vert.x instance.
-+++
-|===
-
 [[ClientOptionsBase]]
 == ClientOptionsBase
 
@@ -741,6 +722,25 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|===
+
+[[MetricsOptions]]
+== MetricsOptions
+
+++++
+ Vert.x metrics base configuration, this class can be extended by provider implementations to configure
+ those specific implementations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`enabled`|`Boolean`|
++++
+Set whether metrics will be enabled on the Vert.x instance.
 +++
 |===
 
@@ -1002,6 +1002,200 @@ Set the websocket subprotocols supported by the server.
 +++
 |===
 
+[[HttpClientOptions]]
+== HttpClientOptions
+
+++++
+ Options describing how an link will make connections.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[connectTimeout]]`connectTimeout`|`Number (int)`|
++++
+Set the connect timeout
++++
+|[[crlPaths]]`crlPaths`|`Array of String`|
++++
+Add a CRL path
++++
+|[[crlValues]]`crlValues`|`Array of Buffer`|
++++
+Add a CRL value
++++
+|[[defaultHost]]`defaultHost`|`String`|
++++
+Set the default host name to be used by this client in requests if none is provided when making the request.
++++
+|[[defaultPort]]`defaultPort`|`Number (int)`|
++++
+Set the default port to be used by this client in requests if none is provided when making the request.
++++
+|[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
++++
+Add an enabled cipher suite
++++
+|[[idleTimeout]]`idleTimeout`|`Number (int)`|
++++
+Set the idle timeout, in seconds. zero means don't timeout.
+ This determines if a connection will timeout and be closed if no data is received within the timeout.
++++
+|[[keepAlive]]`keepAlive`|`Boolean`|
++++
+Set whether keep alive is enabled on the client
++++
+|[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
++++
+Set the key/cert options in jks format, aka Java keystore.
++++
+|[[maxChunkSize]]`maxChunkSize`|`Number (int)`|
++++
+Set the maximum HTTP chunk size
++++
+|[[maxPoolSize]]`maxPoolSize`|`Number (int)`|
++++
+Set the maximum pool size for connections
++++
+|[[maxWaitQueueSize]]`maxWaitQueueSize`|`Number (int)`|
++++
+Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in
+ a ConnectionPoolTooBusyException.  If the value is set to a negative number then the queue will be unbounded.
++++
+|[[maxWebsocketFrameSize]]`maxWebsocketFrameSize`|`Number (int)`|
++++
+Set the max websocket frame size
++++
+|[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|
++++
+Set the key/cert store options in pem format.
++++
+|[[pemTrustOptions]]`pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|
++++
+Set the trust options in pem format
++++
+|[[pfxKeyCertOptions]]`pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
++++
+Set the key/cert options in pfx format.
++++
+|[[pfxTrustOptions]]`pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
++++
+Set the trust options in pfx format
++++
+|[[pipelining]]`pipelining`|`Boolean`|
++++
+Set whether pipe-lining is enabled on the client
++++
+|[[protocolVersion]]`protocolVersion`|`link:enums.html#HttpVersion[HttpVersion]`|
++++
+Set the protocol version.
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[soLinger]]`soLinger`|`Number (int)`|
++++
+Set whether SO_linger keep alive is enabled
++++
+|[[ssl]]`ssl`|`Boolean`|
++++
+Set whether SSL/TLS is enabled
++++
+|[[tcpKeepAlive]]`tcpKeepAlive`|`Boolean`|
++++
+Set whether TCP keep alive is enabled
++++
+|[[tcpNoDelay]]`tcpNoDelay`|`Boolean`|
++++
+Set whether TCP no delay is enabled
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
++++
+|[[trustAll]]`trustAll`|`Boolean`|
++++
+Set whether all server certificates should be trusted
++++
+|[[trustStoreOptions]]`trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
++++
+Set the trust options in jks format, aka Java trustore
++++
+|[[tryUseCompression]]`tryUseCompression`|`Boolean`|
++++
+Set whether compression is enabled
++++
+|[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
++++
+Set whether Netty pooled buffers are enabled
++++
+|[[verifyHost]]`verifyHost`|`Boolean`|
++++
+Set whether hostname verification is enabled
++++
+|===
+
+[[DatagramSocketOptions]]
+== DatagramSocketOptions
+
+++++
+ Options used to configure a datagram socket.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[broadcast]]`broadcast`|`Boolean`|
++++
+Set if the socket can receive broadcast packets
++++
+|[[ipV6]]`ipV6`|`Boolean`|
++++
+Set if IP v6 should be used
++++
+|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
++++
+Set if loopback mode is disabled
++++
+|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
++++
+Set the multicast network interface address
++++
+|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
++++
+Set the multicast ttl value
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
++++
+|===
+
 [[EventBusOptions]]
 == EventBusOptions
 
@@ -1148,200 +1342,6 @@ Set the trust options in jks format, aka Java trustore
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
-+++
-|===
-
-[[DatagramSocketOptions]]
-== DatagramSocketOptions
-
-++++
- Options used to configure a datagram socket.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[broadcast]]`broadcast`|`Boolean`|
-+++
-Set if the socket can receive broadcast packets
-+++
-|[[ipV6]]`ipV6`|`Boolean`|
-+++
-Set if IP v6 should be used
-+++
-|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
-+++
-Set if loopback mode is disabled
-+++
-|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
-+++
-Set the multicast network interface address
-+++
-|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
-+++
-Set the multicast ttl value
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
-+++
-|===
-
-[[HttpClientOptions]]
-== HttpClientOptions
-
-++++
- Options describing how an link will make connections.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[connectTimeout]]`connectTimeout`|`Number (int)`|
-+++
-Set the connect timeout
-+++
-|[[crlPaths]]`crlPaths`|`Array of String`|
-+++
-Add a CRL path
-+++
-|[[crlValues]]`crlValues`|`Array of Buffer`|
-+++
-Add a CRL value
-+++
-|[[defaultHost]]`defaultHost`|`String`|
-+++
-Set the default host name to be used by this client in requests if none is provided when making the request.
-+++
-|[[defaultPort]]`defaultPort`|`Number (int)`|
-+++
-Set the default port to be used by this client in requests if none is provided when making the request.
-+++
-|[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
-+++
-Add an enabled cipher suite
-+++
-|[[idleTimeout]]`idleTimeout`|`Number (int)`|
-+++
-Set the idle timeout, in seconds. zero means don't timeout.
- This determines if a connection will timeout and be closed if no data is received within the timeout.
-+++
-|[[keepAlive]]`keepAlive`|`Boolean`|
-+++
-Set whether keep alive is enabled on the client
-+++
-|[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
-+++
-Set the key/cert options in jks format, aka Java keystore.
-+++
-|[[maxChunkSize]]`maxChunkSize`|`Number (int)`|
-+++
-Set the maximum HTTP chunk size
-+++
-|[[maxPoolSize]]`maxPoolSize`|`Number (int)`|
-+++
-Set the maximum pool size for connections
-+++
-|[[maxWaitQueueSize]]`maxWaitQueueSize`|`Number (int)`|
-+++
-Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in
- a ConnectionPoolTooBusyException.  If the value is set to a negative number then the queue will be unbounded.
-+++
-|[[maxWebsocketFrameSize]]`maxWebsocketFrameSize`|`Number (int)`|
-+++
-Set the max websocket frame size
-+++
-|[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|
-+++
-Set the key/cert store options in pem format.
-+++
-|[[pemTrustOptions]]`pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|
-+++
-Set the trust options in pem format
-+++
-|[[pfxKeyCertOptions]]`pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
-+++
-Set the key/cert options in pfx format.
-+++
-|[[pfxTrustOptions]]`pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
-+++
-Set the trust options in pfx format
-+++
-|[[pipelining]]`pipelining`|`Boolean`|
-+++
-Set whether pipe-lining is enabled on the client
-+++
-|[[protocolVersion]]`protocolVersion`|`link:enums.html#HttpVersion[HttpVersion]`|
-+++
-Set the protocol version.
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[soLinger]]`soLinger`|`Number (int)`|
-+++
-Set whether SO_linger keep alive is enabled
-+++
-|[[ssl]]`ssl`|`Boolean`|
-+++
-Set whether SSL/TLS is enabled
-+++
-|[[tcpKeepAlive]]`tcpKeepAlive`|`Boolean`|
-+++
-Set whether TCP keep alive is enabled
-+++
-|[[tcpNoDelay]]`tcpNoDelay`|`Boolean`|
-+++
-Set whether TCP no delay is enabled
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
-+++
-|[[trustAll]]`trustAll`|`Boolean`|
-+++
-Set whether all server certificates should be trusted
-+++
-|[[trustStoreOptions]]`trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
-+++
-Set the trust options in jks format, aka Java trustore
-+++
-|[[tryUseCompression]]`tryUseCompression`|`Boolean`|
-+++
-Set whether compression is enabled
-+++
-|[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
-+++
-Set whether Netty pooled buffers are enabled
-+++
-|[[verifyHost]]`verifyHost`|`Boolean`|
-+++
-Set whether hostname verification is enabled
 +++
 |===
 

--- a/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxCommandLauncher.java
@@ -375,6 +375,7 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
     // By default this method retrieve the value from the 'Main-Verticle' Manifest header. However it can be overridden.
 
     String verticle = getMainVerticle();
+    String command = getCommandFromManifest();
     if (verticle != null) {
       // We have a main verticle, append it to the arg list and execute the default command (run)
       String[] newArgs = new String[args.length + 1];
@@ -382,9 +383,12 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
       System.arraycopy(args, 0, newArgs, 1, args.length);
       execute(getDefaultCommand(), newArgs);
       return;
+    } else if (command != null) {
+      execute(command, args);
+      return;
     }
 
-    // Fall backs
+    // Fallbacks
     if (args.length == 0) {
       printGlobalUsage();
     } else {
@@ -401,6 +405,14 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
    * @return the default command if specified in the {@code MANIFEST}, "run" if not found.
    */
   protected String getDefaultCommand() {
+    String fromManifest = getCommandFromManifest();
+    if (fromManifest == null) {
+      return "run";
+    }
+    return fromManifest;
+  }
+
+  protected String getCommandFromManifest() {
     try {
       Enumeration<URL> resources = RunCommand.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
       while (resources.hasMoreElements()) {
@@ -420,7 +432,7 @@ public class VertxCommandLauncher extends UsageMessageFormatter {
     } catch (IOException e) {
       throw new IllegalStateException(e.getMessage());
     }
-    return "run";
+    return null;
   }
 
   /**

--- a/src/test/asciidoc/dataobjects.adoc
+++ b/src/test/asciidoc/dataobjects.adoc
@@ -30,21 +30,6 @@
 ^|Name | Type ^| Description
 |===
 
-[[ParentDataObject]]
-== ParentDataObject
-
-++++
- @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[parentProperty]]`parentProperty`|`String`|-
-|===
-
 [[TestDataObject]]
 == TestDataObject
 
@@ -120,6 +105,21 @@
 |[[stringValue]]`stringValue`|`String`|-
 |[[stringValueMap]]`stringValueMap`|`String`|-
 |[[stringValues]]`stringValues`|`Array of String`|-
+|===
+
+[[ParentDataObject]]
+== ParentDataObject
+
+++++
+ @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[parentProperty]]`parentProperty`|`String`|-
 |===
 
 [[AggregatedDataObject]]

--- a/src/test/java/io/vertx/test/core/LauncherTest.java
+++ b/src/test/java/io/vertx/test/core/LauncherTest.java
@@ -220,6 +220,54 @@ public class LauncherTest extends VertxTestBase {
     waitUntil(() -> HelloCommand.called);
   }
 
+  @Test
+  public void testRunVerticleWithoutMainVerticleInManifestButWithCustomCommand() throws Exception {
+    // Copy the right manifest
+    File manifest = new File("target/test-classes/META-INF/MANIFEST-Launcher-Default-Command.MF");
+    if (!manifest.isFile()) {
+      throw new IllegalStateException("Cannot find the MANIFEST-Default-Command.MF file");
+    }
+    File target = new File("target/test-classes/META-INF/MANIFEST.MF");
+    Files.copy(manifest.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+    Launcher launcher = new Launcher();
+    HelloCommand.called = false;
+    String[] args = {"--name=vert.x"};
+    launcher.dispatch(args);
+    waitUntil(() -> HelloCommand.called);
+  }
+
+  @Test
+  public void testRunWithOverriddenDefaultCommand() throws Exception {
+    // Copy the right manifest
+    File manifest = new File("target/test-classes/META-INF/MANIFEST-Launcher-hello.MF");
+    if (!manifest.isFile()) {
+      throw new IllegalStateException("Cannot find the MANIFEST-Launcher-hello.MF file");
+    }
+    File target = new File("target/test-classes/META-INF/MANIFEST.MF");
+    Files.copy(manifest.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+    HelloCommand.called = false;
+    String[] args = {"run", TestVerticle.class.getName(), "--name=vert.x"};
+    Launcher.main(args);
+    waitUntil(() -> TestVerticle.instanceCount.get() == 1);
+  }
+
+  @Test
+  public void testRunWithOverriddenDefaultCommandRequiringArgs() throws Exception {
+    // Copy the right manifest
+    File manifest = new File("target/test-classes/META-INF/MANIFEST-Launcher-run.MF");
+    if (!manifest.isFile()) {
+      throw new IllegalStateException("Cannot find the MANIFEST-Launcher-run.MF file");
+    }
+    File target = new File("target/test-classes/META-INF/MANIFEST.MF");
+    Files.copy(manifest.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+    String[] args = {TestVerticle.class.getName()};
+    Launcher.main(args);
+    waitUntil(() -> TestVerticle.instanceCount.get() == 1);
+  }
+
 
   @Test
   public void testRunVerticleWithExtendedMainVerticleNoArgs() throws Exception {
@@ -366,7 +414,7 @@ public class LauncherTest extends VertxTestBase {
     VertxOptions opts = launcher.getVertxOptions();
 
     assertEquals(123, opts.getEventLoopPoolSize(), 0);
-    assertEquals(123767667l, opts.getMaxEventLoopExecuteTime());
+    assertEquals(123767667L, opts.getMaxEventLoopExecuteTime());
     assertEquals(true, opts.getMetricsOptions().isEnabled());
     assertEquals("somegroup", opts.getHAGroup());
 

--- a/src/test/resources/META-INF/MANIFEST-Launcher-Default-Command.MF
+++ b/src/test/resources/META-INF/MANIFEST-Launcher-Default-Command.MF
@@ -1,0 +1,2 @@
+Main-Class: io.vertx.core.Launcher
+Main-Command: hello

--- a/src/test/resources/META-INF/MANIFEST-Launcher-run.MF
+++ b/src/test/resources/META-INF/MANIFEST-Launcher-run.MF
@@ -1,0 +1,2 @@
+Main-Class: io.vertx.core.Launcher
+Main-Command: run


### PR DESCRIPTION
Fix #1346

Execute the command specified in the manifest if set and not overridden in the command line.