### PR TITLE
Named worker pools

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -268,6 +268,10 @@ Set the isolated class names.
 +++
 Set the isolation group that will be used when deploying the verticle(s)
 +++
+|[[maxWorkerExecuteTime]]`maxWorkerExecuteTime`|`Number (long)`|
++++
+Sets the value of max worker execute time, in ns.
++++
 |[[multiThreaded]]`multiThreaded`|`Boolean`|
 +++
 Set whether the verticle(s) should be deployed as a multi-threaded worker verticle
@@ -275,6 +279,15 @@ Set whether the verticle(s) should be deployed as a multi-threaded worker vertic
 |[[worker]]`worker`|`Boolean`|
 +++
 Set whether the verticle(s) should be deployed as a worker verticle
++++
+|[[workerPoolName]]`workerPoolName`|`String`|
++++
+Set the worker pool name to use for this verticle. When no name is set, the Vert.x
+ worker pool will be used, when a name is set, the verticle will use a named worker pool.
++++
+|[[workerPoolSize]]`workerPoolSize`|`Number (int)`|
++++
+Set the maximum number of worker threads to be used by the Vert.x instance.
 +++
 |===
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -291,6 +291,49 @@ An alternative way to run blocking code is to use a <<worker_verticles, worker v
 
 A worker verticle is always executed with a thread from the worker pool.
 
+By default blocking code is executed on the Vert.x blocking code pool, configured with `link:../../apidocs/io/vertx/core/VertxOptions.html#setWorkerPoolSize-int-[setWorkerPoolSize]`.
+
+Additional pools can be created for different purposes:
+
+[source,java]
+----
+WorkerExecutor executor = vertx.createWorkerExecutor("my-worker-pool");
+executor.executeBlocking(future -> {
+  // Call some blocking API that takes a significant amount of time to return
+  String result = someAPI.blockingMethod("hello");
+  future.complete(result);
+}, res -> {
+  System.out.println("The result is: " + res.result());
+});
+----
+
+The worker executor must be closed when it's not necessary anymore:
+
+[source,java]
+----
+executor.close();
+----
+
+When several workers are created with the same name, they will share the same pool. The worker pool is destroyed
+when all the worker executors using it are closed.
+
+When an executor is created in a Verticle, Vert.x will close it automatically for you when the Verticle
+is undeployed.
+
+Worker executors can be configured when created:
+
+[source,java]
+----
+int poolSize = 10;
+
+// 2 minutes
+long maxExecuteTime = 120000;
+
+WorkerExecutor executor = vertx.createWorkerExecutor("my-worker-pool", poolSize, maxExecuteTime);
+----
+
+NOTE: the configuration is set when the worker pool is created
+
 == Async coordination
 
 Coordination of multiple asynchronous results can be achieved with Vert.x `link:../../apidocs/io/vertx/core/Future.html[futures]`.
@@ -772,6 +815,18 @@ vertx.cancelTimer(timerID);
 
 If you're creating timers from inside verticles, those timers will be automatically closed
 when the verticle is undeployed.
+
+=== Verticle worker pool
+
+Verticle use the Vert.x worker pool for executing blocking actions, i.e `link:../../apidocs/io/vertx/core/Context.html#executeBlocking-io.vertx.core.Handler-boolean-io.vertx.core.Handler-[executeBlocking]` or
+worker verticle.
+
+A different worker pool can be specified in deployment options:
+
+[source,java]
+----
+vertx.deployVerticle("the-verticle", new DeploymentOptions().setWorkerPoolName("the-specific-pool"));
+----
 
 [[event_bus]]
 include::eventbus.adoc[]

--- a/src/main/generated/io/vertx/core/DeploymentOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/DeploymentOptionsConverter.java
@@ -55,11 +55,20 @@ public class DeploymentOptionsConverter {
     if (json.getValue("isolationGroup") instanceof String) {
       obj.setIsolationGroup((String)json.getValue("isolationGroup"));
     }
+    if (json.getValue("maxWorkerExecuteTime") instanceof Number) {
+      obj.setMaxWorkerExecuteTime(((Number)json.getValue("maxWorkerExecuteTime")).longValue());
+    }
     if (json.getValue("multiThreaded") instanceof Boolean) {
       obj.setMultiThreaded((Boolean)json.getValue("multiThreaded"));
     }
     if (json.getValue("worker") instanceof Boolean) {
       obj.setWorker((Boolean)json.getValue("worker"));
+    }
+    if (json.getValue("workerPoolName") instanceof String) {
+      obj.setWorkerPoolName((String)json.getValue("workerPoolName"));
+    }
+    if (json.getValue("workerPoolSize") instanceof Number) {
+      obj.setWorkerPoolSize(((Number)json.getValue("workerPoolSize")).intValue());
     }
   }
 
@@ -86,7 +95,12 @@ public class DeploymentOptionsConverter {
     if (obj.getIsolationGroup() != null) {
       json.put("isolationGroup", obj.getIsolationGroup());
     }
+    json.put("maxWorkerExecuteTime", obj.getMaxWorkerExecuteTime());
     json.put("multiThreaded", obj.isMultiThreaded());
     json.put("worker", obj.isWorker());
+    if (obj.getWorkerPoolName() != null) {
+      json.put("workerPoolName", obj.getWorkerPoolName());
+    }
+    json.put("workerPoolSize", obj.getWorkerPoolSize());
   }
 }

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -79,6 +79,32 @@ public class CoreExamples {
     });
   }
 
+  public void workerExecutor1(Vertx vertx) {
+    WorkerExecutor executor = vertx.createWorkerExecutor("my-worker-pool");
+    executor.executeBlocking(future -> {
+      // Call some blocking API that takes a significant amount of time to return
+      String result = someAPI.blockingMethod("hello");
+      future.complete(result);
+    }, res -> {
+      System.out.println("The result is: " + res.result());
+    });
+  }
+
+  public void workerExecutor2(WorkerExecutor executor) {
+    executor.close();
+  }
+
+  public void workerExecutor3(Vertx vertx) {
+    //
+    // 10 threads max
+    int poolSize = 10;
+
+    // 2 minutes
+    long maxExecuteTime = 120000;
+
+    WorkerExecutor executor = vertx.createWorkerExecutor("my-worker-pool", poolSize, maxExecuteTime);
+  }
+
   BlockingAPI someAPI = new BlockingAPI();
 
   class BlockingAPI {
@@ -282,6 +308,10 @@ public class CoreExamples {
                 addServer("192.168.0.1").
                 addServer("192.168.0.2:40000"))
     );
+  }
+
+  public void deployVerticleWithDifferentWorkerPool(Vertx vertx) {
+    vertx.deployVerticle("the-verticle", new DeploymentOptions().setWorkerPoolName("the-specific-pool"));
   }
 
 }

