### PR TITLE
Allow to limit the number of concurrent streams per http/2 connection…

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -673,6 +673,16 @@ Set the maximum HTTP chunk size
 +++
 Set the maximum pool size for connections
 +++
+|[[maxStreams]]`maxStreams`|`Number (int)`|
++++
+Set the maximum of concurrent concurrency for an HTTP/2 connection, this limits the number
+ of streams the client will create for a connection. The effective number of stream for a
+ connection can be lower than this value when the server has limited this value lower than
+ this value.
+ <p/>
+ Setting a maximum to  means the client will not limit the concurrency and the client
+ will use a single connection.  is the default value.
++++
 |[[maxWaitQueueSize]]`maxWaitQueueSize`|`Number (int)`|
 +++
 Set the maximum requests allowed in the wait queue, any requests beyond the max size will result in

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -1538,8 +1538,24 @@ When pipe-lining is enabled requests will be written to connections without wait
 
 === HTTP/2 multiplexing
 
-For HTTP/2, the http client uses a single connection for each server, all the requests to the same server are
-multiplexed on the same connection.
+HTTP/2 advocates to use a single connection to a server, by default the http client uses a single
+connection for each server, all the streams to the same server are multiplexed on the same connection.
+
+When it is desirable to limit the number of concurrent streams per server and uses a connection
+pool instead of a single connection, `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setMaxStreams-int-[setMaxStreams]`
+can be used.
+
+[source,java]
+----
+HttpClientOptions clientOptions = new HttpClientOptions().setMaxStreams(10).setMaxPoolSize(3);
+
+// Uses up to 3 connections and up to 10 streams per connection
+HttpClient client = vertx.createHttpClient(clientOptions);
+----
+
+The maximum streams for a connection is a setting set on the client that limits the streams
+of a single connection. The effective value can be even lower if the server sets a lower limit
+with the `link:../../apidocs/io/vertx/core/http/Http2Settings.html#setMaxConcurrentStreams-long-[SETTINGS_MAX_CONCURRENT_STREAMS]` setting.
 
 HTTP/2 connections will not be closed by the client automatically. To close them you can call `link:../../apidocs/io/vertx/core/http/HttpConnection.html#close--[close]`
 or close the client instance.

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -56,6 +56,9 @@ public class HttpClientOptionsConverter {
     if (json.getValue("maxPoolSize") instanceof Number) {
       obj.setMaxPoolSize(((Number)json.getValue("maxPoolSize")).intValue());
     }
+    if (json.getValue("maxStreams") instanceof Number) {
+      obj.setMaxStreams(((Number)json.getValue("maxStreams")).intValue());
+    }
     if (json.getValue("maxWaitQueueSize") instanceof Number) {
       obj.setMaxWaitQueueSize(((Number)json.getValue("maxWaitQueueSize")).intValue());
     }
@@ -107,6 +110,7 @@ public class HttpClientOptionsConverter {
     json.put("keepAlive", obj.isKeepAlive());
     json.put("maxChunkSize", obj.getMaxChunkSize());
     json.put("maxPoolSize", obj.getMaxPoolSize());
+    json.put("maxStreams", obj.getMaxStreams());
     json.put("maxWaitQueueSize", obj.getMaxWaitQueueSize());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
     json.put("pipelining", obj.isPipelining());

--- a/src/main/java/examples/HTTP2Examples.java
+++ b/src/main/java/examples/HTTP2Examples.java
@@ -282,4 +282,12 @@ public class HTTP2Examples {
       connection.close();
     });
   }
+
+  public void useMaxStreams(Vertx vertx) {
+
+    HttpClientOptions clientOptions = new HttpClientOptions().setMaxStreams(10).setMaxPoolSize(3);
+
+    // Uses up to 3 connections and up to 10 streams per connection
+    HttpClient client = vertx.createHttpClient(clientOptions);
+  }
 }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -25,7 +25,6 @@ import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.SSLEngine;
