### PR TITLE
Functional idioms for Vert.x futures

### DIFF
--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -22,7 +22,7 @@ import io.vertx.core.impl.CompositeFutureImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * The composite future wraps a list of {@link Future futures}, it is useful when several futures
@@ -74,7 +74,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
 
   /**
    * Like {@link #all(Future, Future)} but with a list of futures.<p>
-   *
+   * <p>
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture all(List<Future> futures) {
@@ -122,11 +122,79 @@ public interface CompositeFuture extends Future<CompositeFuture> {
 
   /**
    * Like {@link #any(Future, Future)} but with a list of futures.<p>
-   *
+   * <p>
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture any(List<Future> futures) {
     return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Reduction of futures.
+   * <p>
+   * When all futures succeed, then the resulting future succeeds with the reduction of their values using {@code zero}
+   * as an initializer, and {@code reducer} as a reduction function.
+   * <p>
+   * If any future fails, then the resulting future also fails with the first failing future exception.
+   *
+   * @param zero    the reduction initial value
+   * @param reducer the reduction function
+   * @param f1      the first future
+   * @param f2      the second future
+   * @param <T>     the futures base type for success values
+   * @param <U>     the reduction success value type
+   * @return a reduction future
+   */
+  static <T, U> Future<U> reduce(U zero, BiFunction<U, T, U> reducer, Future<? extends T> f1, Future<? extends T> f2) {
+    return CompositeFutureImpl.reduce(zero, reducer, f1, f2);
+  }
+
+  /**
+   * Reduction with 3 futures.
+   *
+   * @see CompositeFuture#reduce(Object, BiFunction, Future, Future)
+   */
+  static <T, U> Future<U> reduce(U zero, BiFunction<U, T, U> reducer, Future<? extends T> f1, Future<? extends T> f2, Future<? extends T> f3) {
+    return CompositeFutureImpl.reduce(zero, reducer, f1, f2, f3);
+  }
+
+  /**
+   * Reduction with 4 futures.
+   *
+   * @see CompositeFuture#reduce(Object, BiFunction, Future, Future)
+   */
+  static <T, U> Future<U> reduce(U zero, BiFunction<U, T, U> reducer, Future<? extends T> f1, Future<? extends T> f2, Future<? extends T> f3, Future<? extends T> f4) {
+    return CompositeFutureImpl.reduce(zero, reducer, f1, f2, f3, f4);
+  }
+
+  /**
+   * Reduction with 5 futures.
+   *
+   * @see CompositeFuture#reduce(Object, BiFunction, Future, Future)
+   */
+  static <T, U> Future<U> reduce(U zero, BiFunction<U, T, U> reducer, Future<? extends T> f1, Future<? extends T> f2, Future<? extends T> f3, Future<? extends T> f4, Future<? extends T> f5) {
+    return CompositeFutureImpl.reduce(zero, reducer, f1, f2, f3, f4, f5);
+  }
+
+  /**
+   * Reduction with 6 futures.
+   *
+   * @see CompositeFuture#reduce(Object, BiFunction, Future, Future)
+   */
+  static <T, U> Future<U> reduce(U zero, BiFunction<U, T, U> reducer, Future<? extends T> f1, Future<? extends T> f2, Future<? extends T> f3, Future<? extends T> f4, Future<? extends T> f5, Future<? extends T> f6) {
+    return CompositeFutureImpl.reduce(zero, reducer, f1, f2, f3, f4, f5, f6);
+  }
+
+  /**
+   * Reduction with a list of futures.
+   * <p>
+   * The resulting future succeeds with value {@code zero} if {@code futures} is an empty list.
+   *
+   * @see CompositeFuture#reduce(Object, BiFunction, Future, Future)
+   */
+  @SuppressWarnings("unchecked")
+  static <T, U> Future<U> reduce(U zero, BiFunction<U, T, U> reducer, List<Future<? extends T>> futures) {
+    return CompositeFutureImpl.reduce(zero, reducer, futures.toArray(new Future[futures.size()]));
   }
 
   @Override
