### PR TITLE
add exit codes in the launcher commands

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1576,3 +1576,15 @@ overriding `link:../../apidocs/io/vertx/core/Launcher.html#afterStartingVertx-io
 `link:../../apidocs/io/vertx/core/impl/launcher/VertxCommandLauncher.html#getDefaultCommand--[getDefaultCommand]`
 * add / remove commands using `link:../../apidocs/io/vertx/core/impl/launcher/VertxCommandLauncher.html#register-java.lang.Class-[register]`
 and `link:../../apidocs/io/vertx/core/impl/launcher/VertxCommandLauncher.html#unregister-java.lang.String-[unregister]`
+
+=== Launcher and exit code
+
+When you use the `link:../../apidocs/io/vertx/core/Launcher.html[Launcher]` class as main class, it uses the following exit code:
+
+* `0` if the process ends smoothly, or if an uncaught error is thrown
+* `1` for general purpose error
+* `11` if Vert.x cannot be initialized
+* `12` if a spawn process cannot be started, found or stopped. This error code is used by the `start` and
+`stop` command
+* `14` if the system configuration is not meeting the system requirement (shc as java not found)
+* `15` if the main verticle cannot be deployed

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ExecUtils.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ExecUtils.java
@@ -88,5 +88,42 @@ public class ExecUtils {
     return osName.contains("windows");
   }
 
+  /**
+   * Exits the JVM with the given exit code.
+   * @param code the code, {@code 0} for success. By convention a non zero value if return to denotes an
+   *             error.
+   */
+  public static void exit(int code) {
+    System.exit(code);
+  }
+
+  /**
+   * Exits the JVM and indicate an issue during the Vert.x initialization.
+   */
+  public static void exitBecauseOfVertxInitializationIssue() {
+    exit(1);
+  }
+
+  /**
+   * Exits the JVM and indicate an issue during the deployment of the main verticle.
+   */
+  public static void exitBecauseOfVertxDeploymentIssue() {
+    exit(5);
+  }
+
+  /**
+   * Exits the JVM and indicate an issue with a process creation or termination.
+   */
+  public static void exitBecauseOfProcessIssue() {
+    exit(2);
+  }
+
+  /**
+   * Exits the JVM and indicate an issue with the system configuration.
+   */
+  public static void exitBecauseOfSystemConfigurationIssue() {
+    exit(3);
+  }
+
 
 }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/ExecUtils.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/ExecUtils.java
