### PR TITLE
Pipe lined limit

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -668,7 +668,7 @@ Set to <code>true</code> when an <i>h2c</i> connection is established using an H
 +++
 Set the maximum pool size for HTTP/2 connections
 +++
-|[[http2MaxStreams]]`http2MaxStreams`|`Number (int)`|
+|[[http2MultiplexingLimit]]`http2MultiplexingLimit`|`Number (int)`|
 +++
 Set a client limit of the number concurrent streams for each HTTP/2 connection, this limits the number
  of streams the client can create for a connection. The effective number of streams for a
@@ -739,6 +739,10 @@ Set the trust options in pfx format
 |[[pipelining]]`pipelining`|`Boolean`|
 +++
 Set whether pipe-lining is enabled on the client
++++
+|[[pipeliningLimit]]`pipeliningLimit`|`Number (int)`|
++++
+Set the limit of pending requests a pipe-lined HTTP/1 connection can send.
 +++
 |[[protocolVersion]]`protocolVersion`|`link:enums.html#HttpVersion[HttpVersion]`|
 +++

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -1571,29 +1571,33 @@ By default pipe-lining is disabled.
 
 When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
 
+The number of pipe-lined requests over a single connection is limited by `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setPipeliningLimit-int-[setPipeliningLimit]`.
+This option defines the maximum number of http requests sent to the server awaiting for a response. This limit ensures the
+fairness of the distribution of the client requests over the connections to the same server.
+
 === HTTP/2 multiplexing
 
 HTTP/2 advocates to use a single connection to a server, by default the http client uses a single
-connection for each server, all the streams to the same server are multiplexed on the same connection.
+connection for each server, all the streams to the same server are multiplexed over the same connection.
 
 When the clients needs to use more than a single connection and use pooling, the `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setHttp2MaxPoolSize-int-[setHttp2MaxPoolSize]`
 shall be used.
 
-When it is desirable to limit the number of concurrent streams per server and use a connection
-pool instead of a single connection, `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setHttp2MaxStreams-int-[setHttp2MaxStreams]`
+When it is desirable to limit the number of multiplexed streams per connection and use a connection
+pool instead of a single connection, `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html#setHttp2MultiplexingLimit-int-[setHttp2MultiplexingLimit]`
 can be used.
 
 [source,java]
 ----
 HttpClientOptions clientOptions = new HttpClientOptions().
-    setHttp2MaxStreams(10).
+    setHttp2MultiplexingLimit(10).
     setHttp2MaxPoolSize(3);
 
 // Uses up to 3 connections and up to 10 streams per connection
 HttpClient client = vertx.createHttpClient(clientOptions);
 ----
 
