### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,16 +54,16 @@
   <properties>
 
     <netty.version>4.1.0.CR7</netty.version>
-    <jackson.version>2.7.1</jackson.version>
-    <jackson.databind.version>2.7.1-1</jackson.databind.version>
+    <jackson.version>2.7.3</jackson.version>
+    <jackson.databind.version>2.7.3</jackson.databind.version>
     <log4j.version>1.2.17</log4j.version>
-    <slf4j.version>1.7.16</slf4j.version>
+    <slf4j.version>1.7.21</slf4j.version>
     <junit.version>4.12</junit.version>
-    <assertj.version>3.3.0</assertj.version>
+    <assertj.version>3.4.1</assertj.version>
     <apacheds-protocol-dns.version>1.5.7</apacheds-protocol-dns.version>
     <generated.dir>${project.basedir}/src/main/generated</generated.dir>
     <stack.version>3.3.0-SNAPSHOT</stack.version>
-    <jetty.alpnAgent.version>2.0.0</jetty.alpnAgent.version>
+    <jetty.alpnAgent.version>2.0.2</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
 


### PR DESCRIPTION
Update the dependencies to fill the Eclipse CQ.

Have been updated: slf4j, jackson, assertj (test) and alpn (test).