### PR TITLE
Add a `actualPort` method in HTTPServer to retrieve the listened port

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,30 @@
 = Cheatsheets
 
+[[DeliveryOptions]]
+== DeliveryOptions
+
+++++
+ Delivery options are used to configure message delivery.
+ <p>
+ Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
+ that you wish to send with the message.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[codecName]]`codecName`|`String`|
++++
+Set the codec name.
++++
+|[[sendTimeout]]`sendTimeout`|`Number (long)`|
++++
+Set the send timeout.
++++
+|===
+
 [[NetworkOptions]]
 == NetworkOptions
 
@@ -27,31 +52,6 @@ Set the TCP send buffer size
 |[[trafficClass]]`trafficClass`|`Number (int)`|
 +++
 Set the value of traffic class
-+++
-|===
-
-[[DeliveryOptions]]
-== DeliveryOptions
-
-++++
- Delivery options are used to configure message delivery.
- <p>
- Delivery options allow to configure delivery timeout and message codec name, and to provide any headers
- that you wish to send with the message.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[codecName]]`codecName`|`String`|
-+++
-Set the codec name.
-+++
-|[[sendTimeout]]`sendTimeout`|`Number (long)`|
-+++
-Set the send timeout.
 +++
 |===
 
@@ -153,6 +153,32 @@ Set the key store as a buffer
 +++
 |===
 
+[[GoAway]]
+== GoAway
+
+++++
+ A  frame.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[debugData]]`debugData`|`Buffer`|
++++
+Set the additional debug data
++++
+|[[errorCode]]`errorCode`|`Number (long)`|
++++
+@return the  error code
++++
+|[[lastStreamId]]`lastStreamId`|`Number (int)`|
++++
+Set the last stream id.
++++
+|===
+
 [[VertxOptions]]
 == VertxOptions
 
@@ -244,32 +270,6 @@ Set the threshold value above this, the blocked warning contains a stack trace.
 |[[workerPoolSize]]`workerPoolSize`|`Number (int)`|
 +++
 Set the maximum number of worker threads to be used by the Vert.x instance.
-+++
-|===
-
-[[GoAway]]
-== GoAway
-
-++++
- A  frame.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[debugData]]`debugData`|`Buffer`|
-+++
-Set the additional debug data
-+++
-|[[errorCode]]`errorCode`|`Number (long)`|
-+++
-@return the  error code
-+++
-|[[lastStreamId]]`lastStreamId`|`Number (int)`|
-+++
-Set the last stream id.
 +++
 |===
 
@@ -701,25 +701,6 @@ Set whether Netty pooled buffers are enabled
 +++
 |===
 
-[[MetricsOptions]]
-== MetricsOptions
-
-++++
- Vert.x metrics base configuration, this class can be extended by provider implementations to configure
- those specific implementations.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[enabled]]`enabled`|`Boolean`|
-+++
-Set whether metrics will be enabled on the Vert.x instance.
-+++
-|===
-
 [[ClientOptionsBase]]
 == ClientOptionsBase
 
@@ -820,6 +801,25 @@ Set the ALPN usage.
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|===
+
+[[MetricsOptions]]
+== MetricsOptions
+
+++++
+ Vert.x metrics base configuration, this class can be extended by provider implementations to configure
+ those specific implementations.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[enabled]]`enabled`|`Boolean`|
++++
+Set whether metrics will be enabled on the Vert.x instance.
 +++
 |===
 
@@ -1089,209 +1089,6 @@ Set the websocket subprotocols supported by the server.
 +++
 |===
 