-The maximum streams for a connection is a setting set on the client that limits the streams
+The multiplexing limit for a connection is a setting set on the client that limits the number of streams
 of a single connection. The effective value can be even lower if the server sets a lower limit
 with the `link:../../apidocs/io/vertx/core/http/Http2Settings.html#setMaxConcurrentStreams-long-[SETTINGS_MAX_CONCURRENT_STREAMS]` setting.
 

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -47,8 +47,8 @@ public class HttpClientOptionsConverter {
     if (json.getValue("http2MaxPoolSize") instanceof Number) {
       obj.setHttp2MaxPoolSize(((Number)json.getValue("http2MaxPoolSize")).intValue());
     }
-    if (json.getValue("http2MaxStreams") instanceof Number) {
-      obj.setHttp2MaxStreams(((Number)json.getValue("http2MaxStreams")).intValue());
+    if (json.getValue("http2MultiplexingLimit") instanceof Number) {
+      obj.setHttp2MultiplexingLimit(((Number)json.getValue("http2MultiplexingLimit")).intValue());
     }
     if (json.getValue("initialSettings") instanceof JsonObject) {
       obj.setInitialSettings(new io.vertx.core.http.Http2Settings((JsonObject)json.getValue("initialSettings")));
@@ -70,6 +70,9 @@ public class HttpClientOptionsConverter {
     }
     if (json.getValue("pipelining") instanceof Boolean) {
       obj.setPipelining((Boolean)json.getValue("pipelining"));
+    }
+    if (json.getValue("pipeliningLimit") instanceof Number) {
+      obj.setPipeliningLimit(((Number)json.getValue("pipeliningLimit")).intValue());
     }
     if (json.getValue("protocolVersion") instanceof String) {
       obj.setProtocolVersion(io.vertx.core.http.HttpVersion.valueOf((String)json.getValue("protocolVersion")));
@@ -96,7 +99,7 @@ public class HttpClientOptionsConverter {
     json.put("defaultPort", obj.getDefaultPort());
     json.put("h2cUpgrade", obj.isH2cUpgrade());
     json.put("http2MaxPoolSize", obj.getHttp2MaxPoolSize());
-    json.put("http2MaxStreams", obj.getHttp2MaxStreams());
+    json.put("http2MultiplexingLimit", obj.getHttp2MultiplexingLimit());
     if (obj.getInitialSettings() != null) {
       json.put("initialSettings", obj.getInitialSettings().toJson());
     }
@@ -106,6 +109,7 @@ public class HttpClientOptionsConverter {
     json.put("maxWaitQueueSize", obj.getMaxWaitQueueSize());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
     json.put("pipelining", obj.isPipelining());
+    json.put("pipeliningLimit", obj.getPipeliningLimit());
     if (obj.getProtocolVersion() != null) {
       json.put("protocolVersion", obj.getProtocolVersion().name());
     }

--- a/src/main/java/examples/HTTP2Examples.java
+++ b/src/main/java/examples/HTTP2Examples.java
@@ -285,7 +285,7 @@ public class HTTP2Examples {
   public void useMaxStreams(Vertx vertx) {
 
     HttpClientOptions clientOptions = new HttpClientOptions().
-        setHttp2MaxStreams(10).
+        setHttp2MultiplexingLimit(10).
         setHttp2MaxPoolSize(3);
 
     // Uses up to 3 connections and up to 10 streams per connection

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -382,11 +382,14 @@ public class HttpClientOptions extends ClientOptionsBase {
    * Setting the value to {@code -1} means to use the value sent by the server's initial settings.
    * {@code -1} is the default value.
    *
-   * @param http2MultiplexingLimit the maximum concurrent for an HTTP/2 connection
+   * @param limit the maximum concurrent for an HTTP/2 connection
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpClientOptions setHttp2MultiplexingLimit(int http2MultiplexingLimit) {
-    this.http2MultiplexingLimit = http2MultiplexingLimit;
+  public HttpClientOptions setHttp2MultiplexingLimit(int limit) {
+    if (limit < 1) {
+      throw new IllegalArgumentException("maxPoolSize must be > 0");
+    }
+    this.http2MultiplexingLimit = limit;
     return this;
   }
 
@@ -406,7 +409,7 @@ public class HttpClientOptions extends ClientOptionsBase {
    * @return a reference to this, so the API can be used fluently
    */
   public HttpClientOptions setHttp2MaxPoolSize(int max) {
-    if (maxPoolSize < 1) {
+    if (max < 1) {
       throw new IllegalArgumentException("http2MaxPoolSize must be > 0");
     }
     this.http2MaxPoolSize = max;
@@ -463,11 +466,14 @@ public class HttpClientOptions extends ClientOptionsBase {
   /**
    * Set the limit of pending requests a pipe-lined HTTP/1 connection can send.
    *
-   * @param pipeliningLimit the limit of pending requests
+   * @param limit the limit of pending requests
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpClientOptions setPipeliningLimit(int pipeliningLimit) {
-    this.pipeliningLimit = pipeliningLimit;
+  public HttpClientOptions setPipeliningLimit(int limit) {
+    if (limit < 1) {
+      throw new IllegalArgumentException("pipeliningLimit must be > 0");
+    }
+    this.pipeliningLimit = limit;
     return this;
   }
 
@@ -728,6 +734,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (http2MultiplexingLimit != that.http2MultiplexingLimit) return false;
     if (maxWebsocketFrameSize != that.maxWebsocketFrameSize) return false;
     if (pipelining != that.pipelining) return false;
+    if (pipeliningLimit != that.pipeliningLimit) return false;
     if (tryUseCompression != that.tryUseCompression) return false;
     if (verifyHost != that.verifyHost) return false;
     if (!defaultHost.equals(that.defaultHost)) return false;
@@ -749,6 +756,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     result = 31 * result + http2MultiplexingLimit;
     result = 31 * result + (keepAlive ? 1 : 0);
     result = 31 * result + (pipelining ? 1 : 0);
+    result = 31 * result + pipeliningLimit;
     result = 31 * result + (tryUseCompression ? 1 : 0);
     result = 31 * result + maxWebsocketFrameSize;
     result = 31 * result + defaultHost.hashCode();

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -42,7 +42,7 @@ import java.util.List;
 public class HttpClientOptions extends ClientOptionsBase {
 
   /**
-   * The default maximum number of connections a client will pool = 5
+   * The default maximum number of HTTP/1 connections a client will pool = 5
    */
   public static final int DEFAULT_MAX_POOL_SIZE = 5;
 
@@ -52,9 +52,9 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_HTTP2_MAX_POOL_SIZE = 1;
 
   /**
-   * The default maximum number of concurrent stream per connection for HTTP/2 = -1
+   * The default maximum number of concurrent streams per connection for HTTP/2 = -1
    */
-  public static final int DEFAULT_HTTP2_MAX_STREAMS = -1;
+  public static final int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
 
   /**
    * Default value of whether keep-alive is enabled = true
@@ -65,6 +65,11 @@ public class HttpClientOptions extends ClientOptionsBase {
    * Default value of whether pipe-lining is enabled = false
    */
   public static final boolean DEFAULT_PIPELINING = false;
+
+  /**
+   * The default maximum number of requests an HTTP/1.1 pipe-lined connection can send = 10
+   */
+  public static final int DEFAULT_PIPELINING_LIMIT = 10;
 
   /**
    * Default value of whether the client will attempt to use compression = false
@@ -119,9 +124,10 @@ public class HttpClientOptions extends ClientOptionsBase {
   private boolean verifyHost = true;
   private int maxPoolSize;
   private boolean keepAlive;
+  private int pipeliningLimit;
   private boolean pipelining;
   private int http2MaxPoolSize;
-  private int http2MaxStreams;
+  private int http2MultiplexingLimit;
 
   private boolean tryUseCompression;
   private int maxWebsocketFrameSize;
@@ -153,8 +159,9 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.maxPoolSize = other.getMaxPoolSize();
     this.keepAlive = other.isKeepAlive();
     this.pipelining = other.isPipelining();
+    this.pipeliningLimit = other.getPipeliningLimit();
     this.http2MaxPoolSize = other.getHttp2MaxPoolSize();
-    this.http2MaxStreams = other.http2MaxStreams;
+    this.http2MultiplexingLimit = other.http2MultiplexingLimit;
     this.tryUseCompression = other.isTryUseCompression();
     this.maxWebsocketFrameSize = other.maxWebsocketFrameSize;
     this.defaultHost = other.defaultHost;
@@ -183,7 +190,8 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxPoolSize = DEFAULT_MAX_POOL_SIZE;
     keepAlive = DEFAULT_KEEP_ALIVE;
     pipelining = DEFAULT_PIPELINING;
-    http2MaxStreams = DEFAULT_HTTP2_MAX_STREAMS;
+    pipeliningLimit = DEFAULT_PIPELINING_LIMIT;
+    http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
     http2MaxPoolSize = DEFAULT_HTTP2_MAX_POOL_SIZE;
     tryUseCompression = DEFAULT_TRY_USE_COMPRESSION;
     maxWebsocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
@@ -362,8 +370,8 @@ public class HttpClientOptions extends ClientOptionsBase {
    * @return the maximum number of concurrent streams for an HTTP/2 connection, {@code -1} means
    * the value sent by the server
    */
-  public int getHttp2MaxStreams() {
-    return http2MaxStreams;
+  public int getHttp2MultiplexingLimit() {
+    return http2MultiplexingLimit;
   }
 
   /**
@@ -374,11 +382,11 @@ public class HttpClientOptions extends ClientOptionsBase {
    * Setting the value to {@code -1} means to use the value sent by the server's initial settings.
    * {@code -1} is the default value.
    *
-   * @param http2MaxStreams the maximum concurrent for an HTTP/2 connection
+   * @param http2MultiplexingLimit the maximum concurrent for an HTTP/2 connection
    * @return a reference to this, so the API can be used fluently
    */
-  public HttpClientOptions setHttp2MaxStreams(int http2MaxStreams) {
-    this.http2MaxStreams = http2MaxStreams;
+  public HttpClientOptions setHttp2MultiplexingLimit(int http2MultiplexingLimit) {
+    this.http2MultiplexingLimit = http2MultiplexingLimit;
     return this;
   }
 
@@ -442,6 +450,24 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions setPipelining(boolean pipelining) {
     this.pipelining = pipelining;
+    return this;
+  }
+
+  /**
+   * @return the limit of pending requests a pipe-lined HTTP/1 connection can send
+   */
+  public int getPipeliningLimit() {
+    return pipeliningLimit;
+  }
+
+  /**
+   * Set the limit of pending requests a pipe-lined HTTP/1 connection can send.
+   *
+   * @param pipeliningLimit the limit of pending requests
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setPipeliningLimit(int pipeliningLimit) {
+    this.pipeliningLimit = pipeliningLimit;
     return this;
   }
 
@@ -699,7 +725,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (defaultPort != that.defaultPort) return false;
     if (keepAlive != that.keepAlive) return false;
     if (maxPoolSize != that.maxPoolSize) return false;
-    if (http2MaxStreams != that.http2MaxStreams) return false;
+    if (http2MultiplexingLimit != that.http2MultiplexingLimit) return false;
     if (maxWebsocketFrameSize != that.maxWebsocketFrameSize) return false;
     if (pipelining != that.pipelining) return false;
     if (tryUseCompression != that.tryUseCompression) return false;
@@ -720,7 +746,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     int result = super.hashCode();
     result = 31 * result + (verifyHost ? 1 : 0);
     result = 31 * result + maxPoolSize;
-    result = 31 * result + http2MaxStreams;
+    result = 31 * result + http2MultiplexingLimit;
     result = 31 * result + (keepAlive ? 1 : 0);
     result = 31 * result + (pipelining ? 1 : 0);
     result = 31 * result + (tryUseCompression ? 1 : 0);

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -524,7 +524,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
       metrics.requestEnd(currentRequest.metric());
     }
     currentRequest = null;
-    pool.recycle(this);
+    pool.requestEnded(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -87,7 +87,7 @@ public class ConnectionManager {
     this.keepAlive = client.getOptions().isKeepAlive();
     this.pipelining = client.getOptions().isPipelining();
     this.maxWaitQueueSize = client.getOptions().getMaxWaitQueueSize();
-    this.http2MaxConcurrency = options.getHttp2MaxStreams() < 1 ? Integer.MAX_VALUE : options.getHttp2MaxStreams();
+    this.http2MaxConcurrency = options.getHttp2MultiplexingLimit() < 1 ? Integer.MAX_VALUE : options.getHttp2MultiplexingLimit();
     this.logEnabled = client.getOptions().getLogActivity();
     this.connector = new ChannelConnector();
     this.metrics = metrics;

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -41,6 +41,7 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
   private final Map<Channel, HttpClientConnection> connectionMap;
   private final boolean pipelining;
   private final boolean keepAlive;
+  private final int pipeliningLimit;
   private final boolean ssl;
   private final HttpVersion version;
   private final Set<ClientConnection> allConnections = new HashSet<>();
@@ -55,6 +56,7 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
     this.metrics = metrics;
     this.pipelining = options.isPipelining();
     this.keepAlive = options.isKeepAlive();
+    this.pipeliningLimit = options.getPipeliningLimit();
     this.ssl = options.isSsl();
     this.connectionMap = connectionMap;
     this.maxSockets = maxSockets;
@@ -81,36 +83,37 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
     return conn;
   }
 
-  // Called when the request has ended
   public void recycle(ClientConnection conn) {
-    if (pipelining) {
-      doRecycle(conn);
-    }
-  }
-
-  // Called when the response has ended
-  public void responseEnded(ClientConnection conn, boolean close) {
-    if ((pipelining || keepAlive) && !close && conn.getCurrentRequest() == null) {
-      doRecycle(conn);
-    } else {
-      // Close it now
-      conn.close();
-    }
-  }
-
-  private void doRecycle(ClientConnection conn) {
     synchronized (queue) {
       Waiter waiter = queue.getNextWaiter();
       if (waiter != null) {
-        Context context = waiter.context;
-        if (context == null) {
-          context = conn.getContext();
-        }
-        context.runOnContext(v -> queue.deliverStream(conn, waiter));
+        queue.deliverStream(conn, waiter);
       } else if (conn.getOutstandingRequestCount() == 0) {
         // Return to set of available from here to not return it several times
         availableConnections.add(conn);
       }
+    }
+  }
+
+  void requestEnded(ClientConnection conn) {
+    ContextImpl context = conn.getContext();
+    context.runOnContext(v -> {
+      if (pipelining && conn.getOutstandingRequestCount() < pipeliningLimit) {
+        recycle(conn);
+      }
+    });
+  }
+
+  void responseEnded(ClientConnection conn, boolean close) {
+    if (!keepAlive || close) {
+      conn.close();
+    } else {
+      ContextImpl ctx = conn.getContext();
+      ctx.runOnContext(v -> {
+        if (conn.getCurrentRequest() == null) {
+          recycle(conn);
+        }
+      });
     }
   }
 

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -1206,16 +1206,20 @@
  *
  * When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
  *
+ * The number of pipe-lined requests over a single connection is limited by {@link io.vertx.core.http.HttpClientOptions#setPipeliningLimit}.
+ * This option defines the maximum number of http requests sent to the server awaiting for a response. This limit ensures the
+ * fairness of the distribution of the client requests over the connections to the same server.
+ * 
  * === HTTP/2 multiplexing
  *
  * HTTP/2 advocates to use a single connection to a server, by default the http client uses a single
- * connection for each server, all the streams to the same server are multiplexed on the same connection.
+ * connection for each server, all the streams to the same server are multiplexed over the same connection.
  *
  * When the clients needs to use more than a single connection and use pooling, the {@link io.vertx.core.http.HttpClientOptions#setHttp2MaxPoolSize(int)}
  * shall be used.
  *
- * When it is desirable to limit the number of concurrent streams per server and use a connection
- * pool instead of a single connection, {@link io.vertx.core.http.HttpClientOptions#setHttp2MaxStreams(int)}
+ * When it is desirable to limit the number of multiplexed streams per connection and use a connection
+ * pool instead of a single connection, {@link io.vertx.core.http.HttpClientOptions#setHttp2MultiplexingLimit(int)}
  * can be used.
  *
  * [source,$lang]
@@ -1223,7 +1227,7 @@
  * {@link examples.HTTP2Examples#useMaxStreams}
  * ----
  *
- * The maximum streams for a connection is a setting set on the client that limits the streams
+ * The multiplexing limit for a connection is a setting set on the client that limits the number of streams
  * of a single connection. The effective value can be even lower if the server sets a lower limit
  * with the {@link io.vertx.core.http.Http2Settings#setMaxConcurrentStreams SETTINGS_MAX_CONCURRENT_STREAMS} setting.
  *

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -148,6 +148,27 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setPipelining(true));
     assertTrue(options.isPipelining());
 
+    assertEquals(HttpClientOptions.DEFAULT_PIPELINING_LIMIT, options.getPipeliningLimit());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setPipeliningLimit(rand));
+    assertEquals(rand, options.getPipeliningLimit());
+    assertIllegalArgumentException(() -> options.setPipeliningLimit(0));
+    assertIllegalArgumentException(() -> options.setPipeliningLimit(-1));
+
+    assertEquals(HttpClientOptions.DEFAULT_HTTP2_MAX_POOL_SIZE, options.getHttp2MaxPoolSize());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setHttp2MaxPoolSize(rand));
+    assertEquals(rand, options.getHttp2MaxPoolSize());
+    assertIllegalArgumentException(() -> options.setHttp2MaxPoolSize(0));
+    assertIllegalArgumentException(() -> options.setHttp2MaxPoolSize(-1));
+
+    assertEquals(HttpClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT, options.getHttp2MultiplexingLimit());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setHttp2MultiplexingLimit(rand));
+    assertEquals(rand, options.getHttp2MultiplexingLimit());
+    assertIllegalArgumentException(() -> options.setHttp2MultiplexingLimit(0));
+    assertIllegalArgumentException(() -> options.setHttp2MultiplexingLimit(-1));
+
     assertEquals(60000, options.getConnectTimeout());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setConnectTimeout(rand));
@@ -358,6 +379,9 @@ public class Http1xTest extends HttpTest {
     int maxPoolSize = TestUtils.randomPositiveInt();
     boolean keepAlive = rand.nextBoolean();
     boolean pipelining = rand.nextBoolean();
+    int pipeliningLimit = TestUtils.randomPositiveInt();
+    int http2MaxPoolSize = TestUtils.randomPositiveInt();
+    int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     boolean tryUseCompression = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_0;
     int maxWaitQueueSize = TestUtils.randomPositiveInt();
@@ -388,6 +412,9 @@ public class Http1xTest extends HttpTest {
     options.setMaxPoolSize(maxPoolSize);
     options.setKeepAlive(keepAlive);
     options.setPipelining(pipelining);
+    options.setPipeliningLimit(pipeliningLimit);
+    options.setHttp2MaxPoolSize(http2MaxPoolSize);
+    options.setHttp2MultiplexingLimit(http2MultiplexingLimit);
     options.setTryUseCompression(tryUseCompression);
     options.setProtocolVersion(protocolVersion);
     options.setMaxWaitQueueSize(maxWaitQueueSize);
@@ -423,6 +450,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(maxPoolSize, copy.getMaxPoolSize());
     assertEquals(keepAlive, copy.isKeepAlive());
     assertEquals(pipelining, copy.isPipelining());
+    assertEquals(pipeliningLimit, copy.getPipeliningLimit());
+    assertEquals(http2MaxPoolSize, copy.getHttp2MaxPoolSize());
+    assertEquals(http2MultiplexingLimit, copy.getHttp2MultiplexingLimit());
     assertEquals(tryUseCompression, copy.isTryUseCompression());
     assertEquals(protocolVersion, copy.getProtocolVersion());
     assertEquals(maxWaitQueueSize, copy.getMaxWaitQueueSize());
@@ -440,6 +470,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getMaxPoolSize(), json.getMaxPoolSize());
     assertEquals(def.isKeepAlive(), json.isKeepAlive());
     assertEquals(def.isPipelining(), json.isPipelining());
+    assertEquals(def.getPipeliningLimit(), json.getPipeliningLimit());
+    assertEquals(def.getHttp2MaxPoolSize(), json.getHttp2MaxPoolSize());
+    assertEquals(def.getHttp2MultiplexingLimit(), json.getHttp2MultiplexingLimit());
     assertEquals(def.isVerifyHost(), json.isVerifyHost());
     assertEquals(def.isTryUseCompression(), json.isTryUseCompression());
     assertEquals(def.isTrustAll(), json.isTrustAll());
@@ -491,6 +524,9 @@ public class Http1xTest extends HttpTest {
     int maxPoolSize = TestUtils.randomPositiveInt();
     boolean keepAlive = rand.nextBoolean();
     boolean pipelining = rand.nextBoolean();
+    int pipeliningLimit = TestUtils.randomPositiveInt();
+    int http2MaxPoolSize = TestUtils.randomPositiveInt();
+    int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     boolean tryUseCompression = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_1;
     int maxWaitQueueSize = TestUtils.randomPositiveInt();
@@ -521,6 +557,9 @@ public class Http1xTest extends HttpTest {
       .put("maxPoolSize", maxPoolSize)
       .put("keepAlive", keepAlive)
       .put("pipelining", pipelining)
+      .put("pipeliningLimit", pipeliningLimit)
+      .put("http2MaxPoolSize", http2MaxPoolSize)
+      .put("http2MultiplexingLimit", http2MultiplexingLimit)
       .put("tryUseCompression", tryUseCompression)
       .put("protocolVersion", protocolVersion.name())
       .put("maxWaitQueueSize", maxWaitQueueSize)
@@ -563,6 +602,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(maxPoolSize, options.getMaxPoolSize());
     assertEquals(keepAlive, options.isKeepAlive());
     assertEquals(pipelining, options.isPipelining());
+    assertEquals(pipeliningLimit, options.getPipeliningLimit());
+    assertEquals(http2MaxPoolSize, options.getHttp2MaxPoolSize());
+    assertEquals(http2MultiplexingLimit, options.getHttp2MultiplexingLimit());
     assertEquals(tryUseCompression, options.isTryUseCompression());
     assertEquals(protocolVersion, options.getProtocolVersion());
     assertEquals(maxWaitQueueSize, options.getMaxWaitQueueSize());

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -1682,11 +1682,8 @@ public class Http1xTest extends HttpTest {
     });
     req1.end();
     Consumer<HttpClientRequest> checker = req -> {
-      if (req1.connection() == req.connection()) {
-        assertSame(Vertx.currentContext(), c.get());
-      } else {
-        // This may happen sometimes if the connection
-      }
+      assertSame(Vertx.currentContext(), c.get());
+      assertSame(req1.connection(), req.connection());
     };
     awaitLatch(req1Latch);
     CountDownLatch req2Latch = new CountDownLatch(2);

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -70,10 +70,8 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -1703,7 +1701,7 @@ public class Http2ClientTest extends Http2TestBase {
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions(clientOptions).
         setHttp2MaxPoolSize(poolSize).
-        setHttp2MaxStreams(maxConcurrency));
+        setHttp2MultiplexingLimit(maxConcurrency));
     AtomicInteger respCount = new AtomicInteger();
 
     Set<HttpConnection> clientConnections = Collections.synchronizedSet(new HashSet<>());


### PR DESCRIPTION
This feature sets an upper limit for the number of pipe-lined requests for which no response have been received yet on an HTTP/1.1 persistent connection. 

When a client creates a very large number HTTP client requests at the same time, the distribution of the requests on the pool is not fair (i.e a few connections can get more connections than others). This feature limits the number of requests sent on an connection, the other pending requests remain in the endpoint queue.