@@ -174,13 +242,13 @@ public interface CompositeFuture extends Future<CompositeFuture> {
 
   /**
    * @return a list of the current completed values. If one future is not yet resolved or is failed, {@code} null
-   *         will be used
+   * will be used
    */
   @GenIgnore
   default <T> List<T> list() {
     int size = size();
     ArrayList<T> list = new ArrayList<>(size);
-    for (int index = 0;index < size;index++) {
+    for (int index = 0; index < size; index++) {
       list.add(result(index));
     }
     return list;

--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -22,7 +22,9 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.spi.FutureFactory;
 
+import java.util.NoSuchElementException;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Represents the result of an action that may, or may not, have occurred yet.
@@ -36,8 +38,8 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Create a future that hasn't completed yet
    *
-   * @param <T>  the result type
-   * @return  the future
+   * @param <T> the result type
+   * @return the future
    */
   static <T> Future<T> future() {
     return factory.future();
@@ -46,8 +48,8 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Create a succeeded future with a null result
    *
-   * @param <T>  the result type
-   * @return  the future
+   * @param <T> the result type
+   * @return the future
    */
   static <T> Future<T> succeededFuture() {
     return factory.completedFuture();
@@ -56,9 +58,9 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Created a succeeded future with the specified result.
    *
-   * @param result  the result
-   * @param <T>  the result type
-   * @return  the future
+   * @param result the result
+   * @param <T>    the result type
+   * @return the future
    */
   static <T> Future<T> succeededFuture(T result) {
     return factory.completedFuture(result);
@@ -67,9 +69,9 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Create a failed future with the specified failure cause.
    *
-   * @param t  the failure cause as a Throwable
-   * @param <T>  the result type
-   * @return  the future
+   * @param t   the failure cause as a Throwable
+   * @param <T> the result type
+   * @return the future
    */
   @GenIgnore
   static <T> Future<T> failedFuture(Throwable t) {
@@ -79,9 +81,9 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Create a failed future with the specified failure message.
    *
-   * @param failureMessage  the failure message
-   * @param <T>  the result type
-   * @return  the future
+   * @param failureMessage the failure message
+   * @param <T>            the result type
+   * @return the future
    */
   static <T> Future<T> failedFuture(String failureMessage) {
     return factory.completedFuture(failureMessage, true);
@@ -102,9 +104,8 @@ public interface Future<T> extends AsyncResult<T> {
    * If the future has already been completed it will be called immediately. Otherwise it will be called when the
    * future is completed.
    *
-   * @param handler  the Handler that will be called with the result
+   * @param handler the Handler that will be called with the result
    * @return a reference to this, so it can be used fluently
-   *
    */
   @Fluent
   Future<T> setHandler(Handler<AsyncResult<T>> handler);
@@ -112,7 +113,7 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Set the result. Any handler will be called, if there is one, and the future will be marked as completed.
    *
-   * @param result  the result
+   * @param result the result
    * @throws IllegalStateException when the future is already completed
    */
   void complete(T result);
@@ -127,14 +128,14 @@ public interface Future<T> extends AsyncResult<T> {
   /**
    * Set the failure. Any handler will be called, if there is one, and the future will be marked as completed.
    *
-   * @param throwable  the failure cause
+   * @param throwable the failure cause
    */
   void fail(Throwable throwable);
 
   /**
    * Set the failure. Any handler will be called, if there is one, and the future will be marked as completed.
    *
-   * @param failureMessage  the failure message
+   * @param failureMessage the failure message
    */
   void fail(String failureMessage);
 
@@ -172,16 +173,16 @@ public interface Future<T> extends AsyncResult<T> {
 
   /**
    * Compose this future with a provided {@code next} future.<p>
-   *
+   * <p>
    * When this future succeeds, the {@code handler} will be called with the completed value, this handler
    * should complete the next future.<p>
-   *
+   * <p>
    * If the {@code handler} throws an exception, the returned future will be failed with this exception.<p>
-   *
+   * <p>
    * When this future fails, the failure will be propagated to the {@code next} future and the {@code handler}
    * will not be called.
    *
-   * @param handler the handler
+   * @param handler  the handler
    * @param composed the composed future
    * @return the composed future, used for chaining
    */
@@ -205,12 +206,12 @@ public interface Future<T> extends AsyncResult<T> {
 
   /**
    * Compose this future with a {@code mapper} function.<p>
-   *
+   * <p>
    * When this future succeeds, the {@code mapper} will be called with the completed value and this mapper
    * returns a future. This returned future completion will trigger the future returned by this method call.<p>
-   *
+   * <p>
    * If the {@code mapper} throws an exception, the returned future will be failed with this exception.<p>
-   *
+   * <p>
    * When this future fails, the failure will be propagated to the returned future and the {@code mapper}
    * will not be called.
    *
@@ -238,12 +239,12 @@ public interface Future<T> extends AsyncResult<T> {
 
   /**
    * Apply a {@code mapper} function on this future.<p>
-   *
+   * <p>
    * When this future succeeds, the {@code mapper} will be called with the completed value and this mapper
    * returns a value. This value will complete the future returned by this method call.<p>
-   *
+   * <p>
    * If the {@code mapper} throws an exception, the returned future will be failed with this exception.<p>
-   *
+   * <p>
    * When this future fails, the failure will be propagated to the returned future and the {@code mapper}
    * will not be called.
    *
@@ -271,9 +272,9 @@ public interface Future<T> extends AsyncResult<T> {
 
   /**
    * Map the result of a future to a specific {@code value}.<p>
-   *
+   * <p>
    * When this future succeeds, this {@code value} will complete the future returned by this method call.<p>
-   *
+   * <p>
    * When this future fails, the failure will be propagated to the returned future.
    *
    * @param value the value that eventually completes the mapped future
@@ -292,7 +293,7 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   /**
-   * @return an handler completing this future
+   * @return a handler completing this future
    */
   @CacheReturn
   default Handler<AsyncResult<T>> completer() {
@@ -305,6 +306,92 @@ public interface Future<T> extends AsyncResult<T> {
     };
   }
 
-  static FutureFactory factory = ServiceHelper.loadFactory(FutureFactory.class);
+  /**
+   * Fallbacks to another future result.
+   * <p>
+   * When this future succeeds, then the resulting future succeeds with that value.
+   * When this future fails, then the resulting future will succeed or fail depending on the outcome of {@code fallback}.
+   *
+   * @param fallback a fallback future to use if this future fails
+   * @return a future that fallbacks to {@fallback}
+   */
+  default Future<T> fallbackTo(Future<T> fallback) {
+    Future<T> fallbackFuture = future();
+    setHandler(thisResult -> {
+      if (thisResult.succeeded()) {
+        fallbackFuture.complete(thisResult.result());
+      } else {
+        fallback.setHandler(fallbackResult -> {
+          if (fallbackResult.succeeded()) {
+            fallbackFuture.complete(fallbackResult.result());
+          } else {
+            fallbackFuture.fail(fallbackResult.cause());
+          }
+        });
+      }
+    });
+    return fallbackFuture;
+  }
+
+  /**
+   * Filters the result of this future against a predicate.
+   * <p>
+   * When this future succeeds, then the resulting future either succeeds with this value if it satisfies the provided
+   * predicate, or it fails with a {@link NoSuchElementException}.
+   * <p>
+   * When this future fails, then the resulting future also fails with this future exception.
+   *
+   * @param predicate a predicate
+   * @return a filtering future
+   */
+  default Future<T> filter(Predicate<T> predicate) {
+    Future<T> resultingFuture = future();
+    setHandler(res -> {
+      if (res.succeeded()) {
+        if (predicate.test(res.result())) {
+          resultingFuture.complete(res.result());
+        } else {
+          resultingFuture.fail(new NoSuchElementException());
+        }
+      } else {
+        resultingFuture.fail(res.cause());
+      }
+    });
+    return resultingFuture;
+  }
+
+  /**
+   * Performs a flatMap operation to that future.
+   * <p>
+   * When this future succeeds, then the resulting future applies a future-returning function to its result value.
+   * The resulting future then succeeds or fails depending on the outcome of the future returned by {@code mapper}.
+   * <p>
+   * When this future fails, it also fails with this future exception.
+   *
+   * @param mapper a function to flatMap
+   * @param <U>    a resulting type
+   * @return a flatMap future
+   */
+  default <U> Future<U> flatMap(Function<T, Future<U>> mapper) {
+    Future<U> resultingFuture = future();
+    setHandler(res -> {
+      if (res.succeeded()) {
+        mapper
+            .apply(res.result())
+            .setHandler(ar -> {
+              if (ar.succeeded()) {
+                resultingFuture.complete(ar.result());
+              } else {
+                resultingFuture.fail(ar.cause());
+              }
+            });
+      } else {
+        resultingFuture.fail(res.cause());
+      }
+    });
+    return resultingFuture;
+  }
+
+  FutureFactory factory = ServiceHelper.loadFactory(FutureFactory.class);
 
 }


### PR DESCRIPTION
Vert.x futures already had a map operation.

This set of changes goes further and introduces the following functional idioms:

* fallback of a future to another future
* filter using a predicate
* a flatMap operation
* reduction over futures (complements any() and all())