### PR TITLE
Avoid accessor method for `OrderedExecutorFactory::log`

### DIFF
--- a/src/main/java/io/vertx/core/impl/OrderedExecutorFactory.java
+++ b/src/main/java/io/vertx/core/impl/OrderedExecutorFactory.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Executor;
  * @version <tt>$Revision$</tt>
  */
 public class OrderedExecutorFactory {
-  // It must be package-private rather than `private` in order to avoid the generation of an accessor, which would
+  // It must be package-protected rather than `private` in order to avoid the generation of an accessor, which would
   // cause Quasar 0.7.5-SNAPSHOT+ to print print an harmless error message during vert.x boot when using the agent
   // instrumentation method. See https://github.com/puniverse/quasar/issues/160#issuecomment-205977756 for details.
   static final Logger log = LoggerFactory.getLogger(OrderedExecutorFactory.class);

--- a/src/main/java/io/vertx/core/impl/OrderedExecutorFactory.java
+++ b/src/main/java/io/vertx/core/impl/OrderedExecutorFactory.java
@@ -31,6 +31,9 @@ import java.util.concurrent.Executor;
  * @version <tt>$Revision$</tt>
  */
 public class OrderedExecutorFactory {
+  // It must be package-private rather than `private` in order to avoid the generation of an accessor, which would
+  // cause Quasar 0.7.5-SNAPSHOT+ to print print an harmless error message during vert.x boot when using the agent
+  // instrumentation method. See https://github.com/puniverse/quasar/issues/160#issuecomment-205977756 for details.
   static final Logger log = LoggerFactory.getLogger(OrderedExecutorFactory.class);
 
   private final Executor parent;

--- a/src/main/java/io/vertx/core/impl/OrderedExecutorFactory.java
+++ b/src/main/java/io/vertx/core/impl/OrderedExecutorFactory.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Executor;
  * @version <tt>$Revision$</tt>
  */
 public class OrderedExecutorFactory {
-  private static final Logger log = LoggerFactory.getLogger(OrderedExecutorFactory.class);
+  static final Logger log = LoggerFactory.getLogger(OrderedExecutorFactory.class);
 
   private final Executor parent;
 


### PR DESCRIPTION
The accessor method is not an issue per-se but it causes the Quasar Java agent in the forthcoming release, when used, to print an harmless but annoying error at vert.x boot:

```
ERROR: Unable to instrument class io/vertx/core/impl/OrderedExecutorFactory$OrderedExecutor co.paralleluniverse.fibers.instrument.UnableToInstrumentException: Unable to instrument io/vertx/core/impl/OrderedExecutorFactory$OrderedExecutor#lambda$new$261()V because of synchronization
```

(See https://github.com/puniverse/quasar/issues/160#issuecomment-205977756 and following for details)

An easy workaround for the user is to run the agent with the `=m` suffix ("allow monitors").