### PR TITLE
ClusteredEventBusTest.testDefaultCodecReplyExceptionSubclass test is fixed

### DIFF
--- a/src/test/java/io/vertx/test/core/ClusteredEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/ClusteredEventBusTest.java
@@ -142,11 +142,14 @@ public class ClusteredEventBusTest extends ClusteredEventBusTestBase {
     MyReplyExceptionMessageCodec codec = new MyReplyExceptionMessageCodec();
     vertices[0].eventBus().registerDefaultCodec(MyReplyException.class, codec);
     vertices[1].eventBus().registerDefaultCodec(MyReplyException.class, codec);
-    vertices[0].eventBus().<ReplyException>consumer(ADDRESS1, msg -> {
+    MessageConsumer<ReplyException> reg = vertices[0].eventBus().<ReplyException>consumer(ADDRESS1, msg -> {
       assertTrue(msg.body() instanceof MyReplyException);
       testComplete();
     });
-    vertices[1].eventBus().send(ADDRESS1, myReplyException);
+    reg.completionHandler(ar -> {
+      vertices[1].eventBus().send(ADDRESS1, myReplyException);
+    });
+
     await();
   }
 


### PR DESCRIPTION
Fix for issue #1406.

Signed-off-by: Andrey Gura <andreyn.gura@gmail.com>