### PR TITLE
Fix NPE in deployVerticle

### DIFF
--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -539,7 +539,10 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       closed = this.closed;
     }
     if (closed) {
-      completionHandler.handle(Future.failedFuture("Vert.x closed"));
+      if (completionHandler != null) {
+        // The completionHandler may be null, we should check before calling it.
+        completionHandler.handle(Future.failedFuture("Vert.x closed"));
+      }
     } else {
       deploymentManager.deployVerticle(verticle, options, completionHandler);
     }

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -540,7 +540,6 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     if (closed) {
       if (completionHandler != null) {
-        // The completionHandler may be null, we should check before calling it.
         completionHandler.handle(Future.failedFuture("Vert.x closed"));
       }
     } else {

--- a/src/test/java/io/vertx/test/core/VerticleFactoryTest.java
+++ b/src/test/java/io/vertx/test/core/VerticleFactoryTest.java
@@ -449,6 +449,29 @@ public class VerticleFactoryTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  public void testDeploymentOnClosedVertxWithCompletionHandler() {
+    TestVerticle verticle = new TestVerticle();
+    vertx.close(done -> {
+      vertx.deployVerticle(verticle, ar -> {
+        assertFalse(ar.succeeded());
+        testComplete();
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testDeploymentOnClosedVertxWithoutCompletionHandler() {
+    TestVerticle verticle = new TestVerticle();
+    vertx.close(done -> {
+      vertx.deployVerticle(verticle);
+      testComplete();
+    });
+    await();
+  }
+
+
   class TestVerticleFactory implements VerticleFactory {
 
     String prefix;


### PR DESCRIPTION
Fix issue #1383
Check that the completion handler is not null before calling it upon failed verticle deployment.