--- a/src/main/java/io/vertx/core/DeploymentOptions.java
+++ b/src/main/java/io/vertx/core/DeploymentOptions.java
@@ -43,6 +43,9 @@ public class DeploymentOptions {
   private boolean worker;
   private boolean multiThreaded;
   private String isolationGroup;
+  private String workerPoolName;
+  private int workerPoolSize;
+  private long maxWorkerExecuteTime;
   private boolean ha;
   private List<String> extraClasspath;
   private int instances;
@@ -58,6 +61,9 @@ public class DeploymentOptions {
     this.isolationGroup = DEFAULT_ISOLATION_GROUP;
     this.ha = DEFAULT_HA;
     this.instances = DEFAULT_INSTANCES;
+    this.workerPoolName = null;
+    this.workerPoolSize = VertxOptions.DEFAULT_WORKER_POOL_SIZE;
+    this.maxWorkerExecuteTime = VertxOptions.DEFAULT_MAX_WORKER_EXECUTE_TIME;
   }
 
   /**
@@ -271,6 +277,80 @@ public class DeploymentOptions {
    */
   public DeploymentOptions setIsolatedClasses(List<String> isolatedClasses) {
     this.isolatedClasses = isolatedClasses;
+    return this;
+  }
+
+  /**
+   * @return the worker pool name
+   */
+  public String getWorkerPoolName() {
+    return workerPoolName;
+  }
+
+  /**
+   * Set the worker pool name to use for this verticle. When no name is set, the Vert.x
+   * worker pool will be used, when a name is set, the verticle will use a named worker pool.
+   *
+   * @param workerPoolName the worker pool name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DeploymentOptions setWorkerPoolName(String workerPoolName) {
+    this.workerPoolName = workerPoolName;
+    return this;
+  }
+
+  /**
+   * Get the maximum number of worker threads to be used by the worker pool when the verticle is deployed
+   * with a {@link #setWorkerPoolName}. When the verticle does not use a named worker pool, this option
+   * has no effect.
+   * <p>
+   * Worker threads are used for running blocking code and worker verticles.
+   *
+   * @return the maximum number of worker threads
+   */
+  public int getWorkerPoolSize() {
+    return workerPoolSize;
+  }
+
+  /**
+   * Set the maximum number of worker threads to be used by the Vert.x instance.
+   *
+   * @param workerPoolSize the number of threads
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DeploymentOptions setWorkerPoolSize(int workerPoolSize) {
+    if (workerPoolSize < 1) {
+      throw new IllegalArgumentException("workerPoolSize must be > 0");
+    }
+    this.workerPoolSize = workerPoolSize;
+    return this;
+  }
+
+  /**
+   * Get the value of max worker execute time, in ns.
+   * <p>
+   * Vert.x will automatically log a warning if it detects that worker threads haven't returned within this time.
+   * <p>
+   * This can be used to detect where the user is blocking a worker thread for too long. Although worker threads
+   * can be blocked longer than event loop threads, they shouldn't be blocked for long periods of time.
+   *
+   * @return The value of max worker execute time, in ms.
+   */
+  public long getMaxWorkerExecuteTime() {
+    return maxWorkerExecuteTime;
+  }
+
+  /**
+   * Sets the value of max worker execute time, in ns.
+   *
+   * @param maxWorkerExecuteTime the value of max worker execute time, in ms.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DeploymentOptions setMaxWorkerExecuteTime(long maxWorkerExecuteTime) {
+    if (maxWorkerExecuteTime < 1) {
+      throw new IllegalArgumentException("maxWorkerpExecuteTime must be > 0");
+    }
+    this.maxWorkerExecuteTime = maxWorkerExecuteTime;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/DeploymentOptions.java
+++ b/src/main/java/io/vertx/core/DeploymentOptions.java
@@ -80,6 +80,9 @@ public class DeploymentOptions {
     this.extraClasspath = other.getExtraClasspath() == null ? null : new ArrayList<>(other.getExtraClasspath());
     this.instances = other.instances;
     this.isolatedClasses = other.getIsolatedClasses() == null ? null : new ArrayList<>(other.getIsolatedClasses());
+    this.workerPoolName = other.workerPoolName;
+    setWorkerPoolSize(other.workerPoolSize);
+    setMaxWorkerExecuteTime(other.maxWorkerExecuteTime);
   }
 
   /**
@@ -348,7 +351,7 @@ public class DeploymentOptions {
    */
   public DeploymentOptions setMaxWorkerExecuteTime(long maxWorkerExecuteTime) {
     if (maxWorkerExecuteTime < 1) {
-      throw new IllegalArgumentException("maxWorkerpExecuteTime must be > 0");
+      throw new IllegalArgumentException("maxWorkerExecuteTime must be > 0");
     }
     this.maxWorkerExecuteTime = maxWorkerExecuteTime;
     return this;
@@ -361,16 +364,7 @@ public class DeploymentOptions {
    */
   public JsonObject toJson() {
     JsonObject json = new JsonObject();
-    if (worker) json.put("worker", true);
-    if (multiThreaded) json.put("multiThreaded", true);
-    if (isolationGroup != null) json.put("isolationGroup", isolationGroup);
-    if (ha) json.put("ha", true);
-    if (config != null) json.put("config", config);
-    if (extraClasspath != null) json.put("extraClasspath", new JsonArray(extraClasspath));
-    if (instances != DEFAULT_INSTANCES) {
-      json.put("instances", instances);
-    }
-    if (isolatedClasses != null) json.put("isolatedClasses", new JsonArray(isolatedClasses));
+    DeploymentOptionsConverter.toJson(this, json);
     return json;
   }
 
@@ -404,6 +398,9 @@ public class DeploymentOptions {
     result = 31 * result + (extraClasspath != null ? extraClasspath.hashCode() : 0);
     result = 31 * result + instances;
     result = 31 * result + (isolatedClasses != null ? isolatedClasses.hashCode() : 0);
+    result = 31 * result + (workerPoolName != null ? workerPoolName.hashCode() : 0);
+    result = 31 * result + workerPoolSize;
+    result = 31 * result + Long.hashCode(maxWorkerExecuteTime);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -481,6 +481,33 @@ public interface Vertx extends Measured {
   EventLoopGroup nettyEventLoopGroup();
 
   /**
+   * Like {@link #createWorkerExecutor(String, int)} but with the {@link VertxOptions#setWorkerPoolSize} {@code poolSize}.
+   */
+  WorkerExecutor createWorkerExecutor(String name);
+
+  /**
+   * Like {@link #createWorkerExecutor(String, int, long)} but with the {@link VertxOptions#setMaxWorkerExecuteTime} {@code maxExecuteTime}.
+   */
+  WorkerExecutor createWorkerExecutor(String name, int poolSize);
+
+  /**
+   * Create a named worker executor, the executor should be closed when it's not needed anymore to release
+   * resources.<p/>
+   *
+   * This method can be called mutiple times with the same {@code name}. Executors with the same name will share
+   * the same worker pool. The worker pool size and max execute time are set when the worker pool is created and
+   * won't change after.<p>
+   *
+   * The worker pool is released when all the {@link WorkerExecutor} sharing the same name are closed.
+   *
+   * @param name the name of the worker executor
+   * @param poolSize the size of the pool
+   * @param maxExecuteTime the value of max worker execute time, in ms
+   * @return the named worker executor
+   */
+  WorkerExecutor createWorkerExecutor(String name, int poolSize, long maxExecuteTime);
+
+  /**
    * Set a default exception handler for {@link Context}, set on {@link Context#exceptionHandler(Handler)} at creation.
    *
    * @param handler the exception handler

--- a/src/main/java/io/vertx/core/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/WorkerExecutor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@VertxGen
+public interface WorkerExecutor {
+
+  /**
+   * Safely execute some blocking code.
+   * <p>
+   * Executes the blocking code in the handler {@code blockingCodeHandler} using a thread from the worker pool.
+   * <p>
+   * When the code is complete the handler {@code resultHandler} will be called with the result on the original context
+   * (e.g. on the original event loop of the caller).
+   * <p>
+   * A {@code Future} instance is passed into {@code blockingCodeHandler}. When the blocking code successfully completes,
+   * the handler should call the {@link Future#complete} or {@link Future#complete(Object)} method, or the {@link Future#fail}
+   * method if it failed.
+   * <p>
+   * In the {@code blockingCodeHandler} the current context remains the original context and therefore any task
+   * scheduled in the {@code blockingCodeHandler} will be executed on the this context and not on the worker thread.
+   *
+   * @param blockingCodeHandler  handler representing the blocking code to run
+   * @param resultHandler  handler that will be called when the blocking code is complete
+   * @param ordered  if true then if executeBlocking is called several times on the same context, the executions
+   *                 for that context will be executed serially, not in parallel. if false then they will be no ordering
+   *                 guarantees
+   * @param <T> the type of the result
+   */
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler);
+
+  /**
+   * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
+   */
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> resultHandler);
+
+  /**
+   * Close the executor.
+   */
+  void close();
+
+}

--- a/src/main/java/io/vertx/core/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/WorkerExecutor.java
@@ -19,6 +19,11 @@ package io.vertx.core;
 import io.vertx.codegen.annotations.VertxGen;
 
 /**
+ * An executor for executing blocking code in Vert.x .<p>
+ *
+ * It provides the same <code>executeBlocking</code> operation than {@link io.vertx.core.Context} and
+ * {@link io.vertx.core.Vertx} but on a separate worker pool.<p>
+ *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @VertxGen

--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -36,7 +36,7 @@ public class BlockedThreadChecker {
   private final Map<VertxThread, Object> threads = new WeakHashMap<>();
   private final Timer timer; // Need to use our own timer - can't use event loop for this
 
-  BlockedThreadChecker(long interval, long maxEventLoopExecTime, long maxWorkerExecTime, long warningExceptionTime) {
+  BlockedThreadChecker(long interval, long warningExceptionTime) {
     timer = new Timer("vertx-blocked-thread-checker", true);
     timer.schedule(new TimerTask() {
       @Override
@@ -46,7 +46,7 @@ public class BlockedThreadChecker {
           for (VertxThread thread : threads.keySet()) {
             long execStart = thread.startTime();
             long dur = now - execStart;
-            final long timeLimit = thread.isWorker() ? maxWorkerExecTime : maxEventLoopExecTime;
+            final long timeLimit = thread.getMaxExecTime();
             if (execStart != 0 && dur > timeLimit) {
               final String message = "Thread " + thread + " has been blocked for " + (dur / 1000000) + " ms, time limit is " + (timeLimit / 1000000);
               if (dur <= warningExceptionTime) {

--- a/src/main/java/io/vertx/core/impl/EventLoopContext.java
+++ b/src/main/java/io/vertx/core/impl/EventLoopContext.java
@@ -21,8 +21,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
-import java.util.concurrent.Executor;
-
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -30,9 +28,9 @@ public class EventLoopContext extends ContextImpl {
 
   private static final Logger log = LoggerFactory.getLogger(EventLoopContext.class);
 
-  public EventLoopContext(VertxInternal vertx, Executor internalBlockingExec, Executor workerExec, String deploymentID, JsonObject config,
+  public EventLoopContext(VertxInternal vertx, WorkerPool workerPool, String deploymentID, JsonObject config,
                           ClassLoader tccl) {
-    super(vertx, internalBlockingExec, workerExec, deploymentID, config, tccl);
+    super(vertx, workerPool, deploymentID, config, tccl);
   }
 
   public void executeAsync(Handler<Void> task) {

--- a/src/main/java/io/vertx/core/impl/EventLoopContext.java
+++ b/src/main/java/io/vertx/core/impl/EventLoopContext.java
@@ -34,7 +34,8 @@ public class EventLoopContext extends ContextImpl {
   }
 
   public void executeAsync(Handler<Void> task) {
-    nettyEventLoop().execute(wrapTask(null, task, true));
+    // No metrics, we are on the event loop.
+    nettyEventLoop().execute(wrapTask(null, task, true, null));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/EventLoopContext.java
+++ b/src/main/java/io/vertx/core/impl/EventLoopContext.java
@@ -28,9 +28,9 @@ public class EventLoopContext extends ContextImpl {
 
   private static final Logger log = LoggerFactory.getLogger(EventLoopContext.class);
 
-  public EventLoopContext(VertxInternal vertx, WorkerPool workerPool, String deploymentID, JsonObject config,
+  public EventLoopContext(VertxInternal vertx, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID, JsonObject config,
                           ClassLoader tccl) {
-    super(vertx, workerPool, deploymentID, config, tccl);
+    super(vertx, internalBlockingPool, workerPool, deploymentID, config, tccl);
   }
 
   public void executeAsync(Handler<Void> task) {

--- a/src/main/java/io/vertx/core/impl/HostnameResolver.java
+++ b/src/main/java/io/vertx/core/impl/HostnameResolver.java
@@ -45,7 +45,7 @@ public class HostnameResolver {
   private final InetNameResolver resolver;
 
   public HostnameResolver(VertxImpl vertx, HostnameResolverOptions options) {
-    DnsNameResolverBuilder builder = new DnsNameResolverBuilder(vertx.createEventLoopContext(null, new JsonObject(), Thread.currentThread().getContextClassLoader()).nettyEventLoop());
+    DnsNameResolverBuilder builder = new DnsNameResolverBuilder(vertx.createEventLoopContext(null, null, new JsonObject(), Thread.currentThread().getContextClassLoader()).nettyEventLoop());
     builder.channelFactory(NioDatagramChannel::new);
     if (options != null) {
       List<String> dnsServers = options.getServers();

--- a/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
@@ -31,7 +31,7 @@ public class MultiThreadedWorkerContext extends WorkerContext {
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerPool.workerExec.execute(wrapTask(null, task, false, workerPool.workerMetrics));
+    workerPool.workerPool.execute(wrapTask(null, task, false, workerPool.workerMetrics));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
@@ -19,21 +19,19 @@ package io.vertx.core.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 
-import java.util.concurrent.Executor;
-
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class MultiThreadedWorkerContext extends WorkerContext {
 
-  public MultiThreadedWorkerContext(VertxInternal vertx, Executor orderedInternalExec, Executor workerExec,
+  public MultiThreadedWorkerContext(VertxInternal vertx, WorkerPool workerPool,
                                     String deploymentID, JsonObject config, ClassLoader tccl) {
-    super(vertx, orderedInternalExec, workerExec, deploymentID, config, tccl);
+    super(vertx, workerPool, deploymentID, config, tccl);
   }
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerExec.execute(wrapTask(null, task, false));
+    workerPool.workerExec.execute(wrapTask(null, task, false));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
@@ -31,7 +31,7 @@ public class MultiThreadedWorkerContext extends WorkerContext {
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerPool.workerExec.execute(wrapTask(null, task, false));
+    workerPool.workerExec.execute(wrapTask(null, task, false, workerPool.workerMetrics));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/MultiThreadedWorkerContext.java
@@ -24,14 +24,14 @@ import io.vertx.core.json.JsonObject;
  */
 public class MultiThreadedWorkerContext extends WorkerContext {
 
-  public MultiThreadedWorkerContext(VertxInternal vertx, WorkerPool workerPool,
+  public MultiThreadedWorkerContext(VertxInternal vertx, WorkerPool internalBlockingPool, WorkerPool workerPool,
                                     String deploymentID, JsonObject config, ClassLoader tccl) {
-    super(vertx, workerPool, deploymentID, config, tccl);
+    super(vertx, internalBlockingPool, workerPool, deploymentID, config, tccl);
   }
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerPool.workerPool.execute(wrapTask(null, task, false, workerPool.workerMetrics));
+    workerPool.executor().execute(wrapTask(null, task, false, workerPool.metrics()));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
+++ b/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class NamedWorkerExecutor implements WorkerExecutor, Closeable {
+
+  private final ContextImpl context;
+  final VertxImpl.NamedWorkerPool pool;
+  private boolean closed;
+
+  public NamedWorkerExecutor(ContextImpl context, VertxImpl.NamedWorkerPool pool) {
+    this.pool = pool;
+    this.context = context;
+  }
+
+  public WorkerPool getPool() {
+    return pool;
+  }
+
+  public synchronized <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> asyncResultHandler) {
+    if (closed) {
+      throw new IllegalStateException("Worker executor closed");
+    }
+    pool.executeBlocking(context, null, blockingCodeHandler, false, ordered, asyncResultHandler);
+  }
+
+  public <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> asyncResultHandler) {
+    executeBlocking(blockingCodeHandler, true, asyncResultHandler);
+  }
+
+  @Override
+  public void close() {
+    synchronized (this) {
+      if (!closed) {
+        closed = true;
+      } else {
+        return;
+      }
+    }
+    pool.release();
+  }
+
+  @Override
+  public void close(Handler<AsyncResult<Void>> completionHandler) {
+    close();
+    completionHandler.handle(Future.succeededFuture());
+  }
+
+}

--- a/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
+++ b/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
@@ -22,6 +22,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.WorkerExecutor;
 
+import java.util.concurrent.Executor;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -30,10 +32,12 @@ class NamedWorkerExecutor implements WorkerExecutor, Closeable {
   private final ContextImpl context;
   final VertxImpl.NamedWorkerPool pool;
   private boolean closed;
+  private final Executor workerExec;
 
   public NamedWorkerExecutor(ContextImpl context, VertxImpl.NamedWorkerPool pool) {
     this.pool = pool;
     this.context = context;
+    this.workerExec = pool.workerOrderedFact.getExecutor();
   }
 
   public WorkerPool getPool() {
@@ -44,7 +48,7 @@ class NamedWorkerExecutor implements WorkerExecutor, Closeable {
     if (closed) {
       throw new IllegalStateException("Worker executor closed");
     }
-    pool.executeBlocking(context, null, blockingCodeHandler, false, ordered, asyncResultHandler);
+    context.executeBlocking(null, blockingCodeHandler, asyncResultHandler, ordered ? workerExec : pool.workerPool, pool.workerMetrics);
   }
 
   public <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> asyncResultHandler) {

--- a/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
+++ b/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
@@ -37,7 +37,7 @@ class NamedWorkerExecutor implements WorkerExecutor, Closeable {
   public NamedWorkerExecutor(ContextImpl context, VertxImpl.NamedWorkerPool pool) {
     this.pool = pool;
     this.context = context;
-    this.workerExec = pool.workerOrderedFact.getExecutor();
+    this.workerExec = pool.createOrderedExecutor();
   }
 
   public WorkerPool getPool() {
@@ -48,7 +48,7 @@ class NamedWorkerExecutor implements WorkerExecutor, Closeable {
     if (closed) {
       throw new IllegalStateException("Worker executor closed");
     }
-    context.executeBlocking(null, blockingCodeHandler, asyncResultHandler, ordered ? workerExec : pool.workerPool, pool.workerMetrics);
+    context.executeBlocking(null, blockingCodeHandler, asyncResultHandler, ordered ? workerExec : pool.executor(), pool.metrics());
   }
 
   public <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> asyncResultHandler) {

--- a/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
+++ b/src/main/java/io/vertx/core/impl/NamedWorkerExecutor.java
@@ -30,11 +30,11 @@ import java.util.concurrent.Executor;
 class NamedWorkerExecutor implements WorkerExecutor, Closeable {
 
   private final ContextImpl context;
-  final VertxImpl.NamedWorkerPool pool;
+  final VertxImpl.SharedWorkerPool pool;
   private boolean closed;
   private final Executor workerExec;
 
-  public NamedWorkerExecutor(ContextImpl context, VertxImpl.NamedWorkerPool pool) {
+  public NamedWorkerExecutor(ContextImpl context, VertxImpl.SharedWorkerPool pool) {
     this.pool = pool;
     this.context = context;
     this.workerExec = pool.createOrderedExecutor();

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -21,6 +21,7 @@ import io.netty.channel.EventLoopGroup;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.impl.HttpServerImpl;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.impl.NetServerImpl;
@@ -66,12 +67,21 @@ public interface VertxInternal extends Vertx {
   /**
    * @return event loop context
    */
-  EventLoopContext createEventLoopContext(String deploymentID, JsonObject config, ClassLoader tccl);
+  EventLoopContext createEventLoopContext(String deploymentID, WorkerPool workerPool, JsonObject config, ClassLoader tccl);
 
   /**
    * @return worker loop context
    */
-  ContextImpl createWorkerContext(boolean multiThreaded, String deploymentID, JsonObject config, ClassLoader tccl);
+  ContextImpl createWorkerContext(boolean multiThreaded, String deploymentID, WorkerPool pool, JsonObject config, ClassLoader tccl);
+
+  @Override
+  NamedWorkerExecutor createWorkerExecutor(String name);
+
+  @Override
+  NamedWorkerExecutor createWorkerExecutor(String name, int poolSize);
+
+  @Override
+  NamedWorkerExecutor createWorkerExecutor(String name, int poolSize, long maxExecuteTime);
 
   void simulateKill();
 

--- a/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -24,12 +24,14 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 final class VertxThread extends FastThreadLocalThread {
 
   private final boolean worker;
+  private final long maxExecTime;
   private long execStart;
   private ContextImpl context;
 
-  public VertxThread(Runnable target, String name, boolean worker) {
+  public VertxThread(Runnable target, String name, boolean worker, long maxExecTime) {
     super(target, name);
     this.worker = worker;
+    this.maxExecTime = maxExecTime;
   }
 
   ContextImpl getContext() {
@@ -56,4 +58,7 @@ final class VertxThread extends FastThreadLocalThread {
     return worker;
   }
 
+  public long getMaxExecTime() {
+    return maxExecTime;
+  }
 }

--- a/src/main/java/io/vertx/core/impl/VertxThreadFactory.java
+++ b/src/main/java/io/vertx/core/impl/VertxThreadFactory.java
@@ -39,11 +39,13 @@ public class VertxThreadFactory implements ThreadFactory {
   private final AtomicInteger threadCount = new AtomicInteger(0);
   private final BlockedThreadChecker checker;
   private final boolean worker;
+  private final long maxExecTime;
 
-  VertxThreadFactory(String prefix, BlockedThreadChecker checker, boolean worker) {
+  VertxThreadFactory(String prefix, BlockedThreadChecker checker, boolean worker, long maxExecTime) {
     this.prefix = prefix;
     this.checker = checker;
     this.worker = worker;
+    this.maxExecTime = maxExecTime;
   }
 
   public static synchronized void unsetContext(ContextImpl ctx) {
@@ -55,7 +57,7 @@ public class VertxThreadFactory implements ThreadFactory {
   }
 
   public Thread newThread(Runnable runnable) {
-    VertxThread t = new VertxThread(runnable, prefix + threadCount.getAndIncrement(), worker);
+    VertxThread t = new VertxThread(runnable, prefix + threadCount.getAndIncrement(), worker, maxExecTime);
     // Vert.x threads are NOT daemons - we want them to prevent JVM exit so embededd user doesn't
     // have to explicitly prevent JVM from exiting.
     if (checker != null) {

--- a/src/main/java/io/vertx/core/impl/VertxThreadFactory.java
+++ b/src/main/java/io/vertx/core/impl/VertxThreadFactory.java
@@ -16,6 +16,8 @@
 
 package io.vertx.core.impl;
 
+import io.vertx.core.spi.metrics.ThreadPoolMetrics;
+
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ThreadFactory;

--- a/src/main/java/io/vertx/core/impl/WorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/WorkerContext.java
@@ -24,14 +24,14 @@ import io.vertx.core.json.JsonObject;
  */
 public class WorkerContext extends ContextImpl {
 
-  public WorkerContext(VertxInternal vertx, WorkerPool workerPool, String deploymentID,
+  public WorkerContext(VertxInternal vertx, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID,
                        JsonObject config, ClassLoader tccl) {
-    super(vertx, workerPool, deploymentID, config, tccl);
+    super(vertx, internalBlockingPool, workerPool, deploymentID, config, tccl);
   }
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerExec.execute(wrapTask(null, task, true, workerPool.workerMetrics));
+    workerExec.execute(wrapTask(null, task, true, workerPool.metrics()));
   }
 
   @Override
@@ -53,7 +53,7 @@ public class WorkerContext extends ContextImpl {
   // so we need to execute it on the worker thread
   @Override
   public void executeFromIO(ContextTask task) {
-    workerExec.execute(wrapTask(task, null, true, workerPool.workerMetrics));
+    workerExec.execute(wrapTask(task, null, true, workerPool.metrics()));
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/WorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/WorkerContext.java
@@ -31,7 +31,7 @@ public class WorkerContext extends ContextImpl {
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerPool.workerExec.execute(wrapTask(null, task, true, workerPool.workerMetrics));
+    workerExec.execute(wrapTask(null, task, true, workerPool.workerMetrics));
   }
 
   @Override
@@ -53,7 +53,7 @@ public class WorkerContext extends ContextImpl {
   // so we need to execute it on the worker thread
   @Override
   public void executeFromIO(ContextTask task) {
-    workerPool.workerExec.execute(wrapTask(task, null, true, workerPool.workerMetrics));
+    workerExec.execute(wrapTask(task, null, true, workerPool.workerMetrics));
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/WorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/WorkerContext.java
@@ -19,21 +19,19 @@ package io.vertx.core.impl;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 
-import java.util.concurrent.Executor;
-
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class WorkerContext extends ContextImpl {
 
-  public WorkerContext(VertxInternal vertx, Executor orderedInternalPoolExec, Executor workerExec, String deploymentID,
+  public WorkerContext(VertxInternal vertx, WorkerPool workerPool, String deploymentID,
                        JsonObject config, ClassLoader tccl) {
-    super(vertx, orderedInternalPoolExec, workerExec, deploymentID, config, tccl);
+    super(vertx, workerPool, deploymentID, config, tccl);
   }
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerExec.execute(wrapTask(null, task, true));
+    workerPool.workerExec.execute(wrapTask(null, task, true));
   }
 
   @Override
@@ -55,7 +53,7 @@ public class WorkerContext extends ContextImpl {
   // so we need to execute it on the worker thread
   @Override
   public void executeFromIO(ContextTask task) {
-    workerExec.execute(wrapTask(task, null, true));
+    workerPool.workerExec.execute(wrapTask(task, null, true));
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/WorkerContext.java
+++ b/src/main/java/io/vertx/core/impl/WorkerContext.java
@@ -31,7 +31,7 @@ public class WorkerContext extends ContextImpl {
 
   @Override
   public void executeAsync(Handler<Void> task) {
-    workerPool.workerExec.execute(wrapTask(null, task, true));
+    workerPool.workerExec.execute(wrapTask(null, task, true, workerPool.workerMetrics));
   }
 
   @Override
@@ -53,7 +53,7 @@ public class WorkerContext extends ContextImpl {
   // so we need to execute it on the worker thread
   @Override
   public void executeFromIO(ContextTask task) {
-    workerPool.workerExec.execute(wrapTask(task, null, true));
+    workerPool.workerExec.execute(wrapTask(task, null, true, workerPool.workerMetrics));
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/WorkerPool.java
+++ b/src/main/java/io/vertx/core/impl/WorkerPool.java
@@ -19,19 +19,39 @@ package io.vertx.core.impl;
 import io.vertx.core.spi.metrics.ThreadPoolMetrics;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 class WorkerPool {
 
-  protected final OrderedExecutorFactory workerOrderedFact;
-  protected final Executor workerPool;
-  protected final ThreadPoolMetrics workerMetrics;
+  private final OrderedExecutorFactory orderedFact;
+  private final ExecutorService pool;
+  private final ThreadPoolMetrics metrics;
 
-  public WorkerPool(Executor workerPool, ThreadPoolMetrics workerMetrics) {
-    this.workerOrderedFact = new OrderedExecutorFactory(workerPool);
-    this.workerPool = workerPool;
-    this.workerMetrics = workerMetrics;
+  public WorkerPool(ExecutorService pool, ThreadPoolMetrics metrics) {
+    this.orderedFact = new OrderedExecutorFactory(pool);
+    this.pool = pool;
+    this.metrics = metrics;
+  }
+
+  ExecutorService executor() {
+    return pool;
+  }
+
+  Executor createOrderedExecutor() {
+    return orderedFact.getExecutor();
+  }
+
+  ThreadPoolMetrics metrics() {
+    return metrics;
+  }
+
+  void close() {
+    if (metrics != null) {
+      metrics.close();
+    }
+    pool.shutdownNow();
   }
 }

--- a/src/main/java/io/vertx/core/impl/WorkerPool.java
+++ b/src/main/java/io/vertx/core/impl/WorkerPool.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class WorkerPool {
+
+  protected final Executor orderedInternalPoolExec;
+  protected final Executor workerExec;
+  protected final Executor workerPool;
+
+  public WorkerPool(Executor orderedInternalPoolExec, Executor workerExec, Executor workerPool) {
+    this.orderedInternalPoolExec = orderedInternalPoolExec;
+    this.workerExec = workerExec;
+    this.workerPool = workerPool;
+  }
+
+  <T> void executeBlocking(ContextImpl context, Action<T> action, Handler<Future<T>> blockingCodeHandler, boolean internal,
+                                   boolean ordered, Handler<AsyncResult<T>> resultHandler) {
+    try {
+      Executor exec = internal ? orderedInternalPoolExec : (ordered ? workerExec : workerPool);
+      exec.execute(() -> {
+        Future<T> res = Future.future();
+        try {
+          if (blockingCodeHandler != null) {
+            ContextImpl.setContext(context);
+            blockingCodeHandler.handle(res);
+          } else {
+            T result = action.perform();
+            res.complete(result);
+          }
+        } catch (Throwable e) {
+          res.fail(e);
+        }
+        if (resultHandler != null) {
+          context.runOnContext(v -> res.setHandler(resultHandler));
+        }
+      });
+    } catch (RejectedExecutionException ignore) {
+      // Pool is already shut down
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
+++ b/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
@@ -32,12 +32,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocket;
-import io.vertx.core.spi.metrics.DatagramSocketMetrics;
-import io.vertx.core.spi.metrics.EventBusMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
-import io.vertx.core.spi.metrics.HttpServerMetrics;
-import io.vertx.core.spi.metrics.TCPMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
+import io.vertx.core.spi.metrics.*;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
@@ -94,6 +89,12 @@ public class DummyVertxMetrics implements VertxMetrics {
   public DatagramSocketMetrics createMetrics(DatagramSocket socket, DatagramSocketOptions options) {
     return new DummyDatagramMetrics();
   }
+
+  @Override
+  public ThreadPoolMetrics createMetrics(String name, int poolSize) {
+    return new DummyWorkerPoolMetrics();
+  }
+
 
   @Override
   public void close() {
@@ -341,6 +342,35 @@ public class DummyVertxMetrics implements VertxMetrics {
     @Override
     public boolean isEnabled() {
       return false;
+    }
+  }
+
+  private class DummyWorkerPoolMetrics implements ThreadPoolMetrics<Void> {
+
+    @Override
+    public Void taskSubmitted() {
+      return null;
+    }
+
+    @Override
+    public void taskRejected(Void task) {
+    }
+
+    @Override
+    public void taskExecuting(Void task) {
+    }
+
+    @Override
+    public void taskCompleted(Void task, boolean succeeded) {
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return false;
+    }
+
+    @Override
+    public void close() {
     }
   }
 }

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -293,6 +293,37 @@
  *
  * A worker verticle is always executed with a thread from the worker pool.
  *
+ * By default blocking code is executed on the Vert.x blocking code pool, configured with {@link io.vertx.core.VertxOptions#setWorkerPoolSize(int)}.
+ *
+ * Additional pools can be created for different purposes:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.CoreExamples#workerExecutor1}
+ * ----
+ *
+ * The worker executor must be closed when it's not necessary anymore:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.CoreExamples#workerExecutor2}
+ * ----
+ *
+ * When several workers are created with the same name, they will share the same pool. The worker pool is destroyed
+ * when all the worker executors using it are closed.
+ *
+ * When an executor is created in a Verticle, Vert.x will close it automatically for you when the Verticle
+ * is undeployed.
+ *
+ * Worker executors can be configured when created:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.CoreExamples#workerExecutor3}
+ * ----
+ *
+ * NOTE: the configuration is set when the worker pool is created
+ *
  * == Async coordination
  *
  * Coordination of multiple asynchronous results can be achieved with Vert.x {@link io.vertx.core.Future futures}.
@@ -691,6 +722,18 @@
  *
  * If you're creating timers from inside verticles, those timers will be automatically closed
  * when the verticle is undeployed.
+ *
+ * === Verticle worker pool
+ *
+ * Verticle use the Vert.x worker pool for executing blocking actions, i.e {@link io.vertx.core.Context#executeBlocking} or
+ * worker verticle.
+ *
+ * A different worker pool can be specified in deployment options:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.CoreExamples#deployVerticleWithDifferentWorkerPool}
+ * ----
  *
  * [[event_bus]]
  * include::eventbus.adoc[]

--- a/src/main/java/io/vertx/core/spi/metrics/ThreadPoolMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/ThreadPoolMetrics.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.spi.metrics;
+
+/**
+ * An SPI used internally by Vert.x to gather metrics on a worker thread (execute blocking, worker verticle).
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public interface ThreadPoolMetrics<T> extends Metrics {
+
+  /**
+   * A new task has been submitted to the worker queue.
+   * This method is called from the submitter context.
+   *
+   * @return the submitted task.
+   */
+  T taskSubmitted();
+
+  /**
+   * The task has been rejected. The underlying thread pool has probably be shutdown.
+   */
+  void taskRejected(T task);
+
+  /**
+   * The submitted task start its execution.
+   */
+  void taskExecuting(T task);
+
+  /**
+   * The submitted tasks has completed its execution.
+   *
+   * @param succeeded whether or not the task has gracefully completed
+   */
+  void taskCompleted(T task, boolean succeeded);
+
+}

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -17,6 +17,7 @@
 package io.vertx.core.spi.metrics;
 
 import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.eventbus.EventBus;
@@ -25,11 +26,7 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.metrics.Measured;
-import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServer;
-import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.*;
 
 /**
  * The main Vert.x metrics SPI which Vert.x will use internally. This interface serves two purposes, one
@@ -43,7 +40,7 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Called when a verticle is deployed in Vert.x .<p/>
-   *
+   * <p>
    * This method is invoked with {@link io.vertx.core.Context} and thread of the deployed verticle and therefore
    * might be  different on every invocation.
    *
@@ -53,7 +50,7 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Called when a verticle is undeployed in Vert.x .<p/>
-   *
+   * <p>
    * This method is invoked with {@link io.vertx.core.Context} and thread of the deployed verticle and therefore
    * might be  different on every invocation, however these are the same than the {@link #verticleDeployed} invocation.
    *
@@ -63,7 +60,7 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Called when a timer is created
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.
    *
    * @param id the id of the timer
@@ -72,19 +69,19 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Called when a timer has ended (setTimer) or has been cancelled.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.
    *
-   * @param id the id of the timer
+   * @param id        the id of the timer
    * @param cancelled if the timer was cancelled by the user
    */
   void timerEnded(long id, boolean cancelled);
 
   /**
    * Provides the event bus metrics SPI when the event bus is created.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.<p/>
-   *
+   * <p>
    * This method should be called only once.
    *
    * @param eventBus the Vert.x event bus
@@ -94,27 +91,27 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Provides the http server metrics SPI when an http server is created.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.<p/>
-   *
+   * <p>
    * Note: this method can be called more than one time for the same {@code localAddress} when a server is
    * scaled, it is the responsibility of the metrics implementation to eventually merge metrics. In this case
    * the provided {@code server} argument can be used to distinguish the different {@code HttpServerMetrics}
    * instances.
    *
-   * @param server the Vert.x http server
+   * @param server       the Vert.x http server
    * @param localAddress localAddress the local address the net socket is listening on
-   * @param options the options used to create the {@link io.vertx.core.http.HttpServer}
+   * @param options      the options used to create the {@link io.vertx.core.http.HttpServer}
    * @return the http server metrics SPI
    */
   HttpServerMetrics<?, ?, ?> createMetrics(HttpServer server, SocketAddress localAddress, HttpServerOptions options);
 
   /**
    * Provides the http client metrics SPI when an http client has been created.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.
    *
-   * @param client the Vert.x http client
+   * @param client  the Vert.x http client
    * @param options the options used to create the {@link io.vertx.core.http.HttpClient}
    * @return the http client metrics SPI
    */
@@ -122,27 +119,27 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Provides the net server metrics SPI when a net server is created.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.<p/>
-   *
+   * <p>
    * Note: this method can be called more than one time for the same {@code localAddress} when a server is
    * scaled, it is the responsibility of the metrics implementation to eventually merge metrics. In this case
    * the provided {@code server} argument can be used to distinguish the different {@code TCPMetrics}
    * instances.
-   * 
-   * @param server the Vert.x net server
+   *
+   * @param server       the Vert.x net server
    * @param localAddress localAddress the local address the net socket is listening on
-   * @param options the options used to create the {@link io.vertx.core.net.NetServer}
+   * @param options      the options used to create the {@link io.vertx.core.net.NetServer}
    * @return the net server metrics SPI
    */
   TCPMetrics<?> createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options);
 
   /**
    * Provides the net client metrics SPI when a net client is created.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.
    *
-   * @param client the Vert.x net client
+   * @param client  the Vert.x net client
    * @param options the options used to create the {@link io.vertx.core.net.NetClient}
    * @return the net client metrics SPI
    */
@@ -150,10 +147,10 @@ public interface VertxMetrics extends Metrics, Measured {
 
   /**
    * Provides the datagram/udp metrics SPI when a datagram socket is created.<p/>
-   *
+   * <p>
    * No specific thread and context can be expected when this method is called.
    *
-   * @param socket the Vert.x datagram socket
+   * @param socket  the Vert.x datagram socket
    * @param options the options used to create the {@link io.vertx.core.datagram.DatagramSocket}
    * @return the datagram metrics SPI
    */
@@ -169,4 +166,13 @@ public interface VertxMetrics extends Metrics, Measured {
   default void eventBusInitialized(EventBus bus) {
     // Do nothing by default.
   }
+
+  /**
+   * Provides the thread pool metrics SPI.
+   *
+   * @param poolName the name of the thread pool
+   * @param poolSize the size of the pool
+   * @return the thread pool metrics SPI
+   */
+  ThreadPoolMetrics<?> createMetrics(String poolName, int poolSize);
 }

--- a/src/test/java/io/vertx/test/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/test/core/DeploymentTest.java
@@ -76,6 +76,15 @@ public class DeploymentTest extends VertxTestBase {
     List<String> isol = Arrays.asList("com.foo.MyClass", "org.foo.*");
     assertEquals(options, options.setIsolatedClasses(isol));
     assertSame(isol, options.getIsolatedClasses());
+    String workerPoolName = TestUtils.randomAlphaString(10);
+    assertEquals(options, options.setWorkerPoolName(workerPoolName));
+    assertEquals(workerPoolName, options.getWorkerPoolName());
+    int workerPoolSize = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setWorkerPoolSize(workerPoolSize));
+    assertEquals(workerPoolSize, options.getWorkerPoolSize());
+    long maxWorkerExecuteTime = TestUtils.randomPositiveLong();
+    assertEquals(options, options.setMaxWorkerExecuteTime(maxWorkerExecuteTime));
+    assertEquals(maxWorkerExecuteTime, options.getMaxWorkerExecuteTime());
   }
 
   @Test
@@ -89,6 +98,9 @@ public class DeploymentTest extends VertxTestBase {
     boolean ha = rand.nextBoolean();
     List<String> cp = Arrays.asList("foo", "bar");
     List<String> isol = Arrays.asList("com.foo.MyClass", "org.foo.*");
+    String poolName = TestUtils.randomAlphaString(10);
+    int poolSize = TestUtils.randomPositiveInt();
+    long maxWorkerExecuteTime = TestUtils.randomPositiveLong();
     options.setConfig(config);
     options.setWorker(worker);
     options.setMultiThreaded(multiThreaded);
@@ -96,6 +108,9 @@ public class DeploymentTest extends VertxTestBase {
     options.setHa(ha);
     options.setExtraClasspath(cp);
     options.setIsolatedClasses(isol);
+    options.setWorkerPoolName(poolName);
+    options.setWorkerPoolSize(poolSize);
+    options.setMaxWorkerExecuteTime(maxWorkerExecuteTime);
     DeploymentOptions copy = new DeploymentOptions(options);
     assertEquals(worker, copy.isWorker());
     assertEquals(multiThreaded, copy.isMultiThreaded());
@@ -107,6 +122,9 @@ public class DeploymentTest extends VertxTestBase {
     assertNotSame(cp, copy.getExtraClasspath());
     assertEquals(isol, copy.getIsolatedClasses());
     assertNotSame(isol, copy.getIsolatedClasses());
+    assertEquals(poolName, copy.getWorkerPoolName());
+    assertEquals(poolSize, copy.getWorkerPoolSize());
+    assertEquals(maxWorkerExecuteTime, copy.getMaxWorkerExecuteTime());
   }
 
   @Test
@@ -120,6 +138,9 @@ public class DeploymentTest extends VertxTestBase {
     assertEquals(def.isHa(), json.isHa());
     assertEquals(def.getExtraClasspath(), json.getExtraClasspath());
     assertEquals(def.getIsolatedClasses(), json.getIsolatedClasses());
+    assertEquals(def.getWorkerPoolName(), json.getWorkerPoolName());
+    assertEquals(def.getWorkerPoolSize(), json.getWorkerPoolSize());
+    assertEquals(def.getMaxWorkerExecuteTime(), json.getMaxWorkerExecuteTime());
   }
 
   @Test
@@ -132,6 +153,9 @@ public class DeploymentTest extends VertxTestBase {
     boolean ha = rand.nextBoolean();
     List<String> cp = Arrays.asList("foo", "bar");
     List<String> isol = Arrays.asList("com.foo.MyClass", "org.foo.*");
+    String poolName = TestUtils.randomAlphaString(10);
+    int poolSize = TestUtils.randomPositiveInt();
+    long maxWorkerExecuteTime = TestUtils.randomPositiveLong();
     JsonObject json = new JsonObject();
     json.put("config", config);
     json.put("worker", worker);
@@ -140,6 +164,9 @@ public class DeploymentTest extends VertxTestBase {
     json.put("ha", ha);
     json.put("extraClasspath", new JsonArray(cp));
     json.put("isolatedClasses", new JsonArray(isol));
+    json.put("workerPoolName", poolName);
+    json.put("workerPoolSize", poolSize);
+    json.put("maxWorkerExecuteTime", maxWorkerExecuteTime);
     DeploymentOptions options = new DeploymentOptions(json);
     assertEquals(worker, options.isWorker());
     assertEquals(multiThreaded, options.isMultiThreaded());
@@ -148,6 +175,9 @@ public class DeploymentTest extends VertxTestBase {
     assertEquals(ha, options.isHa());
     assertEquals(cp, options.getExtraClasspath());
     assertEquals(isol, options.getIsolatedClasses());
+    assertEquals(poolName, options.getWorkerPoolName());
+    assertEquals(poolSize, options.getWorkerPoolSize());
+    assertEquals(maxWorkerExecuteTime, options.getMaxWorkerExecuteTime());
   }
 
   @Test
@@ -161,6 +191,9 @@ public class DeploymentTest extends VertxTestBase {
     boolean ha = rand.nextBoolean();
     List<String> cp = Arrays.asList("foo", "bar");
     List<String> isol = Arrays.asList("com.foo.MyClass", "org.foo.*");
+    String poolName = TestUtils.randomAlphaString(10);
+    int poolSize = TestUtils.randomPositiveInt();
+    long maxWorkerExecuteTime = TestUtils.randomPositiveLong();
     options.setConfig(config);
     options.setWorker(worker);
     options.setMultiThreaded(multiThreaded);
@@ -168,6 +201,9 @@ public class DeploymentTest extends VertxTestBase {
     options.setHa(ha);
     options.setExtraClasspath(cp);
     options.setIsolatedClasses(isol);
+    options.setWorkerPoolName(poolName);
+    options.setWorkerPoolSize(poolSize);
+    options.setMaxWorkerExecuteTime(maxWorkerExecuteTime);
     JsonObject json = options.toJson();
     DeploymentOptions copy = new DeploymentOptions(json);
     assertEquals(worker, copy.isWorker());
@@ -177,6 +213,9 @@ public class DeploymentTest extends VertxTestBase {
     assertEquals(ha, copy.isHa());
     assertEquals(cp, copy.getExtraClasspath());
     assertEquals(isol, copy.getIsolatedClasses());
+    assertEquals(poolName, copy.getWorkerPoolName());
+    assertEquals(poolSize, copy.getWorkerPoolSize());
+    assertEquals(maxWorkerExecuteTime, copy.getMaxWorkerExecuteTime());
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/MetricsTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsTest.java
@@ -16,36 +16,19 @@
 
 package io.vertx.test.core;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.eventbus.ReplyFailure;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServer;
-import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.file.FileSystem;
+import io.vertx.core.http.*;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.net.NetSocket;
-import io.vertx.test.fakemetrics.FakeDatagramSocketMetrics;
-import io.vertx.test.fakemetrics.FakeEventBusMetrics;
-import io.vertx.test.fakemetrics.FakeHttpClientMetrics;
-import io.vertx.test.fakemetrics.FakeHttpServerMetrics;
-import io.vertx.test.fakemetrics.FakeMetricsBase;
-import io.vertx.test.fakemetrics.FakeMetricsFactory;
-import io.vertx.test.fakemetrics.FakeVertxMetrics;
-import io.vertx.test.fakemetrics.HandlerMetric;
-import io.vertx.test.fakemetrics.HttpClientMetric;
-import io.vertx.test.fakemetrics.HttpServerMetric;
-import io.vertx.test.fakemetrics.PacketMetric;
-import io.vertx.test.fakemetrics.ReceivedMessage;
-import io.vertx.test.fakemetrics.SentMessage;
-import io.vertx.test.fakemetrics.SocketMetric;
-import io.vertx.test.fakemetrics.WebSocketMetric;
+import io.vertx.core.spi.metrics.ThreadPoolMetrics;
+import io.vertx.test.fakemetrics.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -53,11 +36,15 @@ import org.junit.Test;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
+import static org.hamcrest.core.Is.is;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -189,7 +176,7 @@ public class MetricsTest extends VertxTestBase {
   private void testReceiveMessagePublished(Vertx from, Vertx to, boolean expectedLocal, int expectedHandlers) {
     FakeEventBusMetrics eventBusMetrics = FakeMetricsBase.getMetrics(to.eventBus());
     AtomicInteger count = new AtomicInteger();
-    for (int i = 0;i < expectedHandlers;i++) {
+    for (int i = 0; i < expectedHandlers; i++) {
       MessageConsumer<Object> consumer = to.eventBus().consumer(ADDRESS1);
       consumer.completionHandler(done -> {
         assertTrue(done.succeeded());
@@ -338,7 +325,7 @@ public class MetricsTest extends VertxTestBase {
     assertEquals(1, metrics.getReceivedMessages().size());
     HandlerMetric registration = metrics.getRegistrations().get(0);
     long now = System.currentTimeMillis();
-    while (registration.failureCount.get() < 1 && (System.currentTimeMillis() - now ) < 10 * 1000) {
+    while (registration.failureCount.get() < 1 && (System.currentTimeMillis() - now) < 10 * 1000) {
       Thread.sleep(10);
     }
     assertEquals(1, registration.beginCount.get());
@@ -682,5 +669,245 @@ public class MetricsTest extends VertxTestBase {
       assertTrue(ar.succeeded());
     });
     await();
+  }
+
+  @Test
+  public void testThreadPoolMetricsWithExecuteBlocking() {
+    Map<String, ThreadPoolMetrics> all = FakeThreadPoolMetrics.getThreadPoolMetrics();
+
+    FakeThreadPoolMetrics metrics = (FakeThreadPoolMetrics) all.get("vert.x-worker-thread");
+
+    assertThat(metrics.getPoolSize(), is(getOptions().getInternalBlockingPoolSize()));
+    assertThat(metrics.numberOfIdleThreads(), is(getOptions().getWorkerPoolSize()));
+
+    Handler<Future<Void>> job = getSomeDumbTask();
+
+    AtomicInteger counter = new AtomicInteger();
+    AtomicBoolean hadWaitingQueue = new AtomicBoolean();
+    AtomicBoolean hadIdle = new AtomicBoolean();
+    AtomicBoolean hadRunning = new AtomicBoolean();
+    for (int i = 0; i < 100; i++) {
+      vertx.executeBlocking(
+          job,
+          ar -> {
+            if (metrics.numberOfWaitingTasks() > 0) {
+              hadWaitingQueue.set(true);
+            }
+            if (metrics.numberOfIdleThreads() > 0) {
+              hadIdle.set(true);
+            }
+            if (metrics.numberOfRunningTasks() > 0) {
+              hadRunning.set(true);
+            }
+            if (counter.incrementAndGet() == 100) {
+              testComplete();
+            }
+          }
+      );
+    }
+
+    await();
+
+    assertEquals(metrics.submitted(), 100);
+    assertEquals(metrics.completed(), 100);
+    assertTrue(hadIdle.get());
+    assertTrue(hadWaitingQueue.get());
+    assertTrue(hadRunning.get());
+
+    assertEquals(metrics.numberOfIdleThreads(), getOptions().getWorkerPoolSize());
+    assertEquals(metrics.numberOfRunningTasks(), 0);
+    assertEquals(metrics.numberOfWaitingTasks(), 0);
+  }
+
+  @Test
+  public void testThreadPoolMetricsWithInternalExecuteBlocking() {
+    // Internal blocking thread pool is used by blocking file system actions.
+
+    Map<String, ThreadPoolMetrics> all = FakeThreadPoolMetrics.getThreadPoolMetrics();
+    FakeThreadPoolMetrics metrics = (FakeThreadPoolMetrics) all.get("vert.x-internal-blocking");
+
+    assertThat(metrics.getPoolSize(), is(getOptions().getInternalBlockingPoolSize()));
+    assertThat(metrics.numberOfIdleThreads(), is(getOptions().getInternalBlockingPoolSize()));
+
+    AtomicInteger counter = new AtomicInteger();
+    AtomicBoolean hadWaitingQueue = new AtomicBoolean();
+    AtomicBoolean hadIdle = new AtomicBoolean();
+    AtomicBoolean hadRunning = new AtomicBoolean();
+
+    FileSystem system = vertx.fileSystem();
+    for (int i = 0; i < 100; i++) {
+      vertx.executeBlocking(
+          fut -> {
+            system.readFile("afile.html", buffer -> {
+              fut.complete(null);
+            });
+          },
+          ar -> {
+            if (metrics.numberOfWaitingTasks() > 0) {
+              hadWaitingQueue.set(true);
+            }
+            if (metrics.numberOfIdleThreads() > 0) {
+              hadIdle.set(true);
+            }
+            if (metrics.numberOfRunningTasks() > 0) {
+              hadRunning.set(true);
+            }
+            if (counter.incrementAndGet() == 100) {
+              testComplete();
+            }
+          }
+      );
+    }
+
+    await();
+
+    assertEquals(metrics.submitted(), 100);
+    assertEquals(metrics.completed(), 100);
+    assertTrue(hadIdle.get());
+    assertTrue(hadWaitingQueue.get());
+    assertTrue(hadRunning.get());
+
+    assertEquals(metrics.numberOfIdleThreads(), getOptions().getWorkerPoolSize());
+    assertEquals(metrics.numberOfRunningTasks(), 0);
+    assertEquals(metrics.numberOfWaitingTasks(), 0);
+  }
+
+  @Test
+  public void testThreadPoolMetricsWithWorkerVerticle() {
+    testWithWorkerVerticle(new DeploymentOptions().setWorker(true));
+  }
+
+  @Test
+  public void testThreadPoolMetricsWithWorkerVerticleAndMultiThread() {
+    testWithWorkerVerticle(new DeploymentOptions().setWorker(true).setMultiThreaded(true));
+  }
+
+  private void testWithWorkerVerticle(DeploymentOptions options) {
+    AtomicInteger counter = new AtomicInteger();
+    Map<String, ThreadPoolMetrics> all = FakeThreadPoolMetrics.getThreadPoolMetrics();
+    FakeThreadPoolMetrics metrics = (FakeThreadPoolMetrics) all.get("vert.x-worker-thread");
+
+    assertThat(metrics.getPoolSize(), is(getOptions().getInternalBlockingPoolSize()));
+    assertThat(metrics.numberOfIdleThreads(), is(getOptions().getWorkerPoolSize()));
+
+    AtomicBoolean hadWaitingQueue = new AtomicBoolean();
+    AtomicBoolean hadIdle = new AtomicBoolean();
+    AtomicBoolean hadRunning = new AtomicBoolean();
+
+    int count = 100;
+
+    Verticle worker = new AbstractVerticle() {
+      @Override
+      public void start(Future<Void> done) throws Exception {
+        vertx.eventBus().localConsumer("message", d -> {
+              try {
+                Thread.sleep(10);
+
+                if (metrics.numberOfWaitingTasks() > 0) {
+                  hadWaitingQueue.set(true);
+                }
+                if (metrics.numberOfIdleThreads() > 0) {
+                  hadIdle.set(true);
+                }
+                if (metrics.numberOfRunningTasks() > 0) {
+                  hadRunning.set(true);
+                }
+
+                if (counter.incrementAndGet() == count) {
+                  testComplete();
+                }
+
+              } catch (InterruptedException e) {
+                Thread.currentThread().isInterrupted();
+              }
+            }
+        );
+        done.complete();
+      }
+    };
+
+
+    vertx.deployVerticle(worker, options, s -> {
+      for (int i = 0; i < count; i++) {
+        vertx.eventBus().send("message", i);
+      }
+    });
+
+    await();
+
+    // The verticle deployment is also executed on the worker thread pool
+    assertEquals(metrics.submitted(), count + 1);
+    assertEquals(metrics.completed(), count + 1);
+    assertTrue(hadIdle.get());
+    assertTrue(hadWaitingQueue.get());
+    assertTrue(hadRunning.get());
+
+    assertEquals(metrics.numberOfIdleThreads(), getOptions().getWorkerPoolSize());
+    assertEquals(metrics.numberOfRunningTasks(), 0);
+    assertEquals(metrics.numberOfWaitingTasks(), 0);
+  }
+
+  @Test
+  public void testThreadPoolMetricsWithNamedExecuteBlocking() {
+    vertx.close(); // Close the instance automatically created
+    vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
+
+    WorkerExecutor workerExec = vertx.createWorkerExecutor("my-pool", 10);
+
+    Map<String, ThreadPoolMetrics> all = FakeThreadPoolMetrics.getThreadPoolMetrics();
+
+    FakeThreadPoolMetrics metrics = (FakeThreadPoolMetrics) all.get("my-pool");
+
+    assertThat(metrics.getPoolSize(), is(10));
+    assertThat(metrics.numberOfIdleThreads(), is(10));
+
+    Handler<Future<Void>> job = getSomeDumbTask();
+
+    AtomicInteger counter = new AtomicInteger();
+    AtomicBoolean hadWaitingQueue = new AtomicBoolean();
+    AtomicBoolean hadIdle = new AtomicBoolean();
+    AtomicBoolean hadRunning = new AtomicBoolean();
+    for (int i = 0; i < 100; i++) {
+      workerExec.executeBlocking(
+          job,
+          false,
+          ar -> {
+            if (metrics.numberOfWaitingTasks() > 0) {
+              hadWaitingQueue.set(true);
+            }
+            if (metrics.numberOfIdleThreads() > 0) {
+              hadIdle.set(true);
+            }
+            if (metrics.numberOfRunningTasks() > 0) {
+              hadRunning.set(true);
+            }
+            if (counter.incrementAndGet() == 100) {
+              testComplete();
+            }
+          });
+    }
+
+    await();
+
+    assertEquals(metrics.submitted(), 100);
+    assertEquals(metrics.completed(), 100);
+    assertTrue(hadIdle.get());
+    assertTrue(hadWaitingQueue.get());
+    assertTrue(hadRunning.get());
+
+    assertEquals(metrics.numberOfIdleThreads(), 10);
+    assertEquals(metrics.numberOfRunningTasks(), 0);
+    assertEquals(metrics.numberOfWaitingTasks(), 0);
+  }
+
+  private Handler<Future<Void>> getSomeDumbTask() {
+    return (future) -> {
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        Thread.currentThread().isInterrupted();
+      }
+      future.complete(null);
+    };
   }
 }

--- a/src/test/java/io/vertx/test/core/NamedWorkerPoolTest.java
+++ b/src/test/java/io/vertx/test/core/NamedWorkerPoolTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *      The Eclipse Public License is available at
+ *      http://www.eclipse.org/legal/epl-v10.html
+ *
+ *      The Apache License v2.0 is available at
+ *      http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.WorkerExecutor;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class NamedWorkerPoolTest extends VertxTestBase {
+
+  @Test
+  public void testThread() {
+    String poolName = TestUtils.randomAlphaString(10);
+    WorkerExecutor worker = vertx.createWorkerExecutor(poolName);
+    worker.executeBlocking(fut -> {
+      assertTrue(Context.isOnVertxThread());
+      assertTrue(Context.isOnWorkerThread());
+      assertFalse(Context.isOnEventLoopThread());
+      assertTrue(Thread.currentThread().getName().startsWith("vert.x-" + poolName + "-"));
+      fut.complete(null);
+    }, ar -> {
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testOrdered() {
+    String poolName = TestUtils.randomAlphaString(10);
+    WorkerExecutor worker = vertx.createWorkerExecutor(poolName);
+    int num = 1000;
+    AtomicReference<Thread> t = new AtomicReference<>();
+    CountDownLatch submitted = new CountDownLatch(1);
+    for (int i = 0;i < num;i++) {
+      boolean first = i == 0;
+      boolean last = i == num - 1;
+      worker.executeBlocking(fut -> {
+        if (first) {
+          try {
+            awaitLatch(submitted);
+          } catch (InterruptedException e) {
+            fail(e);
+            return;
+          }
+          assertNull(t.get());
+          t.set(Thread.currentThread());
+        } else {
+          assertEquals(t.get(), Thread.currentThread());
+        }
+        assertTrue(Thread.currentThread().getName().startsWith("vert.x-" + poolName + "-"));
+        fut.complete(null);
+      }, ar -> {
+        if (last) {
+          testComplete();
+        }
+      });
+    }
+    submitted.countDown();
+    await();
+  }
+
+  @Test
+  public void testUnordered() throws Exception {
+    String poolName = TestUtils.randomAlphaString(10);
+    int num = 5;
+    waitFor(num);
+    WorkerExecutor worker = vertx.createWorkerExecutor(poolName);
+    CountDownLatch latch1 = new CountDownLatch(num);
+    CountDownLatch latch2 = new CountDownLatch(1);
+    for (int i = 0;i < num;i++) {
+      worker.executeBlocking(fut -> {
+        latch1.countDown();
+        try {
+          awaitLatch(latch2);
+        } catch (InterruptedException e) {
+          fail(e);
+          return;
+        }
+        assertTrue(Thread.currentThread().getName().startsWith("vert.x-" + poolName + "-"));
+        fut.complete(null);
+      }, false, ar -> {
+        complete();
+      });
+    }
+    awaitLatch(latch1);
+    latch2.countDown();
+    await();
+  }
+
+  @Test
+  public void testPoolSize() throws Exception {
+    String poolName = TestUtils.randomAlphaString(10);
+    int poolSize = 5;
+    waitFor(poolSize);
+    WorkerExecutor worker = vertx.createWorkerExecutor(poolName, poolSize);
+    CountDownLatch latch1 = new CountDownLatch(poolSize * 100);
+    Set<String> names = Collections.synchronizedSet(new HashSet<>());
+    for (int i = 0;i < poolSize * 100;i++) {
+      worker.executeBlocking(fut -> {
+        names.add(Thread.currentThread().getName());
+        latch1.countDown();
+      }, false, ar -> {
+      });
+    }
+    awaitLatch(latch1);
+    assertEquals(5, names.size());
+  }
+
+  @Test
+  public void testCloseWorkerPool() throws Exception {
+    String poolName = TestUtils.randomAlphaString(10);
+    AtomicReference<Thread> thread = new AtomicReference<>();
+    WorkerExecutor worker1 = vertx.createWorkerExecutor(poolName);
+    WorkerExecutor worker2 = vertx.createWorkerExecutor(poolName);
+    worker1.executeBlocking(fut -> {
+      thread.set(Thread.currentThread());
+    }, ar -> {
+    });
+    waitUntil(() -> thread.get() != null);
+    worker1.close();
+    assertNotSame(thread.get().getState(), Thread.State.TERMINATED);
+    worker2.close();
+    waitUntil(() -> thread.get().getState() == Thread.State.TERMINATED);
+  }
+
+  @Test
+  public void testDestroyWorkerPoolWhenVerticleUndeploys() throws Exception {
+    String poolName = TestUtils.randomAlphaString(10);
+    AtomicReference<Thread> thread = new AtomicReference<>();
+    AtomicReference<String> deployment = new AtomicReference<>();
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        WorkerExecutor pool = vertx.createWorkerExecutor(poolName);
+        pool.executeBlocking(fut -> {
+          thread.set(Thread.currentThread());
+        }, ar -> {
+        });
+      }
+    }, onSuccess(deployment::set));
+    waitUntil(() -> thread.get() != null);
+    vertx.undeploy(deployment.get(), onSuccess(v -> {}));
+    waitUntil(() -> thread.get().getState() == Thread.State.TERMINATED);
+  }
+
+  @Test
+  public void testDeployUsingNamedPool() throws Exception {
+    AtomicReference<Thread> thread = new AtomicReference<>();
+    String poolName = TestUtils.randomAlphaString(10);
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        vertx.executeBlocking(fut -> {
+          thread.set(Thread.currentThread());
+          assertTrue(Context.isOnVertxThread());
+          assertTrue(Context.isOnWorkerThread());
+          assertFalse(Context.isOnEventLoopThread());
+          assertTrue(Thread.currentThread().getName().startsWith("vert.x-" + poolName + "-"));
+          fut.complete();
+        }, onSuccess(v -> {
+          vertx.undeploy(context.deploymentID());
+        }));
+      }
+    }, new DeploymentOptions().setWorkerPoolName(poolName), onSuccess(v -> {}));
+    waitUntil(() -> thread.get() != null && thread.get().getState() == Thread.State.TERMINATED);
+  }
+
+  @Test
+  public void testDeployWorkerUsingNamedPool() throws Exception {
+    AtomicReference<Thread> thread = new AtomicReference<>();
+    AtomicReference<String> deployment = new AtomicReference<>();
+    String poolName = TestUtils.randomAlphaString(10);
+    vertx.deployVerticle(new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        thread.set(Thread.currentThread());
+        assertTrue(Context.isOnVertxThread());
+        assertTrue(Context.isOnWorkerThread());
+        assertFalse(Context.isOnEventLoopThread());
+        assertTrue(Thread.currentThread().getName().startsWith("vert.x-" + poolName + "-"));
+        context.runOnContext(v -> {
+          vertx.undeploy(context.deploymentID());
+        });
+      }
+    }, new DeploymentOptions().setWorker(true).setWorkerPoolName(poolName), onSuccess(deployment::set));
+    waitUntil(() -> thread.get() != null && thread.get().getState() == Thread.State.TERMINATED);
+  }
+}

--- a/src/test/java/io/vertx/test/fakemetrics/FakeMetricsBase.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeMetricsBase.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class FakeMetricsBase implements Metrics {
 
-  private static final ConcurrentHashMap<Object, FakeMetricsBase> metricsMap = new ConcurrentHashMap<>();
+  public static final ConcurrentHashMap<Object, FakeMetricsBase> metricsMap = new ConcurrentHashMap<>();
 
   public static <M extends FakeMetricsBase> M getMetrics(Measured measured) {
     // Free cast :-)

--- a/src/test/java/io/vertx/test/fakemetrics/FakeThreadPoolMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeThreadPoolMetrics.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.fakemetrics;
+
+import io.vertx.core.spi.metrics.ThreadPoolMetrics;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A fake implementation of the {@link ThreadPoolMetrics} SPI.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class FakeThreadPoolMetrics implements ThreadPoolMetrics<Void> {
+  private final static Map<String, ThreadPoolMetrics> METRICS = new ConcurrentHashMap<>();
+
+  private final int poolSize;
+
+  private final AtomicInteger submitted = new AtomicInteger();
+  private final AtomicInteger completed = new AtomicInteger();
+  private final AtomicInteger idle = new AtomicInteger();
+  private final AtomicInteger waiting = new AtomicInteger();
+  private final AtomicInteger running = new AtomicInteger();
+  private final String name;
+  private final AtomicBoolean closed = new AtomicBoolean();
+
+  public FakeThreadPoolMetrics(String name, int poolSize) {
+    this.poolSize = poolSize;
+    this.name = name;
+    this.idle.set(this.poolSize);
+    METRICS.put(name, this);
+  }
+
+  public int getPoolSize() {
+    return poolSize;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public synchronized Void taskSubmitted() {
+    submitted.incrementAndGet();
+    waiting.incrementAndGet();
+    return null;
+  }
+
+  @Override
+  public void taskRejected(Void task) {
+    waiting.decrementAndGet();
+  }
+
+  @Override
+  public void taskExecuting(Void task) {
+    waiting.decrementAndGet();
+    idle.decrementAndGet();
+    running.incrementAndGet();
+  }
+
+  @Override
+  public void taskCompleted(Void task, boolean succeeded) {
+    running.decrementAndGet();
+    idle.incrementAndGet();
+    completed.incrementAndGet();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public void close() {
+    closed.set(true);
+    METRICS.remove(name);
+  }
+
+  public boolean isClosed() {
+    return closed.get();
+  }
+
+  public int submitted() {
+    return submitted.get();
+  }
+
+  public int completed() {
+    return completed.get();
+  }
+
+  public int numberOfWaitingTasks() {
+    return waiting.get();
+  }
+
+  public int numberOfIdleThreads() {
+    return idle.get();
+  }
+
+  public int numberOfRunningTasks() {
+    return running.get();
+  }
+
+  public static Map<String, ThreadPoolMetrics> getThreadPoolMetrics() {
+    return METRICS;
+  }
+
+}

--- a/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -30,12 +30,7 @@ import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.spi.metrics.DatagramSocketMetrics;
-import io.vertx.core.spi.metrics.EventBusMetrics;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
-import io.vertx.core.spi.metrics.HttpServerMetrics;
-import io.vertx.core.spi.metrics.TCPMetrics;
-import io.vertx.core.spi.metrics.VertxMetrics;
+import io.vertx.core.spi.metrics.*;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -139,8 +134,13 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     return new FakeDatagramSocketMetrics(socket);
   }
 
+  @Override
+  public ThreadPoolMetrics createMetrics(String poolName, int poolSize) {
+    return new FakeThreadPoolMetrics(poolName, poolSize);
+  }
+
   public boolean isEnabled() {
-    throw new UnsupportedOperationException();
+    return true;
   }
 
   @Override


### PR DESCRIPTION
This PR handles:

* https://github.com/eclipse/vert.x/issues/1332
* https://github.com/eclipse/vert.x/issues/1333
* https://github.com/vert-x3/issues/issues/83
* https://github.com/eclipse/vert.x/issues/1246

It also provides "named" thread pool (as discussed on https://groups.google.com/forum/#!topic/vertx-dev/-J9ISW1x8eY)

* creation of extra named thread pool for specific purposes configured with pool size and max execute time
* specify a specific thread pool in Verticle deployment options
* a new SPI for ThreadPoolMetrics
* the collection of _worker_ thread metrics (worker, executeBlocking, internal blocking, named thread pools)