-import io.vertx.core.net.TCPSSLOptions;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +42,11 @@ public class HttpClientOptions extends ClientOptionsBase {
    * The default maximum number of connections a client will pool = 5
    */
   public static final int DEFAULT_MAX_POOL_SIZE = 5;
+
+  /**
+   * The default maximum number of concurrent stream per connection for HTTP/2 = -1
+   */
+  public static final int DEFAULT_MAX_STREAMS = -1;
 
   /**
    * Default value of whether keep-alive is enabled = true
@@ -108,6 +112,8 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int maxPoolSize;
   private boolean keepAlive;
   private boolean pipelining;
+  private int maxStreams;
+
   private boolean tryUseCompression;
   private int maxWebsocketFrameSize;
   private String defaultHost;
@@ -143,6 +149,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.maxPoolSize = other.getMaxPoolSize();
     this.keepAlive = other.isKeepAlive();
     this.pipelining = other.isPipelining();
+    this.maxStreams = other.maxStreams;
     this.tryUseCompression = other.isTryUseCompression();
     this.maxWebsocketFrameSize = other.maxWebsocketFrameSize;
     this.defaultHost = other.defaultHost;
@@ -175,6 +182,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxPoolSize = DEFAULT_MAX_POOL_SIZE;
     keepAlive = DEFAULT_KEEP_ALIVE;
     pipelining = DEFAULT_PIPELINING;
+    maxStreams = DEFAULT_MAX_STREAMS;
     tryUseCompression = DEFAULT_TRY_USE_COMPRESSION;
     maxWebsocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
     defaultHost = DEFAULT_DEFAULT_HOST;
@@ -337,6 +345,31 @@ public class HttpClientOptions extends ClientOptionsBase {
       throw new IllegalArgumentException("maxPoolSize must be > 0");
     }
     this.maxPoolSize = maxPoolSize;
+    return this;
+  }
+
+  /**
+   * @return the maximum number of concurrent streams for an HTTP/2 connection, {@literal -1} means
+   * no limit (default value)
+   */
+  public int getMaxStreams() {
+    return maxStreams;
+  }
+
+  /**
+   * Set the maximum of concurrent concurrency for an HTTP/2 connection, this limits the number
+   * of streams the client will create for a connection. The effective number of stream for a
+   * connection can be lower than this value when the server has limited this value lower than
+   * this value.
+   * <p/>
+   * Setting a maximum to {@literal -1} means the client will not limit the concurrency and the client
+   * will use a single connection. {@literal -1} is the default value.
+   *
+   * @param maxStreams the maximum concurrent for a connection
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setMaxStreams(int maxStreams) {
+    this.maxStreams = maxStreams;
     return this;
   }
 
@@ -705,6 +738,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (defaultPort != that.defaultPort) return false;
     if (keepAlive != that.keepAlive) return false;
     if (maxPoolSize != that.maxPoolSize) return false;
+    if (maxStreams != that.maxStreams) return false;
     if (maxWebsocketFrameSize != that.maxWebsocketFrameSize) return false;
     if (pipelining != that.pipelining) return false;
     if (tryUseCompression != that.tryUseCompression) return false;
@@ -729,6 +763,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     int result = super.hashCode();
     result = 31 * result + (verifyHost ? 1 : 0);
     result = 31 * result + maxPoolSize;
+    result = 31 * result + maxStreams;
     result = 31 * result + (keepAlive ? 1 : 0);
     result = 31 * result + (pipelining ? 1 : 0);
     result = 31 * result + (tryUseCompression ? 1 : 0);

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -58,20 +58,9 @@ public class Http1xPool extends ConnectionManager.Pool<ClientConnection> {
     return version;
   }
 
-  public boolean getConnection(Waiter waiter) {
-    ClientConnection conn = availableConnections.poll();
-    if (conn != null && conn.isValid()) {
-      ContextImpl context = waiter.context;
-      if (context == null) {
-        context = conn.getContext();
-      } else if (context != conn.getContext()) {
-        ConnectionManager.log.warn("Reusing a connection with a different context: an HttpClient is probably shared between different Verticles");
-      }
-      context.runOnContext(v -> deliverStream(conn, waiter));
-      return true;
-    } else {
-      return false;
-    }
+  @Override
+  ClientConnection pollConnection() {
+    return availableConnections.poll();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -54,7 +54,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   final Http2Pool http2Pool;
   final HttpClientMetrics metrics;
   final Object metric;
-  long streamCount;
+  int streamCount;
 
   public Http2ClientConnection(Http2Pool http2Pool,
                                ContextImpl context,

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -16,14 +16,14 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Context;
+import io.vertx.core.impl.ContextImpl;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 interface HttpClientConnection {
 
-  Context getContext();
+  ContextImpl getContext();
 
   void reportBytesWritten(long numberOfBytes);
 

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -1176,8 +1176,21 @@
  *
  * === HTTP/2 multiplexing
  *
- * For HTTP/2, the http client uses a single connection for each server, all the requests to the same server are
- * multiplexed on the same connection.
+ * HTTP/2 advocates to use a single connection to a server, by default the http client uses a single
+ * connection for each server, all the streams to the same server are multiplexed on the same connection.
+ *
+ * When it is desirable to limit the number of concurrent streams per server and uses a connection
+ * pool instead of a single connection, {@link io.vertx.core.http.HttpClientOptions#setMaxStreams(int)}
+ * can be used.
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.HTTP2Examples#useMaxStreams}
+ * ----
+ *
+ * The maximum streams for a connection is a setting set on the client that limits the streams
+ * of a single connection. The effective value can be even lower if the server sets a lower limit
+ * with the {@link io.vertx.core.http.Http2Settings#setMaxConcurrentStreams SETTINGS_MAX_CONCURRENT_STREAMS} setting.
  *
  * HTTP/2 connections will not be closed by the client automatically. To close them you can call {@link io.vertx.core.http.HttpConnection#close()}
  * or close the client instance.

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -55,6 +55,7 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.StreamResetException;
@@ -69,7 +70,9 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -1655,6 +1658,54 @@ public class Http2ClientTest extends Http2TestBase {
       });
     });
     req.end();
+    await();
+  }
+
+  @Test
+  public void testMaxConcurrencySingleConnection() throws Exception {
+    testMaxConcurrency(1, 5);
+  }
+
+  @Test
+  public void testMaxConcurrencyMultipleConnections() throws Exception {
+    testMaxConcurrency(3, 5);
+  }
+
+  private void testMaxConcurrency(int poolSize, int maxConcurrency) throws Exception {
+    int maxRequests = poolSize * maxConcurrency;
+    int totalRequests = maxRequests + maxConcurrency;
+    Set<HttpConnection> serverConn = new HashSet<>();
+    server.connectionHandler(conn -> {
+      serverConn.add(conn);
+      assertTrue(serverConn.size() <= poolSize);
+    });
+    ArrayList<HttpServerRequest> requests = new ArrayList<>();
+    server.requestHandler(req -> {
+      if (requests.size() < maxRequests) {
+        requests.add(req);
+        if (requests.size() == maxRequests) {
+          vertx.setTimer(300, v -> {
+            assertEquals(maxRequests, requests.size());
+            requests.forEach(r -> r.response().end());
+          });
+        }
+      } else {
+        req.response().end();
+      }
+    });
+    startServer();
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions(clientOptions).setMaxPoolSize(poolSize).setMaxStreams(maxConcurrency));
+    AtomicInteger respCount = new AtomicInteger();
+    for (int i = 0;i < maxRequests + maxConcurrency;i++) {
+      client.getNow(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/somepath", resp -> {
+        resp.endHandler(v -> {
+          if (respCount.incrementAndGet() == totalRequests) {
+            testComplete();
+          }
+        });
+      });
+    }
     await();
   }
 }


### PR DESCRIPTION
… and use a connection pool

By default the HTTP client uses a single connection for HTTP/2.

It can be desirable to use a connection and pool and limit the number of streams for a given HTTP/2 connection. (to have an higher throughput).