### PR TITLE
Open ssl session cache enabled

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -79,6 +79,11 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public static final long DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS = 100;
 
+  /**
+   * Default value of whether session cache is enabled in open SSL session server context
+   */
+  public static final boolean DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED = true;
+
   private boolean compressionSupported;
   private int maxWebsocketFrameSize;
   private String websocketSubProtocols;
@@ -88,6 +93,7 @@ public class HttpServerOptions extends NetServerOptions {
   private int maxHeaderSize;
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
+  private boolean openSslSessionCacheEnabled;
 
   /**
    * Default constructor
@@ -114,6 +120,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxHeaderSize = other.getMaxHeaderSize();
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
+    this.openSslSessionCacheEnabled = other.isOpenSslSessionCacheEnabled();
   }
 
   /**
@@ -137,6 +144,7 @@ public class HttpServerOptions extends NetServerOptions {
     maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
     initialSettings = new Http2Settings().setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
+    openSslSessionCacheEnabled = DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED;
   }
 
   @Override
@@ -326,6 +334,26 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   /**
+   * Set whether session cache is enabled in open SSL session server context
+   *
+   * @param sessionCacheEnabled true if session cache is enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setOpenSslSessionCacheEnabled(boolean sessionCacheEnabled) {
+    this.openSslSessionCacheEnabled = sessionCacheEnabled;
+    return this;
+  }
+
+  /**
+  * Whether session cache is enabled in open SSL session server context
+  *
+  * @return true if session cache is enabled
+  */
+  public boolean isOpenSslSessionCacheEnabled() {
+    return openSslSessionCacheEnabled;
+  }
+
+    /**
    * @return  the maximum websocket framesize
    */
   public int getMaxWebsocketFrameSize() {
@@ -490,6 +518,7 @@ public class HttpServerOptions extends NetServerOptions {
     if (maxHeaderSize != that.maxHeaderSize) return false;
     if (initialSettings == null ? that.initialSettings != null : !initialSettings.equals(that.initialSettings)) return false;
     if (alpnVersions == null ? that.alpnVersions != null : !alpnVersions.equals(that.alpnVersions)) return false;
+    if (openSslSessionCacheEnabled != that.openSslSessionCacheEnabled) return false;
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
   }
 
@@ -505,6 +534,7 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + maxInitialLineLength;
     result = 31 * result + maxHeaderSize;
     result = 31 * result + (alpnVersions != null ? alpnVersions.hashCode() : 0);
+    result = 31 * result + (openSslSessionCacheEnabled ? 1 : 0);
     return result;
   }
 }

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -338,6 +338,10 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     Http2Settings initialSettings = randomHttp2Settings();
     assertEquals(new Http2Settings().setMaxConcurrentStreams(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS), options.getInitialSettings());
     assertEquals(options, options.setInitialSettings(initialSettings));
@@ -669,6 +673,7 @@ public class Http1xTest extends HttpTest {
     int maxChunkSize = rand.nextInt(10000);
     Http2Settings initialSettings = randomHttp2Settings();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     options.setSendBufferSize(sendBufferSize);
@@ -698,6 +703,7 @@ public class Http1xTest extends HttpTest {
     options.setSslEngine(sslEngine);
     options.setInitialSettings(initialSettings);
     options.setAlpnVersions(alpnVersions);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
     HttpServerOptions copy = new HttpServerOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -731,6 +737,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(alpnVersions, copy.getAlpnVersions());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -759,6 +766,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getAlpnVersions(), json.getAlpnVersions());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -801,6 +809,7 @@ public class Http1xTest extends HttpTest {
     boolean useAlpn = TestUtils.randomBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
+    boolean openSslSessionCacheEnabled = TestUtils.randomBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -837,7 +846,8 @@ public class Http1xTest extends HttpTest {
           .put("maxFrameSize", initialSettings.getMaxFrameSize()))
       .put("useAlpn", useAlpn)
       .put("sslEngine", sslEngine.name())
-      .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()));
+      .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     HttpServerOptions options = new HttpServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -873,6 +883,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(initialSettings, options.getInitialSettings());
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
     assertEquals(alpnVersions, options.getAlpnVersions());
 
     // Test other keystore/truststore types


### PR DESCRIPTION
Hello, 

As discussed yesterday with @vietj, I exposed  session cache mode setting in HttpServerOptions.
See the following thread in the groups: 
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/vertx/UUMJ4Y4uMcc

I did my best to add the new property also to the relevant JUnit tests. I hope you'll find my work suitable. If you have questions/requests - please contact me.

Please pay attention that I'm not committing under the same name/email as in the groups because I was asked by my employer not to use my own email (legal stuff), but I'm the same person.