@@ -27,6 +27,37 @@ public class ExecUtils {
   private static final String SINGLE_QUOTE = "\'";
   private static final String DOUBLE_QUOTE = "\"";
 
+
+  // A note about exit code
+  // * 0 for success
+  // * 1 for general error
+  // * exit codes 1-2, 126-165, and 255 have special meanings, and should therefore be avoided for user-specified
+  // exit parameters
+  // * Ending with exit 127 would certainly cause confusion when troubleshooting as it's the command not found code
+  // * 130, 134, 133, 135, 137, 140, 129, 142, 143, 145, 146, 149, 150, 152, 154, 155, 158 are used by the JVM, and
+  // so have special meanings
+  // * it's better to avoid 3-9
+
+  /**
+   * Error code used when vert.x cannot be initialized.
+   */
+  public static final int VERTX_INITIALIZATION_EXIT_CODE = 11;
+
+  /**
+   * Error code used when a deployment failed.
+   */
+  public static final int VERTX_DEPLOYMENT_EXIT_CODE = 15;
+
+  /**
+   * Error code used when a spawn process cannot be found, created, or stopped smoothly.
+   */
+  public static final int PROCESS_ERROR_EXIT_CODE = 12;
+
+  /**
+   * Error code used when the system configuration does not satisfy the requirements (java not found for example).
+   */
+  public static final int SYSTEM_CONFIGURATION_EXIT_CODE = 14;
+
   /**
    * The {@code os.name} property is mandatory (from the Java Virtual Machine specification).
    */
@@ -50,7 +81,7 @@ public class ExecUtils {
 
     // strip the quotes from both ends
     while (cleanedArgument.startsWith(SINGLE_QUOTE) && cleanedArgument.endsWith(SINGLE_QUOTE)
-        || cleanedArgument.startsWith(DOUBLE_QUOTE)  && cleanedArgument.endsWith(DOUBLE_QUOTE)) {
+        || cleanedArgument.startsWith(DOUBLE_QUOTE) && cleanedArgument.endsWith(DOUBLE_QUOTE)) {
       cleanedArgument = cleanedArgument.substring(1, cleanedArgument.length() - 1);
     }
 
@@ -74,7 +105,7 @@ public class ExecUtils {
   /**
    * Adds an argument to the given list. It automatically adds quotes to the argument if necessary.
    *
-   * @param args the list of arguments
+   * @param args     the list of arguments
    * @param argument the argument to add
    */
   public static void addArgument(List<String> args, String argument) {
@@ -90,6 +121,7 @@ public class ExecUtils {
 
   /**
    * Exits the JVM with the given exit code.
+   *
    * @param code the code, {@code 0} for success. By convention a non zero value if return to denotes an
    *             error.
    */
@@ -101,28 +133,28 @@ public class ExecUtils {
    * Exits the JVM and indicate an issue during the Vert.x initialization.
    */
   public static void exitBecauseOfVertxInitializationIssue() {
-    exit(1);
+    exit(VERTX_INITIALIZATION_EXIT_CODE);
   }
 
   /**
    * Exits the JVM and indicate an issue during the deployment of the main verticle.
    */
   public static void exitBecauseOfVertxDeploymentIssue() {
-    exit(5);
+    exit(VERTX_DEPLOYMENT_EXIT_CODE);
   }
 
   /**
    * Exits the JVM and indicate an issue with a process creation or termination.
    */
   public static void exitBecauseOfProcessIssue() {
-    exit(2);
+    exit(PROCESS_ERROR_EXIT_CODE);
   }
 
   /**
    * Exits the JVM and indicate an issue with the system configuration.
    */
   public static void exitBecauseOfSystemConfigurationIssue() {
-    exit(3);
+    exit(SYSTEM_CONFIGURATION_EXIT_CODE);
   }
 
 

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -240,7 +240,8 @@ public class RunCommand extends BareCommand {
 
       super.run();
       if (vertx == null) {
-        return; // Already logged.
+        // Already logged.
+        ExecUtils.exitBecauseOfVertxInitializationIssue();
       }
       deploymentOptions = new DeploymentOptions();
       configureFromSystemProperties(deploymentOptions, DEPLOYMENT_OPTIONS_PROP_PREFIX);
@@ -298,8 +299,7 @@ public class RunCommand extends BareCommand {
    * @param onCompletion an optional on-completion handler. If set it must be invoked at the end of this method.
    */
   protected synchronized void stopBackgroundApplication(Handler<Void> onCompletion) {
-    executionContext.execute("stop", vertxApplicationBackgroundId);
-
+    executionContext.execute("stop", vertxApplicationBackgroundId, "--redeploy");
     if (redeployTerminationPeriod > 0) {
       try {
         Thread.sleep(redeployTerminationPeriod);
@@ -383,6 +383,8 @@ public class RunCommand extends BareCommand {
   private void handleDeployFailed(Throwable cause) {
     if (executionContext.main() instanceof VertxLifecycleHooks) {
       ((VertxLifecycleHooks) executionContext.main()).handleDeployFailed(vertx, mainVerticle, deploymentOptions, cause);
+    } else {
+      ExecUtils.exitBecauseOfVertxDeploymentIssue();
     }
   }
 

--- a/src/main/java/io/vertx/core/impl/launcher/commands/StartCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/StartCommand.java
@@ -22,7 +22,6 @@ import io.vertx.core.impl.launcher.CommandLineUtils;
 import io.vertx.core.spi.launcher.DefaultCommand;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -124,9 +123,10 @@ public class StartCommand extends DefaultCommand {
       }
       builder.start();
       out.println(id);
-    } catch (IOException e) {
+    } catch (Exception e) {
       out.println("Cannot create vert.x application process");
       e.printStackTrace(out);
+      ExecUtils.exitBecauseOfProcessIssue();
     }
 
   }
@@ -162,8 +162,8 @@ public class StartCommand extends DefaultCommand {
     }
 
     if (!java.isFile()) {
-      throw new IllegalStateException("Cannot find java executable - " + java.getAbsolutePath()
-          + " does not exist");
+      out.println("Cannot find java executable - " + java.getAbsolutePath() + " does not exist");
+      ExecUtils.exitBecauseOfSystemConfigurationIssue();
     }
     return java;
   }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
@@ -278,7 +278,8 @@ public class Watcher implements Runnable {
             .redirectOutput(ProcessBuilder.Redirect.INHERIT)
             .start();
 
-        process.waitFor();
+        int status = process.waitFor();
+        System.out.println("User command terminated with status " + status);
       } catch (Throwable e) {
         System.err.println("Error while executing the on-redeploy command : '" + cmd + "'");
         e.printStackTrace();

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1476,6 +1476,19 @@
  * * add / remove commands using {@link io.vertx.core.impl.launcher.VertxCommandLauncher#register(java.lang.Class)}
  * and {@link io.vertx.core.impl.launcher.VertxCommandLauncher#unregister(java.lang.String)}
  *
+ * === Launcher and exit code
+ *
+ * When you use the {@link io.vertx.core.Launcher} class as main class, it uses the following exit code:
+ *
+ * * {@code 0} if the process ends smoothly, or if an uncaught error is thrown
+ * * {@code 1} for general purpose error
+ * * {@code 11} if Vert.x cannot be initialized
+ * * {@code 12} if a spawn process cannot be started, found or stopped. This error code is used by the `start` and
+ * `stop` command
+ * * {@code 14} if the system configuration is not meeting the system requirement (shc as java not found)
+ * * {@code 15} if the main verticle cannot be deployed
+ *
+ *
  */
 @Document(fileName = "index.adoc")
 @io.vertx.codegen.annotations.ModuleGen(name = "vertx", groupPackage = "io.vertx")

--- a/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
@@ -271,6 +271,10 @@ public class StartStopListCommandsTest extends CommandTestBase {
 
   @Test
   public void testStoppingAnUnknownProcess() {
+    if (ExecUtils.isWindows()) {
+      // Test skipped on windows, because on windows we do not check whether or not the pid exists.
+      return;
+    }
     record();
     String id = "this-process-does-not-exist";
     output.reset();

--- a/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
@@ -64,10 +64,12 @@ public class StartStopListCommandsTest extends CommandTestBase {
     String[] lines = output.toString().split(System.lineSeparator());
     String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     output.reset();
-    cli.dispatch(new String[]{"stop", id});
+    // pass --redeploy to not call system.exit
+    cli.dispatch(new String[]{"stop", id, "--redeploy"});
     assertThat(output.toString())
         .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' stopped");
+        .contains("Application '" + id + "' terminated with status 0");
+
 
     waitForShutdown();
 
@@ -102,10 +104,11 @@ public class StartStopListCommandsTest extends CommandTestBase {
     String[] lines = output.toString().split(System.lineSeparator());
     String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     output.reset();
-    cli.dispatch(new String[]{"stop", id});
+    // pass --redeploy to not call system.exit
+    cli.dispatch(new String[]{"stop", id, "--redeploy"});
     assertThat(output.toString())
         .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' stopped");
+        .contains("Application '" + id + "' terminated with status 0");
 
     waitForShutdown();
 
@@ -158,10 +161,11 @@ public class StartStopListCommandsTest extends CommandTestBase {
     String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     assertThat(id).isEqualToIgnoringCase("hello");
     output.reset();
-    cli.dispatch(new String[]{"stop", id});
+    // pass --redeploy to not call system.exit
+    cli.dispatch(new String[]{"stop", id, "--redeploy"});
     assertThat(output.toString())
         .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' stopped");
+        .contains("Application '" + id + "' terminated with status 0");
 
     waitForShutdown();
 
@@ -194,10 +198,11 @@ public class StartStopListCommandsTest extends CommandTestBase {
     String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     assertThat(id).isEqualToIgnoringCase("hello");
     output.reset();
-    cli.dispatch(new String[]{"stop", id});
+    // pass --redeploy to not call system.exit
+    cli.dispatch(new String[]{"stop", id, "--redeploy"});
     assertThat(output.toString())
         .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' stopped");
+        .contains("Application '" + id + "' terminated with status 0");
 
     waitForShutdown();
 
@@ -230,10 +235,11 @@ public class StartStopListCommandsTest extends CommandTestBase {
     String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
     assertThat(id).isEqualToIgnoringCase("hello");
     output.reset();
-    cli.dispatch(new String[]{"stop", id});
+    // pass --redeploy to not call system.exit
+    cli.dispatch(new String[]{"stop", id, "--redeploy"});
     assertThat(output.toString())
         .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' stopped");
+        .contains("Application '" + id + "' terminated with status 0");
 
     waitForShutdown();
 
@@ -261,6 +267,18 @@ public class StartStopListCommandsTest extends CommandTestBase {
 
     command = "java foo bar -Dvertx.id=xxx --cluster";
     assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("");
+  }
+
+  @Test
+  public void testStoppingAnUnknownProcess() {
+    record();
+    String id = "this-process-does-not-exist";
+    output.reset();
+    // pass --redeploy to not call system.exit
+    cli.dispatch(new String[]{"stop", id, "--redeploy"});
+    assertThat(output.toString())
+        .contains("Stopping vert.x application '" + id + "'")
+        .contains("Cannot find process for application using the id");
   }
 
   @Test

--- a/src/test/java/io/vertx/core/logging/Log4J2LogDelegateTest.java
+++ b/src/test/java/io/vertx/core/logging/Log4J2LogDelegateTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Theses test checks the Log4J 2 log delegate.


### PR DESCRIPTION
Fix #1401 - exit the process with a non 0 status code when an error is detected
Fix #1402 - the stop command should propagate the exit code from the stopped process

Notice that this support is not enabled when the redeploy mode is enabled.