### PR TITLE
Add SSL options to delegate key and trust store configuration to Java Security Providers.

### DIFF
--- a/src/main/java/io/vertx/core/net/SecurityProviderOptions.java
+++ b/src/main/java/io/vertx/core/net/SecurityProviderOptions.java
@@ -1,0 +1,105 @@
+package io.vertx.core.net;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Key or trust store options delegating configuration of private key and/or certificates to previously setup
+ * <a href="https://docs.oracle.com/javase/8/docs/api/java/security/Provider.html">Java Security Providers</a>.
+ * <p>
+ * This can be used for key and trust stores. The managerAlgorithm property references the algorithm name of
+ * the chosen Provider service, whose KeyManagerFactory or TrustManagerFactory implementation is then used.<br/>
+ * Additionally, a KeyStore implementation can be used in both cases by setting the keyStoreAlgorithm property
+ * accordingly.
+ * <p>
+ * This may be useful in cases where Vert.x should use existing custom code based on the java.security API, e.g.
+ * for use cases involving dynamic key updates.
+ * <p>
+ *
+ *
+ * @author <a href="mailto:mario@ellebrecht.com">Mario Ellebrecht</a>
+ */
+@DataObject(generateConverter = true)
+public class SecurityProviderOptions implements KeyCertOptions, TrustOptions, Cloneable {
+
+  private String keyStoreAlgorithm;
+  private String managerAlgorithm;
+
+  /**
+   * Default constructor
+   */
+  public SecurityProviderOptions() {
+    super();
+  }
+
+  /**
+   * Copy constructor
+   *
+   * @param other  the options to copy
+   */
+  public SecurityProviderOptions(SecurityProviderOptions other) {
+    super();
+    this.keyStoreAlgorithm = other.keyStoreAlgorithm;
+    this.managerAlgorithm = other.managerAlgorithm;
+  }
+
+  /**
+   * Create options from JSON
+   *
+   * @param json  the JSON
+   */
+  public SecurityProviderOptions(JsonObject json) {
+    super();
+    SecurityProviderOptionsConverter.fromJson(json, this);
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    SecurityProviderOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  public String getKeyStoreAlgorithm() {
+    return keyStoreAlgorithm;
+  }
+
+  public SecurityProviderOptions setKeyStoreAlgorithm(String keyStoreAlgorithm) {
+    this.keyStoreAlgorithm = keyStoreAlgorithm;
+    return this;
+  }
+
+  public String getManagerAlgorithm() {
+    return managerAlgorithm;
+  }
+
+  public SecurityProviderOptions setManagerAlgorithm(String managerAlgorithm) {
+    this.managerAlgorithm = managerAlgorithm;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    SecurityProviderOptions that = (SecurityProviderOptions) o;
+
+    if (keyStoreAlgorithm != null ? !keyStoreAlgorithm.equals(that.keyStoreAlgorithm) : that.keyStoreAlgorithm != null)
+      return false;
+    return managerAlgorithm != null ? managerAlgorithm.equals(that.managerAlgorithm) : that.managerAlgorithm == null;
+
+  }
+
+  @Override
+  public int hashCode() {
+    int result = keyStoreAlgorithm != null ? keyStoreAlgorithm.hashCode() : 0;
+    result = 31 * result + (managerAlgorithm != null ? managerAlgorithm.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public SecurityProviderOptions clone() {
+    return new SecurityProviderOptions(this);
+  }
+
+}

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -297,6 +297,16 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   }
 
   /**
+   * Set the key/cert options by delegating to an existing Java Security Provider.
+   * @param options the key store options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setKeyProviderOptions(SecurityProviderOptions options) {
+    this.keyCertOptions = options;
+    return this;
+  }
+
+  /**
    * @return the trust options
    */
   public TrustOptions getTrustOptions() {
@@ -309,6 +319,16 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public TCPSSLOptions setTrustStoreOptions(JksOptions options) {
+    this.trustOptions = options;
+    return this;
+  }
+
+  /**
+   * Set the trust options by delegating to an existing Java Security Provider.
+   * @param options the trust store options
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setTrustProviderOptions(SecurityProviderOptions options) {
     this.trustOptions = options;
     return this;
   }


### PR DESCRIPTION
See also: https://groups.google.com/forum/?fromgroups#!topic/vertx/q5zLoEWMH1U

This change adds new SSL options that allow configuration of key and trust stores to be delegated to named algorithms implemented by Java Security Providers. These might be standard algorithms or custom classes plugged in via the standard Java security SPI.

My specific use case was to enable dynamic key/certificate updates in a HTTPS server using pre-existing custom providers. It might be helpful to anyone with key/trust handling requirements beyond the static file support currently offered.
