### PR TITLE
Use Service Helper to avoid classloading issue

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -305,6 +305,6 @@ public interface Future<T> extends AsyncResult<T> {
     };
   }
 
-  static FutureFactory factory = ServiceHelper.loadFactory(FutureFactory.class);
+  FutureFactory factory = ServiceHelper.loadFactory(FutureFactory.class);
 
 }

--- a/src/main/java/io/vertx/core/ServiceHelper.java
+++ b/src/main/java/io/vertx/core/ServiceHelper.java
@@ -16,7 +16,7 @@
 
 package io.vertx.core;
 
-import java.util.ServiceLoader;
+import java.util.*;
 
 /**
  * A helper class for loading factories from the classpath and from the vert.x OSGi bundle.
@@ -26,18 +26,50 @@ import java.util.ServiceLoader;
 public class ServiceHelper {
 
   public static <T> T loadFactory(Class<T> clazz) {
-    ServiceLoader<T> factories = ServiceLoader.load(clazz);
-    if (factories.iterator().hasNext()) {
-      return factories.iterator().next();
+    T factory = loadFactoryOrNull(clazz);
+    if (factory == null) {
+      throw new IllegalStateException("Cannot find META-INF/services/" + clazz.getName() + " on classpath");
+    }
+    return factory;
+  }
+
+  public static <T> T loadFactoryOrNull(Class<T> clazz) {
+    Collection<T> collection = loadFactories(clazz);
+    if (!collection.isEmpty()) {
+      return collection.iterator().next();
     } else {
-      // By default ServiceLoader.load uses the TCCL, this may not be enough in environment deading with
+      return null;
+    }
+  }
+
+
+  public static <T> Collection<T> loadFactories(Class<T> clazz) {
+    return loadFactories(clazz, null);
+  }
+
+  public static <T> Collection<T> loadFactories(Class<T> clazz, ClassLoader classLoader) {
+    List<T> list = new ArrayList<>();
+    ServiceLoader<T> factories;
+    if (classLoader != null) {
+      factories = ServiceLoader.load(clazz, classLoader);
+    } else {
+      // this is equivalent to:
+      // ServiceLoader.load(clazz, TCCL);
+      factories = ServiceLoader.load(clazz);
+    }
+    if (factories.iterator().hasNext()) {
+      factories.iterator().forEachRemaining(list::add);
+      return list;
+    } else {
+      // By default ServiceLoader.load uses the TCCL, this may not be enough in environment dealing with
       // classloaders differently such as OSGi. So we should try to use the  classloader having loaded this
       // class. In OSGi it would be the bundle exposing vert.x and so have access to all its classes.
       factories = ServiceLoader.load(clazz, ServiceHelper.class.getClassLoader());
       if (factories.iterator().hasNext()) {
-        return factories.iterator().next();
+        factories.iterator().forEachRemaining(list::add);
+        return list;
       } else {
-        throw new IllegalStateException("Cannot find META-INF/services/" + clazz.getName() + " on classpath");
+        return Collections.emptyList();
       }
     }
   }

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -521,5 +521,5 @@ public interface Vertx extends Measured {
    */
   @Nullable @GenIgnore Handler<Throwable> exceptionHandler();
 
-  static final VertxFactory factory = ServiceHelper.loadFactory(VertxFactory.class);
+  VertxFactory factory = ServiceHelper.loadFactory(VertxFactory.class);
 }

--- a/src/main/java/io/vertx/core/buffer/Buffer.java
+++ b/src/main/java/io/vertx/core/buffer/Buffer.java
@@ -697,6 +697,6 @@ public interface Buffer extends ClusterSerializable {
   @GenIgnore
   ByteBuf getByteBuf();
 
-  static final BufferFactory factory = ServiceHelper.loadFactory(BufferFactory.class);
+  BufferFactory factory = ServiceHelper.loadFactory(BufferFactory.class);
 
 }