-[[EventBusOptions]]
-== EventBusOptions
-
-++++
- Options to configure the event bus.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[acceptBacklog]]`acceptBacklog`|`Number (int)`|
-+++
-Set the accept back log.
-+++
-|[[clientAuth]]`clientAuth`|`link:enums.html#ClientAuth[ClientAuth]`|
-+++
-Set whether client auth is required
-+++
-|[[clusterPingInterval]]`clusterPingInterval`|`Number (long)`|
-+++
-Set the value of cluster ping interval, in ms.
-+++
-|[[clusterPingReplyInterval]]`clusterPingReplyInterval`|`Number (long)`|
-+++
-Set the value of cluster ping reply interval, in ms.
-+++
-|[[clusterPublicHost]]`clusterPublicHost`|`String`|
-+++
-Set the public facing hostname to be used for clustering.
- Sometimes, e.g. when running on certain clouds, the local address the server listens on for clustering is
- not the same address that other nodes connect to it at, as the OS / cloud infrastructure does some kind of
- proxying. If this is the case you can specify a public hostname which is different from the hostname the
- server listens at.
- <p>
- The default value is null which means use the same as the cluster hostname.
-+++
-|[[clusterPublicPort]]`clusterPublicPort`|`Number (int)`|
-+++
-See link for an explanation.
-+++
-|[[clustered]]`clustered`|`Boolean`|
-+++
-Sets whether or not the event bus is clustered.
-+++
-|[[connectTimeout]]`connectTimeout`|`Number (int)`|
-+++
-Sets the connect timeout
-+++
-|[[crlPaths]]`crlPaths`|`Array of String`|
-+++
-Add a CRL path
-+++
-|[[crlValues]]`crlValues`|`Array of Buffer`|
-+++
-Add a CRL value
-+++
-|[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
-+++
-Add an enabled cipher suite
-+++
-|[[host]]`host`|`String`|
-+++
-Sets the host.
-+++
-|[[idleTimeout]]`idleTimeout`|`Number (int)`|
-+++
-Set the idle timeout, in seconds. zero means don't timeout.
- This determines if a connection will timeout and be closed if no data is received within the timeout.
-+++
-|[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
-+++
-Set the key/cert options in jks format, aka Java keystore.
-+++
-|[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|
-+++
-Set the key/cert store options in pem format.
-+++
-|[[pemTrustOptions]]`pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|
-+++
-Set the trust options in pem format
-+++
-|[[pfxKeyCertOptions]]`pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
-+++
-Set the key/cert options in pfx format.
-+++
-|[[pfxTrustOptions]]`pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
-+++
-Set the trust options in pfx format
-+++
-|[[port]]`port`|`Number (int)`|
-+++
-Sets the port.
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reconnectAttempts]]`reconnectAttempts`|`Number (int)`|
-+++
-Sets the value of reconnect attempts.
-+++
-|[[reconnectInterval]]`reconnectInterval`|`Number (long)`|
-+++
-Set the reconnect interval.
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[soLinger]]`soLinger`|`Number (int)`|
-+++
-Set whether SO_linger keep alive is enabled
-+++
-|[[ssl]]`ssl`|`Boolean`|
-+++
-Set whether SSL/TLS is enabled
-+++
-|[[tcpKeepAlive]]`tcpKeepAlive`|`Boolean`|
-+++
-Set whether TCP keep alive is enabled
-+++
-|[[tcpNoDelay]]`tcpNoDelay`|`Boolean`|
-+++
-Set whether TCP no delay is enabled
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
-+++
-|[[trustAll]]`trustAll`|`Boolean`|
-+++
-Set whether all server certificates should be trusted.
-+++
-|[[trustStoreOptions]]`trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
-+++
-Set the trust options in jks format, aka Java trustore
-+++
-|[[useAlpn]]`useAlpn`|`Boolean`|
-+++
-Set the ALPN usage.
-+++
-|[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
-+++
-Set whether Netty pooled buffers are enabled
-+++
-|===
-
-[[DatagramSocketOptions]]
-== DatagramSocketOptions
-
-++++
- Options used to configure a datagram socket.
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[broadcast]]`broadcast`|`Boolean`|
-+++
-Set if the socket can receive broadcast packets
-+++
-|[[ipV6]]`ipV6`|`Boolean`|
-+++
-Set if IP v6 should be used
-+++
-|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
-+++
-Set if loopback mode is disabled
-+++
-|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
-+++
-Set the multicast network interface address
-+++
-|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
-+++
-Set the multicast ttl value
-+++
-|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
-+++
-Set the TCP receive buffer size
-+++
-|[[reuseAddress]]`reuseAddress`|`Boolean`|
-+++
-Set the value of reuse address
-+++
-|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
-+++
-Set the TCP send buffer size
-+++
-|[[trafficClass]]`trafficClass`|`Number (int)`|
-+++
-Set the value of traffic class
-+++
-|===
-
 [[HttpClientOptions]]
 == HttpClientOptions
 
@@ -1445,6 +1242,209 @@ Set whether Netty pooled buffers are enabled
 |[[verifyHost]]`verifyHost`|`Boolean`|
 +++
 Set whether hostname verification is enabled
++++
+|===
+
+[[DatagramSocketOptions]]
+== DatagramSocketOptions
+
+++++
+ Options used to configure a datagram socket.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[broadcast]]`broadcast`|`Boolean`|
++++
+Set if the socket can receive broadcast packets
++++
+|[[ipV6]]`ipV6`|`Boolean`|
++++
+Set if IP v6 should be used
++++
+|[[loopbackModeDisabled]]`loopbackModeDisabled`|`Boolean`|
++++
+Set if loopback mode is disabled
++++
+|[[multicastNetworkInterface]]`multicastNetworkInterface`|`String`|
++++
+Set the multicast network interface address
++++
+|[[multicastTimeToLive]]`multicastTimeToLive`|`Number (int)`|
++++
+Set the multicast ttl value
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
++++
+|===
+
+[[EventBusOptions]]
+== EventBusOptions
+
+++++
+ Options to configure the event bus.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[acceptBacklog]]`acceptBacklog`|`Number (int)`|
++++
+Set the accept back log.
++++
+|[[clientAuth]]`clientAuth`|`link:enums.html#ClientAuth[ClientAuth]`|
++++
+Set whether client auth is required
++++
+|[[clusterPingInterval]]`clusterPingInterval`|`Number (long)`|
++++
+Set the value of cluster ping interval, in ms.
++++
+|[[clusterPingReplyInterval]]`clusterPingReplyInterval`|`Number (long)`|
++++
+Set the value of cluster ping reply interval, in ms.
++++
+|[[clusterPublicHost]]`clusterPublicHost`|`String`|
++++
+Set the public facing hostname to be used for clustering.
+ Sometimes, e.g. when running on certain clouds, the local address the server listens on for clustering is
+ not the same address that other nodes connect to it at, as the OS / cloud infrastructure does some kind of
+ proxying. If this is the case you can specify a public hostname which is different from the hostname the
+ server listens at.
+ <p>
+ The default value is null which means use the same as the cluster hostname.
++++
+|[[clusterPublicPort]]`clusterPublicPort`|`Number (int)`|
++++
+See link for an explanation.
++++
+|[[clustered]]`clustered`|`Boolean`|
++++
+Sets whether or not the event bus is clustered.
++++
+|[[connectTimeout]]`connectTimeout`|`Number (int)`|
++++
+Sets the connect timeout
++++
+|[[crlPaths]]`crlPaths`|`Array of String`|
++++
+Add a CRL path
++++
+|[[crlValues]]`crlValues`|`Array of Buffer`|
++++
+Add a CRL value
++++
+|[[enabledCipherSuites]]`enabledCipherSuites`|`Array of String`|
++++
+Add an enabled cipher suite
++++
+|[[host]]`host`|`String`|
++++
+Sets the host.
++++
+|[[idleTimeout]]`idleTimeout`|`Number (int)`|
++++
+Set the idle timeout, in seconds. zero means don't timeout.
+ This determines if a connection will timeout and be closed if no data is received within the timeout.
++++
+|[[keyStoreOptions]]`keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
++++
+Set the key/cert options in jks format, aka Java keystore.
++++
+|[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|
++++
+Set the key/cert store options in pem format.
++++
+|[[pemTrustOptions]]`pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|
++++
+Set the trust options in pem format
++++
+|[[pfxKeyCertOptions]]`pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
++++
+Set the key/cert options in pfx format.
++++
+|[[pfxTrustOptions]]`pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|
++++
+Set the trust options in pfx format
++++
+|[[port]]`port`|`Number (int)`|
++++
+Sets the port.
++++
+|[[receiveBufferSize]]`receiveBufferSize`|`Number (int)`|
++++
+Set the TCP receive buffer size
++++
+|[[reconnectAttempts]]`reconnectAttempts`|`Number (int)`|
++++
+Sets the value of reconnect attempts.
++++
+|[[reconnectInterval]]`reconnectInterval`|`Number (long)`|
++++
+Set the reconnect interval.
++++
+|[[reuseAddress]]`reuseAddress`|`Boolean`|
++++
+Set the value of reuse address
++++
+|[[sendBufferSize]]`sendBufferSize`|`Number (int)`|
++++
+Set the TCP send buffer size
++++
+|[[soLinger]]`soLinger`|`Number (int)`|
++++
+Set whether SO_linger keep alive is enabled
++++
+|[[ssl]]`ssl`|`Boolean`|
++++
+Set whether SSL/TLS is enabled
++++
+|[[tcpKeepAlive]]`tcpKeepAlive`|`Boolean`|
++++
+Set whether TCP keep alive is enabled
++++
+|[[tcpNoDelay]]`tcpNoDelay`|`Boolean`|
++++
+Set whether TCP no delay is enabled
++++
+|[[trafficClass]]`trafficClass`|`Number (int)`|
++++
+Set the value of traffic class
++++
+|[[trustAll]]`trustAll`|`Boolean`|
++++
+Set whether all server certificates should be trusted.
++++
+|[[trustStoreOptions]]`trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|
++++
+Set the trust options in jks format, aka Java trustore
++++
+|[[useAlpn]]`useAlpn`|`Boolean`|
++++
+Set the ALPN usage.
++++
+|[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
++++
+Set whether Netty pooled buffers are enabled
 +++
 |===
 

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -174,4 +174,11 @@ public interface HttpServer extends Measured {
    */
   void close(Handler<AsyncResult<Void>> completionHandler);
 
+  /**
+   * The actual port the server is listening on. This is useful if you bound the server specifying 0 as port number
+   * signifying an ephemeral port
+   *
+   * @return the actual port the server is listening on.
+   */
+  int actualPort();
 }

--- a/src/test/asciidoc/dataobjects.adoc
+++ b/src/test/asciidoc/dataobjects.adoc
@@ -30,21 +30,6 @@
 ^|Name | Type ^| Description
 |===
 
-[[ParentDataObject]]
-== ParentDataObject
-
-++++
- @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
-++++
-'''
-
-[cols=">25%,^25%,50%"]
-[frame="topbot"]
-|===
-^|Name | Type ^| Description
-|[[parentProperty]]`parentProperty`|`String`|-
-|===
-
 [[TestDataObject]]
 == TestDataObject
 
@@ -120,6 +105,21 @@
 |[[stringValue]]`stringValue`|`String`|-
 |[[stringValueMap]]`stringValueMap`|`String`|-
 |[[stringValues]]`stringValues`|`Array of String`|-
+|===
+
+[[ParentDataObject]]
+== ParentDataObject
+
+++++
+ @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[parentProperty]]`parentProperty`|`String`|-
 |===
 
 [[AggregatedDataObject]]


### PR DESCRIPTION
It fixes #1318.

I open this PR on the http2 branch as it handles both HTTP 1 and HTTP 2 servers.