### PR TITLE
On windows - allow / in Watch include patterns

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/Watcher.java
@@ -23,6 +23,7 @@ import io.vertx.core.logging.LoggerFactory;
 import java.io.File;
 import java.nio.file.WatchService;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A file alteration monitor based on a home made file system scan and watching files matching a set of includes
@@ -74,7 +75,10 @@ public class Watcher implements Runnable {
                  String onRedeployCommand, long gracePeriod, long scanPeriod) {
     this.gracePeriod = gracePeriod;
     this.root = root;
-    this.includes = includes;
+    // If the include list contains /, replace them by the system file separator, so on windows you can still use
+    // "/", it will be replaced by "\", On other systems, it does nothing. Be aware that it lets windows users uses
+    // "/" but not Linux and Mac user uses "\".
+    this.includes = includes.stream().map(incl -> incl.replace("/", File.separator)).collect(Collectors.toList());
     this.deploy = deploy;
     this.undeploy = undeploy;
     this.cmd = onRedeployCommand;

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherTest.java
@@ -51,7 +51,8 @@ public class WatcherTest extends CommandTestBase {
     deploy = new AtomicInteger();
     undeploy = new AtomicInteger();
 
-    watcher = new Watcher(root, Collections.singletonList("**" + File.separator + "*.txt"),
+    // Use "/" on purpose, on windows it should replace it by "\".
+    watcher = new Watcher(root, Collections.singletonList("**" + "/" + "*.txt"),
         next -> {
           deploy.incrementAndGet();
           if (next != null) {


### PR DESCRIPTION
Fix issue #1415, on windows when / is used in Ant patterns (watcher), they are replaced by the system-specific file separator.
