### PR TITLE
Implement HttpConnection for HTTP/1.1 client and server

### DIFF
--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -167,15 +167,13 @@ public class DatagramSocketImpl extends ConnectionBase implements DatagramSocket
   }
 
   @Override
-  public synchronized DatagramSocket endHandler(Handler<Void> endHandler) {
-    this.closeHandler = endHandler;
-    return this;
+  public DatagramSocketImpl endHandler(Handler<Void> endHandler) {
+    return (DatagramSocketImpl) super.closeHandler(endHandler);
   }
 
   @Override
-  public synchronized DatagramSocket exceptionHandler(Handler<Throwable> handler) {
-    this.exceptionHandler = handler;
-    return this;
+  public DatagramSocketImpl exceptionHandler(Handler<Throwable> handler) {
+    return (DatagramSocketImpl) super.exceptionHandler(handler);
   }
 
   private DatagramSocket listen(SocketAddress local, Handler<AsyncResult<DatagramSocket>> handler) {

--- a/src/main/java/io/vertx/core/http/HttpClientRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpClientRequest.java
@@ -321,13 +321,13 @@ public interface HttpClientRequest extends WriteStream<Buffer>, ReadStream<HttpC
   void reset(long code);
 
   /**
-   * @return the {@link HttpConnection} associated with this request when it is an HTTP/2 connection, null otherwise
+   * @return the {@link HttpConnection} associated with this request
    */
   @CacheReturn
   HttpConnection connection();
 
   /**
-   * Set a connection handler called when an HTTP/2 connection has been established.
+   * Set a connection handler called when an HTTP connection has been established.
    *
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -17,7 +17,6 @@
 package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
@@ -25,7 +24,14 @@ import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 
 /**
- * Represents an HTTP/2 connection.<p/>
+ * Represents an HTTP connection.
+ * <p/>
+ * HTTP/1.x connection provides an limited implementation, the following methods are implemented:
+ * <ul>
+ *   <li>{@link #close}</li>
+ *   <li>{@link #closeHandler}</li>
+ *   <li>{@link #exceptionHandler}</li>
+ * </ul>
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -49,13 +55,15 @@ public interface HttpConnection {
   }
 
   /**
-   * Send a go away frame to the remote endpoint of the connection.<p/>
-   *
+   * Send a go away frame to the remote endpoint of the connection.
+   * <p/>
    * <ul>
    *   <li>a {@literal GOAWAY} frame is sent to the to the remote endpoint with the {@code errorCode} and {@@code debugData}</li>
    *   <li>any stream created after the stream identified by {@code lastStreamId} will be closed</li>
    *   <li>for an {@literal errorCode} is different than {@literal 0} when all the remaining streams are closed this connection will be closed automatically</li>
    * </ul>
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param errorCode the {@literal GOAWAY} error code
    * @param lastStreamId the last stream id
@@ -67,6 +75,8 @@ public interface HttpConnection {
 
   /**
    * Set an handler called when a {@literal GOAWAY} frame is received.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
@@ -76,6 +86,8 @@ public interface HttpConnection {
 
   /**
    * Set an handler called when a {@literal GOAWAY} frame has been sent or received and all connections are closed.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param handler the handler
    * @return a reference to this, so the API can be used fluently
@@ -86,6 +98,8 @@ public interface HttpConnection {
   /**
    * Initiate a connection shutdown, a go away frame is sent and the connection is closed when all current active streams
    * are closed or after a time out of 30 seconds.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @return a reference to this, so the API can be used fluently
    */
@@ -95,6 +109,8 @@ public interface HttpConnection {
   /**
    * Initiate a connection shutdown, a go away frame is sent and the connection is closed when all current streams
    * will be closed or the {@code timeout} is fired.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param timeoutMs the timeout in milliseconds
    * @return a reference to this, so the API can be used fluently
@@ -112,17 +128,21 @@ public interface HttpConnection {
   HttpConnection closeHandler(Handler<Void> handler);
 
   /**
-   * Close the connection and all the currently active streams. A {@literal GOAWAY} frame will be sent before.<p/>
+   * Close the connection and all the currently active streams.
+   * <p/>
+   * An HTTP/2 connection will send a {@literal GOAWAY} frame before.
    */
   void close();
 
   /**
-   * @return the latest server settings acknowledged by the remote endpoint
+   * @return the latest server settings acknowledged by the remote endpoint - this is not implemented for HTTP/1.x
    */
   Http2Settings settings();
 
   /**
    * Send to the remote endpoint an update of the server settings.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param settings the new settings
    * @return a reference to this, so the API can be used fluently
@@ -131,9 +151,11 @@ public interface HttpConnection {
   HttpConnection updateSettings(Http2Settings settings);
 
   /**
-   * Send to the remote endpoint an update of this endpoint settings.<p/>
-   *
+   * Send to the remote endpoint an update of this endpoint settings
+   * <p/>
    * The {@code completionHandler} will be notified when the remote endpoint has acknowledged the settings.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param settings the new settings
    * @param completionHandler the handler notified when the settings have been acknowledged by the remote endpoint
@@ -143,12 +165,14 @@ public interface HttpConnection {
   HttpConnection updateSettings(Http2Settings settings, Handler<AsyncResult<Void>> completionHandler);
 
   /**
-   * @return the current remote endpoint settings for this connection
+   * @return the current remote endpoint settings for this connection - this is not implemented for HTTP/1.x
    */
   Http2Settings remoteSettings();
 
   /**
    * Set an handler that is called when remote endpoint {@link Http2Settings} are updated.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param handler the handler for remote endpoint settings
    * @return a reference to this, so the API can be used fluently
@@ -157,13 +181,9 @@ public interface HttpConnection {
   HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler);
 
   /**
-   * @return the handler for remote endpoint settings
-   */
-  @GenIgnore
-  Handler<Http2Settings> remoteSettingsHandler();
-
-  /**
    * Send a {@literal PING} frame to the remote endpoint.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param data the 8 bytes data of the frame
    * @param pongHandler an async result handler notified with pong reply or the failure
@@ -174,6 +194,8 @@ public interface HttpConnection {
 
   /**
    * Set an handler notified when a {@literal PING} frame is received from the remote endpoint.
+   * <p/>
+   * This is not implemented for HTTP/1.x.
    *
    * @param handler the handler to be called when a {@literal PING} is received
    * @return a reference to this, so the API can be used fluently
@@ -190,9 +212,4 @@ public interface HttpConnection {
   @Fluent
   HttpConnection exceptionHandler(Handler<Throwable> handler);
 
-  /**
-   * @return the handler for exceptions
-   */
-  @GenIgnore
-  Handler<Throwable> exceptionHandler();
 }

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -58,9 +58,9 @@ public interface HttpConnection {
    * Send a go away frame to the remote endpoint of the connection.
    * <p/>
    * <ul>
-   *   <li>a {@literal GOAWAY} frame is sent to the to the remote endpoint with the {@code errorCode} and {@@code debugData}</li>
+   *   <li>a {@literal GOAWAY} frame is sent to the to the remote endpoint with the {@code errorCode} and {@code debugData}</li>
    *   <li>any stream created after the stream identified by {@code lastStreamId} will be closed</li>
-   *   <li>for an {@literal errorCode} is different than {@literal 0} when all the remaining streams are closed this connection will be closed automatically</li>
+   *   <li>for an {@literal errorCode} is different than {@code 0} when all the remaining streams are closed this connection will be closed automatically</li>
    * </ul>
    * <p/>
    * This is not implemented for HTTP/1.x.

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -64,8 +64,7 @@ public interface HttpServer extends Measured {
   Handler<HttpServerRequest> requestHandler();
 
   /**
-   * Set a connection handler for the server. The connection handler is called after an HTTP2 connection has
-   * been negociated.
+   * Set a connection handler for the server.
    *
    * @return a reference to this, so the API can be used fluently
    */

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -286,7 +286,7 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   HttpServerRequest unknownFrameHandler(Handler<HttpFrame> handler);
 
   /**
-   * @return the {@link HttpConnection} associated with this request when it is an HTTP/2 connection, null otherwise
+   * @return the {@link HttpConnection} associated with this request
    */
   @CacheReturn
   HttpConnection connection();

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -117,20 +117,16 @@ public class Http1xPool extends ConnectionManager.Pool<ClientConnection> {
   }
 
   void createConn(HttpVersion version, ContextImpl context, int port, String host, Channel ch, Waiter waiter) {
-    ClientConnection conn = new ClientConnection(version, client, waiter::handleFailure, ch,
+    ClientConnection conn = new ClientConnection(version, client, ch,
         ssl, host, port, context, this, client.metrics);
-    conn.closeHandler(v -> {
-      // The connection has been closed - tell the pool about it, this allows the pool to create more
-      // connections. Note the pool doesn't actually remove the connection, when the next person to get a connection
-      // gets the closed on, they will check if it's closed and if so get another one.
-      connectionClosed(conn);
-    });
+    conn.exceptionHandler(waiter::handleFailure);
     ClientHandler handler = ch.pipeline().get(ClientHandler.class);
     handler.conn = conn;
     synchronized (queue) {
       allConnections.add(conn);
     }
     connectionMap.put(ch, conn);
+    waiter.handleConnection(conn);
     deliverStream(conn, waiter);
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -90,7 +89,6 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   private Http2Settings serverSettings = new Http2Settings();
   private Handler<GoAway> goAwayHandler;
   private Handler<Void> shutdownHandler;
-  private Handler<Throwable> exceptionHandler;
   private Handler<Buffer> pingHandler;
   private boolean closed;
 
@@ -147,10 +145,7 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
           }
         });
       }
-      Handler<Throwable> handler = exceptionHandler;
-      if (handler != null) {
-        handler.handle(cause);
-      }
+      handleException(cause);
     }
   }
 
@@ -340,10 +335,8 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   }
 
   @Override
