### PR TITLE
fixing some formatting, spelling and unicode characters

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -239,11 +239,13 @@ If your application is not responsive it might be a sign that you are blocking a
 you diagnose such issues, Vert.x will automatically log warnings if it detects an event loop hasn't returned for
 some time. If you see warnings like these in your logs, then you should investigate.
 
- Thread vertx-eventloop-thread-3 has been blocked for 20458 ms
+----
+Thread vertx-eventloop-thread-3 has been blocked for 20458 ms
+----
 
 Vert.x will also provide stack traces to pinpoint exactly where the blocking is occurring.
 
-If you want to turn of these warnings or change the settings, you can do that in the
+If you want to turn off these warnings or change the settings, you can do that in the
 `link:../../apidocs/io/vertx/core/VertxOptions.html[VertxOptions]` object before creating the Vertx object.
 
 [[blocking_code]]
@@ -1091,7 +1093,7 @@ examples:
 ----
 vertx run MyVerticle.groovy --redeploy="**/*.groovy" --launcher-class=io.vertx.core.Launcher
 vertx run MyVerticle.groovy --redeploy="**/*.groovy,**/*.rb"  --launcher-class=io.vertx.core.Launcher
-java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**/*.class"  --launcher-class=io.vertx.core
+java io.vertx.core.Launcher run org.acme.MyVerticle --redeploy="**/*.class"  --launcher-class=io.vertx.core
 .Launcher -cp ...
 ----
 
@@ -1128,7 +1130,7 @@ You can also hook your build process in the redeploy cycle:
 
 [source]
 ----
-java –jar target/my-fat-jar.jar –redeploy="**/*.java" --on-redeploy="mvn package"
+java -jar target/my-fat-jar.jar --redeploy="**/*.java" --on-redeploy="mvn package"
 java -jar build/libs/my-fat-jar.jar --redeploy="src/**/*.java" --on-redeploy='./gradlew shadowJar'
 ----
 

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -247,11 +247,13 @@
  * you diagnose such issues, Vert.x will automatically log warnings if it detects an event loop hasn't returned for
  * some time. If you see warnings like these in your logs, then you should investigate.
  *
- *  Thread vertx-eventloop-thread-3 has been blocked for 20458 ms
+ * ----
+ * Thread vertx-eventloop-thread-3 has been blocked for 20458 ms
+ * ----
  *
  * Vert.x will also provide stack traces to pinpoint exactly where the blocking is occurring.
  *
- * If you want to turn of these warnings or change the settings, you can do that in the
+ * If you want to turn off these warnings or change the settings, you can do that in the
  * {@link io.vertx.core.VertxOptions} object before creating the Vertx object.
  *
  * [[blocking_code]]
@@ -1015,7 +1017,7 @@
  * ----
  * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy" --launcher-class=io.vertx.core.Launcher
  * vertx run MyVerticle.groovy --redeploy="**&#47;*.groovy,**&#47;*.rb"  --launcher-class=io.vertx.core.Launcher
- * java io.vertx.core.Launcher run org.acme.MyVerticle –redeploy="**&#47;*.class"  --launcher-class=io.vertx.core
+ * java io.vertx.core.Launcher run org.acme.MyVerticle --redeploy="**&#47;*.class"  --launcher-class=io.vertx.core
  * .Launcher -cp ...
  * ----
  *
@@ -1052,7 +1054,7 @@
  *
  * [source]
  * ----
- * java –jar target/my-fat-jar.jar –redeploy="**&#47;*.java" --on-redeploy="mvn package"
+ * java -jar target/my-fat-jar.jar --redeploy="**&#47;*.java" --on-redeploy="mvn package"
  * java -jar build/libs/my-fat-jar.jar --redeploy="src&#47;**&#47;*.java" --on-redeploy='./gradlew shadowJar'
  * ----
  *


### PR DESCRIPTION
I found the spelling mistake of -> off. When looking closer in my IDE I also found some unicode long-hyphens where there should have been double ascii hypens on a command line.