### PR TITLE
Issues/#1361 add another unit test

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1187,7 +1187,7 @@ the Program arguments write: `run your-verticle-fully-qualified-name --redeploy=
 the module explicitly (_Build_ menu -> _Make project_).
 
 To debug your application, create your run configuration as a remote application and configure the debugger
-using `--java-opts`. However, don’t forget to re-plug the debugger after every redeployment as a new process is
+using `--java-opts`. However, don't forget to re-plug the debugger after every redeployment as a new process is
 created every time.
 
 You can also hook your build process in the redeploy cycle:

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1094,7 +1094,7 @@
  * the module explicitly (_Build_ menu -> _Make project_).
  *
  * To debug your application, create your run configuration as a remote application and configure the debugger
- * using `--java-opts`. However, don’t forget to re-plug the debugger after every redeployment as a new process is
+ * using `--java-opts`. However, don't forget to re-plug the debugger after every redeployment as a new process is
  * created every time.
  *
  * You can also hook your build process in the redeploy cycle:

--- a/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
+++ b/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
@@ -29,6 +29,7 @@ public class ConnectHttpProxy {
   private final String username;
   private HttpServer server;
   private String lastUri;
+  private String forceUri;
 
   public ConnectHttpProxy(String username) {
     this.username = username;
@@ -40,6 +41,14 @@ public class ConnectHttpProxy {
    */
   public String getLastUri() {
     return lastUri;
+  }
+
+  /**
+   * force uri to connect to a given string (e.g. "localhost:4443")
+   * this is to simulate a host that only resolves on the proxy
+   */
+  public void setForceUri(String uri) {
+    forceUri = uri;
   }
 
   /**
@@ -69,6 +78,9 @@ public class ConnectHttpProxy {
         request.response().setStatusCode(405).end("method not allowed");
       } else {
         lastUri = uri;
+        if (forceUri != null) {
+          uri = forceUri;
+        }
         String split[] = uri.split(":");
         String host = split[0];
         int port;

--- a/src/test/java/io/vertx/test/core/HttpTLSTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTLSTest.java
@@ -726,8 +726,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   public void testHttpsProxy() throws Exception {
     startProxy(null);
     testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy().pass();
-    // check that the connection did in fact go through the proxy
-    assertNotNull(proxy.getLastUri());
+    assertNotNull("connection didn't access the proxy", proxy.getLastUri());
     assertEquals("hostname resolved but it shouldn't be", "localhost:4043", proxy.getLastUri());
   }
 
@@ -743,8 +742,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   public void testHttpsProxyAuth() throws Exception {
     startProxy("username");
     testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy().useProxyAuth().pass();
-    // check that the connection did in fact go through the proxy
-    assertNotNull(proxy.getLastUri());
+    assertNotNull("connection didn't access the proxy", proxy.getLastUri());
     assertEquals("hostname resolved but it shouldn't be", "localhost:4043", proxy.getLastUri());
   }
 
@@ -757,8 +755,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
     proxy.setForceUri("localhost:4043");
     testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy().useProxyAuth()
         .connectHostname("doesnt-resolve.host-name").clientTrustAll().clientVerifyHost(false).pass();
-    // check that the connection did in fact go through the proxy
-    assertNotNull(proxy.getLastUri());
+    assertNotNull("connection didn't access the proxy", proxy.getLastUri());
     assertEquals("hostname resolved but it shouldn't be", "doesnt-resolve.host-name:4043", proxy.getLastUri());
   }
 }


### PR DESCRIPTION
Issues/#1361 add another unit test:

The unit test previously tested if localhost is resolved or not (which shows the issue we had), however I prefer to have a test where the dns resolution really fails it is being done.
The unit test is quite simple, the one general thing I had to change in the TLS test implementation is to support clientVerifyHost(false).