-  public synchronized HttpConnection closeHandler(Handler<Void> handler) {
-    closed = true;
-    closeHandler = handler;
-    return this;
+  public Http2ConnectionBase closeHandler(Handler<Void> handler) {
+    return (Http2ConnectionBase) super.closeHandler(handler);
   }
 
   @Override
@@ -356,11 +349,6 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   public synchronized HttpConnection remoteSettingsHandler(Handler<io.vertx.core.http.Http2Settings> handler) {
     clientSettingsHandler = handler;
     return this;
-  }
-
-  @Override
-  public synchronized Handler<io.vertx.core.http.Http2Settings> remoteSettingsHandler() {
-    return clientSettingsHandler;
   }
 
   @Override
@@ -445,14 +433,8 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   }
 
   @Override
-  public synchronized HttpConnection exceptionHandler(Handler<Throwable> handler) {
-    exceptionHandler = handler;
-    return this;
-  }
-
-  @Override
-  public synchronized Handler<Throwable> exceptionHandler() {
-    return exceptionHandler;
+  public synchronized Http2ConnectionBase exceptionHandler(Handler<Throwable> handler) {
+    return (Http2ConnectionBase) super.exceptionHandler(handler);
   }
 
   // Private

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -17,11 +17,12 @@
 package io.vertx.core.http.impl;
 
 import io.vertx.core.Context;
+import io.vertx.core.http.HttpConnection;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-interface HttpClientConnection {
+interface HttpClientConnection extends HttpConnection {
 
   Context getContext();
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -378,7 +378,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
       if (stream == null) {
         throw new IllegalStateException("Not yet connected");
       }
-      return (HttpConnection) stream.connection();
+      return stream.connection();
     }
   }
 
@@ -589,8 +589,8 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
         @Override
         void handleConnection(HttpClientConnection conn) {
           synchronized (HttpClientRequestImpl.this) {
-            if (connectionHandler != null && conn instanceof HttpConnection) {
-              connectionHandler.handle((HttpConnection) conn);
+            if (connectionHandler != null) {
+              connectionHandler.handle(conn);
             }
           }
         }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -694,6 +694,10 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
         connectionMap.put(ch, conn);
         reqHandler.context.executeFromIO(() -> {
           conn.metric(metrics.connected(conn.remoteAddress(), conn.remoteName()));
+          Handler<HttpConnection> connHandler = reqHandler.handler.connectionHandler;
+          if (connHandler != null) {
+            connHandler.handle(conn);
+          }
           conn.handleMessage(msg);
         });
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -357,7 +357,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
 
   @Override
   public HttpConnection connection() {
-    return null;
+    return conn;
   }
 
   void handleData(Buffer data) {

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -26,11 +26,15 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.stream.ChunkedFile;
 import io.netty.util.ReferenceCountUtil;
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.VoidHandler;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.GoAway;
+import io.vertx.core.http.Http2Settings;
+import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
@@ -64,7 +68,7 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-class ServerConnection extends ConnectionBase {
+class ServerConnection extends ConnectionBase implements HttpConnection {
 
   private static final Logger log = LoggerFactory.getLogger(ServerConnection.class);
 
@@ -473,5 +477,78 @@ class ServerConnection extends ConnectionBase {
     } else {
       return -1;
     }
+  }
+
+  //
+
+
+  @Override
+  public synchronized ServerConnection closeHandler(Handler<Void> handler) {
+    return (ServerConnection) super.closeHandler(handler);
+  }
+
+  @Override
+  public synchronized ServerConnection exceptionHandler(Handler<Throwable> handler) {
+    return (ServerConnection) super.exceptionHandler(handler);
+  }
+
+  @Override
+  public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection goAwayHandler(@Nullable Handler<GoAway> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection shutdown() {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection shutdown(long timeoutMs) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public Http2Settings settings() {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection updateSettings(Http2Settings settings) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection updateSettings(Http2Settings settings, Handler<AsyncResult<Void>> completionHandler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public Http2Settings remoteSettings() {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection ping(Buffer data, Handler<AsyncResult<Buffer>> pongHandler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
+  }
+
+  @Override
+  public HttpConnection pingHandler(@Nullable Handler<Buffer> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -53,8 +53,8 @@ public abstract class ConnectionBase {
   protected final Channel channel;
   protected final ContextImpl context;
   protected final NetworkMetrics metrics;
-  protected Handler<Throwable> exceptionHandler;
-  protected Handler<Void> closeHandler;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Void> closeHandler;
   private boolean read;
   private boolean needsFlush;
   private Thread ctxThread;
@@ -132,6 +132,20 @@ public abstract class ConnectionBase {
     // make sure everything is flushed out on close
     endReadAndFlush();
     channel.close();
+  }
+
+  public synchronized ConnectionBase closeHandler(Handler<Void> handler) {
+    closeHandler = handler;
+    return this;
+  }
+
+  public synchronized ConnectionBase exceptionHandler(Handler<Throwable> handler) {
+    this.exceptionHandler = handler;
+    return this;
+  }
+
+  protected synchronized Handler<Throwable> exceptionHandler() {
+    return exceptionHandler;
   }
 
   public void doPause() {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -222,15 +222,13 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   }
 
   @Override
-  public synchronized NetSocket exceptionHandler(Handler<Throwable> handler) {
-    this.exceptionHandler = handler;
-    return this;
+  public NetSocketImpl exceptionHandler(Handler<Throwable> handler) {
+    return (NetSocketImpl) super.exceptionHandler(handler);
   }
 
   @Override
-  public synchronized NetSocket closeHandler(Handler<Void> handler) {
-    this.closeHandler = handler;
-    return this;
+  public NetSocketImpl closeHandler(Handler<Void> handler) {
+    return (NetSocketImpl) super.closeHandler(handler);
   }
 
   @Override


### PR DESCRIPTION
This provides a limited impl of HttpConnection for HTTP/1.1 : close / exceptionHandler and closeHandler . These operations are useful for dealing with the underlying connection, for instance when writing a remote proxy.