--- a/src/main/java/io/vertx/core/http/WebSocketFrame.java
+++ b/src/main/java/io/vertx/core/http/WebSocketFrame.java
@@ -106,5 +106,5 @@ public interface WebSocketFrame {
    */
   boolean isFinal();
 
-  static final WebSocketFrameFactory factory = ServiceHelper.loadFactory(WebSocketFrameFactory.class);
+  WebSocketFrameFactory factory = ServiceHelper.loadFactory(WebSocketFrameFactory.class);
 }

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -52,10 +52,8 @@ public class DeploymentManager {
   }
 
   private void loadVerticleFactories() {
-    ServiceLoader<VerticleFactory> factories = ServiceLoader.load(VerticleFactory.class);
-    for (VerticleFactory factory: factories) {
-      registerVerticleFactory(factory);
-    }
+    Collection<VerticleFactory> factories = ServiceHelper.loadFactories(VerticleFactory.class);
+    factories.forEach(this::registerVerticleFactory);
     VerticleFactory defaultFactory = new JavaVerticleFactory();
     defaultFactory.init(vertx);
     defaultFactories.add(defaultFactory);

--- a/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
+++ b/src/main/java/io/vertx/core/impl/launcher/ServiceCommandFactoryLoader.java
@@ -15,13 +15,13 @@
  */
 package io.vertx.core.impl.launcher;
 
+import io.vertx.core.ServiceHelper;
 import io.vertx.core.spi.launcher.CommandFactory;
 import io.vertx.core.spi.launcher.CommandFactoryLookup;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.ServiceLoader;
 
 /**
  * Looks for command factories using a service loader.
@@ -30,28 +30,28 @@ import java.util.ServiceLoader;
  */
 public class ServiceCommandFactoryLoader implements CommandFactoryLookup {
 
-  private ServiceLoader<CommandFactory> loader;
+  private Collection<CommandFactory> commands;
 
   /**
    * Creates a new instance of {@link ServiceCommandFactoryLoader} using the classloader having loaded the
    * {@link ServiceCommandFactoryLoader} class.
    */
   public ServiceCommandFactoryLoader() {
-    this.loader = ServiceLoader.load(CommandFactory.class, getClass().getClassLoader());
+    this.commands = ServiceHelper.loadFactories(CommandFactory.class, getClass().getClassLoader());
   }
 
   /**
    * Creates a new instance of {@link ServiceCommandFactoryLoader} using specified classloader.
    */
   public ServiceCommandFactoryLoader(ClassLoader loader) {
-    this.loader = ServiceLoader.load(CommandFactory.class, loader);
+    this.commands = ServiceHelper.loadFactories(CommandFactory.class, loader);
   }
 
   @Override
   public Collection<CommandFactory<?>> lookup() {
-    List<CommandFactory<?>> commands = new ArrayList<>();
-    loader.forEach(commands::add);
-    return commands;
+    List<CommandFactory<?>> list = new ArrayList<>();
+    commands.stream().forEach(list::add);
+    return list;
   }
 
 }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -15,10 +15,7 @@
  */
 package io.vertx.core.impl.launcher.commands;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.cli.annotations.*;
 import io.vertx.core.impl.launcher.VertxLifecycleHooks;
 import io.vertx.core.metrics.MetricsOptions;
@@ -32,7 +29,6 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.Enumeration;
 import java.util.Properties;
-import java.util.ServiceLoader;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -231,9 +227,8 @@ public class BareCommand extends ClasspathHandler {
    */
   protected MetricsOptions getMetricsOptions() {
     MetricsOptions metricsOptions;
-    ServiceLoader<VertxMetricsFactory> factories = ServiceLoader.load(VertxMetricsFactory.class);
-    if (factories.iterator().hasNext()) {
-      VertxMetricsFactory factory = factories.iterator().next();
+    VertxMetricsFactory factory = ServiceHelper.loadFactoryOrNull(VertxMetricsFactory.class);
+    if (factory != null) {
       metricsOptions = factory.newOptions();
     } else {
       metricsOptions = new MetricsOptions();

--- a/src/main/java/io/vertx/core/streams/Pump.java
+++ b/src/main/java/io/vertx/core/streams/Pump.java
@@ -101,7 +101,7 @@ public interface Pump {
    */
   int numberPumped();
 
-  static final PumpFactory factory = ServiceHelper.loadFactory(PumpFactory.class);
+  PumpFactory factory = ServiceHelper.loadFactory(PumpFactory.class);
 
 
 }

--- a/src/test/externals/META-INF/services/io.vertx.test.spi.SomeFactory
+++ b/src/test/externals/META-INF/services/io.vertx.test.spi.SomeFactory
@@ -1,0 +1,16 @@
+#
+#  Copyright (c) 2011-2015 The original author or authors
+#  ------------------------------------------------------
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  and Apache License v2.0 which accompanies this distribution.
+#
+#       The Eclipse Public License is available at
+#       http://www.eclipse.org/legal/epl-v10.html
+#
+#       The Apache License v2.0 is available at
+#       http://www.opensource.org/licenses/apache2.0.php
+#
+#  You may elect to redistribute this code under either of these licenses.
+#
+io.vertx.core.externals.SomeFactoryImplA

--- a/src/test/externals/SomeFactoryImplA.java
+++ b/src/test/externals/SomeFactoryImplA.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.externals;
+
+import io.vertx.test.spi.SomeFactory;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class SomeFactoryImplA implements SomeFactory {
+  @Override
+  public String name() {
+    return "A";
+  }
+
+  @Override
+  public ClassLoader classloader() {
+    return this.getClass().getClassLoader();
+  }
+}

--- a/src/test/java/io/vertx/core/FakeFactoryImplA.java
+++ b/src/test/java/io/vertx/core/FakeFactoryImplA.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core;
+
+import io.vertx.test.spi.FakeFactory;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class FakeFactoryImplA implements FakeFactory {
+  @Override
+  public String name() {
+    return "A";
+  }
+
+  @Override
+  public ClassLoader classloader() {
+    return this.getClass().getClassLoader();
+  }
+}

--- a/src/test/java/io/vertx/core/FakeFactoryImplB.java
+++ b/src/test/java/io/vertx/core/FakeFactoryImplB.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core;
+
+import io.vertx.test.spi.FakeFactory;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class FakeFactoryImplB implements FakeFactory {
+  @Override
+  public String name() {
+    return "B";
+  }
+
+  @Override
+  public ClassLoader classloader() {
+    return this.getClass().getClassLoader();
+  }
+}

--- a/src/test/java/io/vertx/core/ServiceHelperTest.java
+++ b/src/test/java/io/vertx/core/ServiceHelperTest.java
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core;
+
+import io.vertx.test.spi.FakeFactory;
+import io.vertx.test.spi.NotImplementedSPI;
+import io.vertx.test.spi.SomeFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.tools.*;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Check the service helper behavior.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class ServiceHelperTest {
+
+  @Before
+  public void setUp() throws IOException {
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+    File output = new File("target/externals");
+    output.mkdirs();
+    fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singletonList(
+        output));
+
+    List<File> classesToCompile = new ArrayList<>();
+    classesToCompile.add(new File("src/test/externals/MyVerticle.java"));
+    classesToCompile.add(new File("src/test/externals/SomeFactoryImplA.java"));
+
+    Iterable<? extends JavaFileObject> compilationUnits1 =
+        fileManager.getJavaFileObjectsFromFiles(classesToCompile);
+
+    compiler.getTask(null, fileManager, null, null, null, compilationUnits1).call();
+
+    // Also copy the META-INF dir
+    File source = new File("src/test/externals/META-INF/services/io.vertx.test.spi.SomeFactory");
+    File out = new File("target/externals/META-INF/services/io.vertx.test.spi.SomeFactory");
+    out.getParentFile().mkdirs();
+    Files.copy(source.toPath(), out.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+  }
+
+  @Test
+  public void loadFactory() throws Exception {
+    FakeFactory factory = ServiceHelper.loadFactory(FakeFactory.class);
+    assertThat(factory.classloader()).isEqualTo(ServiceHelperTest.class.getClassLoader());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void loadNotImplementedSPI() throws Exception {
+    ServiceHelper.loadFactory(NotImplementedSPI.class);
+  }
+
+  @Test
+  public void loadFactoryOrNull() throws Exception {
+    NotImplementedSPI factory = ServiceHelper.loadFactoryOrNull(NotImplementedSPI.class);
+    assertThat(factory).isNull();
+
+    FakeFactory fake = ServiceHelper.loadFactoryOrNull(FakeFactory.class);
+    assertThat(fake).isNotNull();
+    assertThat(fake.classloader()).isEqualTo(ServiceHelperTest.class.getClassLoader());
+  }
+
+  @Test
+  public void loadFactories() throws Exception {
+    Collection<FakeFactory> factories = ServiceHelper.loadFactories(FakeFactory.class);
+    assertThat(factories)
+        .isNotNull()
+        .hasSize(2);
+
+    Collection<NotImplementedSPI> impl = ServiceHelper.loadFactories(NotImplementedSPI.class);
+    assertThat(impl)
+        .isNotNull()
+        .hasSize(0);
+  }
+
+  @Test
+  public void loadFactoriesWithClassloader() throws Exception {
+    ClassLoader custom = new URLClassLoader(new URL[]{new File("target/externals").toURI().toURL()});
+
+    // Try without the custom classloader.
+    Collection<SomeFactory> factories = ServiceHelper.loadFactories(SomeFactory.class);
+    assertThat(factories)
+        .isNotNull()
+        .hasSize(0);
+
+    // Try with the custom classloader
+    factories = ServiceHelper.loadFactories(SomeFactory.class, custom);
+    assertThat(factories)
+        .isNotNull()
+        .hasSize(1);
+    assertThat(factories.iterator().next().classloader()).isEqualTo(custom);
+  }
+
+  @Test
+  public void loadFactoriesFromTCCL() throws Exception {
+    ClassLoader custom = new URLClassLoader(new URL[]{new File("target/externals").toURI().toURL()});
+
+    // Try without the TCCL classloader.
+    Collection<SomeFactory> factories = ServiceHelper.loadFactories(SomeFactory.class);
+    assertThat(factories)
+        .isNotNull()
+        .hasSize(0);
+
+    // Try with the TCCL classloader
+    final ClassLoader originalTCCL = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(custom);
+      factories = ServiceHelper.loadFactories(SomeFactory.class);
+      assertThat(factories)
+          .isNotNull()
+          .hasSize(1);
+      assertThat(factories.iterator().next().classloader()).isEqualTo(custom);
+    } finally {
+      Thread.currentThread().setContextClassLoader(originalTCCL);
+    }
+
+  }
+
+  @Test
+  public void loadFactoriesWithVertxClassloader() throws Exception {
+    // This test is a bit more tricky as we need to load the ServiceHelper class from a custom classloader.
+    ClassLoader custom = new URLClassLoader(new URL[]{
+        new File("target/classes").toURI().toURL(),
+        new File("target/test-classes").toURI().toURL(),
+        new File("target/externals").toURI().toURL(),
+    }, null);
+
+    Class serviceHelperClass = custom.loadClass(ServiceHelper.class.getName());
+    Class someFactoryClass = custom.loadClass(SomeFactory.class.getName());
+    assertThat(serviceHelperClass.getClassLoader()).isEqualTo(custom);
+    assertThat(someFactoryClass.getClassLoader()).isEqualTo(custom);
+    Method method = serviceHelperClass.getMethod("loadFactories", Class.class);
+    Collection collection = (Collection) method.invoke(null, someFactoryClass);
+    assertThat(collection).hasSize(1);
+  }
+
+}

--- a/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/ServiceCommandLoaderTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class ServiceCommandLoaderTest {
 
-  ServiceCommandFactoryLoader loader = new ServiceCommandFactoryLoader();
+  private ServiceCommandFactoryLoader loader = new ServiceCommandFactoryLoader();
 
   @Test
   public void testLookup() throws Exception {
@@ -56,8 +56,10 @@ public class ServiceCommandLoaderTest {
   @Test
   public void testNoCommandsWhenLoadedFromEmptyClassloader() {
     ClassLoader classLoader = new URLClassLoader(new URL[0], null);
+
+    // We see the implementation from the classpath
     loader = new ServiceCommandFactoryLoader(classLoader);
-    assertThat(loader.lookup()).isEmpty();
+    assertThat(loader.lookup()).isNotEmpty();
   }
 
 

--- a/src/test/java/io/vertx/test/spi/FakeFactory.java
+++ b/src/test/java/io/vertx/test/spi/FakeFactory.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.spi;
+
+/**
+ * A very simple SPI for testing purpose.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public interface FakeFactory {
+
+  String name();
+
+  ClassLoader classloader();
+
+}

--- a/src/test/java/io/vertx/test/spi/NotImplementedSPI.java
+++ b/src/test/java/io/vertx/test/spi/NotImplementedSPI.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.spi;
+
+/**
+ * A SPI not implemented.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public interface NotImplementedSPI {
+}

--- a/src/test/java/io/vertx/test/spi/SomeFactory.java
+++ b/src/test/java/io/vertx/test/spi/SomeFactory.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *  ------------------------------------------------------
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.spi;
+
+/**
+ * A very simple SPI for testing purpose.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public interface SomeFactory {
+
+  String name();
+
+  ClassLoader classloader();
+
+}

--- a/src/test/resources/META-INF/services/io.vertx.test.spi.FakeFactory
+++ b/src/test/resources/META-INF/services/io.vertx.test.spi.FakeFactory
@@ -1,0 +1,18 @@
+#
+#  Copyright (c) 2011-2015 The original author or authors
+#  ------------------------------------------------------
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  and Apache License v2.0 which accompanies this distribution.
+#
+#       The Eclipse Public License is available at
+#       http://www.eclipse.org/legal/epl-v10.html
+#
+#       The Apache License v2.0 is available at
+#       http://www.opensource.org/licenses/apache2.0.php
+#
+#  You may elect to redistribute this code under either of these licenses.
+#
+
+io.vertx.core.FakeFactoryImplA
+io.vertx.core.FakeFactoryImplB


### PR DESCRIPTION
Fix issue #1438 by generalizing the usage of the `ServiceHelper` class.

Also add tests to check the behavior of the `ServiceHelper` when using different classloaders.