### PR TITLE
Fix #1389 - Close vert.x instances

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -363,4 +363,11 @@ public class BareCommand extends ClasspathHandler {
   public void setExecutionContext(ExecutionContext context) {
     this.executionContext = context;
   }
+
+  /**
+   * @return the vert.x instance if created.
+   */
+  public synchronized Vertx vertx() {
+    return vertx;
+  }
 }

--- a/src/test/java/io/vertx/core/impl/launcher/commands/ClasspathHandlerTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/ClasspathHandlerTest.java
@@ -56,12 +56,12 @@ public class ClasspathHandlerTest extends CommandTestBase {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws InterruptedException {
     if (run != null) {
-      run.vertx.close();
+      close(run.vertx);
     }
     if (bare != null) {
-      bare.vertx.close();
+      close(bare.vertx);
     }
   }
 


### PR DESCRIPTION
Fix #1389 

Close vert.x instances in the LauncherTest and StarterTest