### PR TITLE
Open ssl session cache enabled pr

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -79,6 +79,11 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public static final long DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS = 100;
 
+  /**
+   * Default value of whether session cache is enabled in open SSL session server context
+   */
+  public static final boolean DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED = true;
+
   private boolean compressionSupported;
   private int maxWebsocketFrameSize;
   private String websocketSubProtocols;
@@ -88,6 +93,7 @@ public class HttpServerOptions extends NetServerOptions {
   private int maxHeaderSize;
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
+  private boolean openSslSessionCacheEnabled;
 
   /**
    * Default constructor
@@ -114,6 +120,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxHeaderSize = other.getMaxHeaderSize();
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
+    this.openSslSessionCacheEnabled = other.isOpenSslSessionCacheEnabled();
   }
 
   /**
@@ -137,6 +144,7 @@ public class HttpServerOptions extends NetServerOptions {
     maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
     initialSettings = new Http2Settings().setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
+    openSslSessionCacheEnabled = DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED;
   }
 
   @Override
@@ -326,6 +334,26 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   /**
+   * Set whether session cache is enabled in open SSL session server context
+   *
+   * @param sessionCacheEnabled true if session cache is enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setOpenSslSessionCacheEnabled(boolean sessionCacheEnabled) {
+    this.openSslSessionCacheEnabled = sessionCacheEnabled;
+    return this;
+  }
+
+  /**
+  * Whether session cache is enabled in open SSL session server context
+  *
+  * @return true if session cache is enabled
+  */
+  public boolean isOpenSslSessionCacheEnabled() {
+    return openSslSessionCacheEnabled;
+  }
+
+    /**
    * @return  the maximum websocket framesize
    */
   public int getMaxWebsocketFrameSize() {
@@ -490,6 +518,7 @@ public class HttpServerOptions extends NetServerOptions {
     if (maxHeaderSize != that.maxHeaderSize) return false;
     if (initialSettings == null ? that.initialSettings != null : !initialSettings.equals(that.initialSettings)) return false;
     if (alpnVersions == null ? that.alpnVersions != null : !alpnVersions.equals(that.alpnVersions)) return false;
+    if (openSslSessionCacheEnabled != that.openSslSessionCacheEnabled) return false;
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
   }
 
@@ -505,6 +534,7 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + maxInitialLineLength;
     result = 31 * result + maxHeaderSize;
     result = 31 * result + (alpnVersions != null ? alpnVersions.hashCode() : 0);
+    result = 31 * result + (openSslSessionCacheEnabled ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -79,11 +79,6 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public static final long DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS = 100;
 
-  /**
-   * Default value of whether session cache is enabled in open SSL session server context
-   */
-  public static final boolean DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED = true;
-
   private boolean compressionSupported;
   private int maxWebsocketFrameSize;
   private String websocketSubProtocols;
@@ -93,7 +88,6 @@ public class HttpServerOptions extends NetServerOptions {
   private int maxHeaderSize;
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
-  private boolean openSslSessionCacheEnabled;
 
   /**
    * Default constructor
@@ -120,7 +114,6 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxHeaderSize = other.getMaxHeaderSize();
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
-    this.openSslSessionCacheEnabled = other.isOpenSslSessionCacheEnabled();
   }
 
   /**
@@ -144,7 +137,6 @@ public class HttpServerOptions extends NetServerOptions {
     maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
     initialSettings = new Http2Settings().setMaxConcurrentStreams(DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS);
     alpnVersions = new ArrayList<>(DEFAULT_ALPN_VERSIONS);
-    openSslSessionCacheEnabled = DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED;
   }
 
   @Override
@@ -334,26 +326,6 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   /**
-   * Set whether session cache is enabled in open SSL session server context
-   *
-   * @param sessionCacheEnabled true if session cache is enabled
-   * @return a reference to this, so the API can be used fluently
-   */
-  public HttpServerOptions setOpenSslSessionCacheEnabled(boolean sessionCacheEnabled) {
-    this.openSslSessionCacheEnabled = sessionCacheEnabled;
-    return this;
-  }
-
-  /**
-  * Whether session cache is enabled in open SSL session server context
-  *
-  * @return true if session cache is enabled
-  */
-  public boolean isOpenSslSessionCacheEnabled() {
-    return openSslSessionCacheEnabled;
-  }
-
-    /**
    * @return  the maximum websocket framesize
    */
   public int getMaxWebsocketFrameSize() {
@@ -424,17 +396,17 @@ public class HttpServerOptions extends NetServerOptions {
     return maxChunkSize;
   }
 
-  
+
   /**
    * @return the maximum length of the initial line for HTTP/1.x (e.g. {@code "GET / HTTP/1.0"})
    */
   public int getMaxInitialLineLength() {
     return maxInitialLineLength;
   }
-	
+
   /**
    * Set the maximum length of the initial line for HTTP/1.x (e.g. {@code "GET / HTTP/1.0"})
-   * 
+   *
    * @param maxInitialLineLength the new maximum initial length
    * @return a reference to this, so the API can be used fluently
    */
@@ -442,14 +414,14 @@ public class HttpServerOptions extends NetServerOptions {
     this.maxInitialLineLength = maxInitialLineLength;
     return this;
   }
-	
+
   /**
    * @return Returns the maximum length of all headers for HTTP/1.x
    */
   public int getMaxHeaderSize() {
     return maxHeaderSize;
   }
-	
+
   /**
    * Set the maximum length of all headers for HTTP/1.x .
    *
@@ -518,7 +490,6 @@ public class HttpServerOptions extends NetServerOptions {
     if (maxHeaderSize != that.maxHeaderSize) return false;
     if (initialSettings == null ? that.initialSettings != null : !initialSettings.equals(that.initialSettings)) return false;
     if (alpnVersions == null ? that.alpnVersions != null : !alpnVersions.equals(that.alpnVersions)) return false;
-    if (openSslSessionCacheEnabled != that.openSslSessionCacheEnabled) return false;
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
   }
 
@@ -534,7 +505,6 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + maxInitialLineLength;
     result = 31 * result + maxHeaderSize;
     result = 31 * result + (alpnVersions != null ? alpnVersions.hashCode() : 0);
-    result = 31 * result + (openSslSessionCacheEnabled ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -71,6 +71,11 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     */
   public static final SSLEngine DEFAULT_SSL_ENGINE = SSLEngine.JDK;
 
+  /**
+   * Default value of whether session cache is enabled in open SSL session server context
+   */
+  public static final boolean DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED = true;
+
 
   private boolean tcpNoDelay;
   private boolean tcpKeepAlive;
@@ -86,6 +91,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   private boolean useAlpn;
   private SSLEngine sslEngine;
   private Set<String> enabledSecureTransportProtocols = new HashSet<>();
+  private boolean openSslSessionCacheEnabled;
 
   /**
    * Default constructor
@@ -116,6 +122,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     this.useAlpn = other.useAlpn;
     this.sslEngine = other.sslEngine;
     this.enabledSecureTransportProtocols = other.getEnabledSecureTransportProtocols() == null ? new HashSet<>() : new HashSet<>(other.getEnabledSecureTransportProtocols());
+    this.openSslSessionCacheEnabled = other.isOpenSslSessionCacheEnabled();
   }
 
   /**
@@ -140,6 +147,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     crlValues = new ArrayList<>();
     useAlpn = DEFAULT_USE_ALPN;
     sslEngine = DEFAULT_SSL_ENGINE;
+    openSslSessionCacheEnabled = DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED;
   }
 
   /**
@@ -477,6 +485,26 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     return (TCPSSLOptions) super.setLogActivity(logEnabled);
   }
 
+  /**
+   * Set whether session cache is enabled in open SSL session server context
+   *
+   * @param sessionCacheEnabled true if session cache is enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setOpenSslSessionCacheEnabled(boolean sessionCacheEnabled) {
+    this.openSslSessionCacheEnabled = sessionCacheEnabled;
+    return this;
+  }
+
+  /**
+   * Whether session cache is enabled in open SSL session server context
+   *
+   * @return true if session cache is enabled
+   */
+  public boolean isOpenSslSessionCacheEnabled() {
+    return openSslSessionCacheEnabled;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -499,6 +527,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     if (trustOptions != null ? !trustOptions.equals(that.trustOptions) : that.trustOptions != null) return false;
     if (useAlpn != that.useAlpn) return false;
     if (sslEngine != that.sslEngine) return false;
+    if (openSslSessionCacheEnabled != that.openSslSessionCacheEnabled) return false;
     if (!enabledSecureTransportProtocols.equals(that.enabledSecureTransportProtocols)) return false;
 
     return true;
@@ -522,6 +551,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     result = 31 * result + (sslEngine != null ? sslEngine.hashCode() : 0);
     result = 31 * result + (enabledSecureTransportProtocols != null ? enabledSecureTransportProtocols
         .hashCode() : 0);
+    result = 31 * result + (openSslSessionCacheEnabled ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -115,6 +115,7 @@ public class SSLHelper {
     if (options.isVerifyHost()) {
       this.endpointIdentificationAlgorithm = "HTTPS";
     }
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public SSLHelper(HttpServerOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
@@ -145,6 +146,7 @@ public class SSLHelper {
     this.useAlpn = false;
     this.enabledProtocols = options.getEnabledSecureTransportProtocols();
     this.endpointIdentificationAlgorithm = options.getHostnameVerificationAlgorithm();
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public SSLHelper(NetServerOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
@@ -159,6 +161,7 @@ public class SSLHelper {
     this.client = false;
     this.useAlpn = false;
     this.enabledProtocols = options.getEnabledSecureTransportProtocols();
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public boolean isSSL() {

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -394,6 +394,7 @@ public class Http1xTest extends HttpTest {
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     boolean h2cUpgrade = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
 
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -427,6 +428,8 @@ public class Http1xTest extends HttpTest {
     options.setSslEngine(sslEngine);
     options.setAlpnVersions(alpnVersions);
     options.setH2cUpgrade(h2cUpgrade);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
+
     HttpClientOptions copy = new HttpClientOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -465,6 +468,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(alpnVersions, copy.getAlpnVersions());
     assertEquals(h2cUpgrade, copy.isH2cUpgrade());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -495,6 +499,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getAlpnVersions(), json.getAlpnVersions());
     assertEquals(def.isH2cUpgrade(), json.isH2cUpgrade());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -539,6 +544,7 @@ public class Http1xTest extends HttpTest {
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     boolean h2cUpgrade = rand.nextBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -577,7 +583,8 @@ public class Http1xTest extends HttpTest {
       .put("useAlpn", useAlpn)
       .put("sslEngine", sslEngine.name())
       .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
-      .put("h2cUpgrade", h2cUpgrade);
+      .put("h2cUpgrade", h2cUpgrade)
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     HttpClientOptions options = new HttpClientOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -617,6 +624,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(sslEngine, options.getSslEngine());
     assertEquals(alpnVersions, options.getAlpnVersions());
     assertEquals(h2cUpgrade, options.isH2cUpgrade());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -338,6 +338,10 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     Http2Settings initialSettings = randomHttp2Settings();
     assertEquals(new Http2Settings().setMaxConcurrentStreams(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS), options.getInitialSettings());
     assertEquals(options, options.setInitialSettings(initialSettings));
@@ -669,6 +673,7 @@ public class Http1xTest extends HttpTest {
     int maxChunkSize = rand.nextInt(10000);
     Http2Settings initialSettings = randomHttp2Settings();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     options.setSendBufferSize(sendBufferSize);
@@ -698,6 +703,7 @@ public class Http1xTest extends HttpTest {
     options.setSslEngine(sslEngine);
     options.setInitialSettings(initialSettings);
     options.setAlpnVersions(alpnVersions);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
     HttpServerOptions copy = new HttpServerOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -731,6 +737,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(alpnVersions, copy.getAlpnVersions());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -759,6 +766,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getAlpnVersions(), json.getAlpnVersions());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -801,6 +809,7 @@ public class Http1xTest extends HttpTest {
     boolean useAlpn = TestUtils.randomBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
+    boolean openSslSessionCacheEnabled = TestUtils.randomBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -837,7 +846,8 @@ public class Http1xTest extends HttpTest {
           .put("maxFrameSize", initialSettings.getMaxFrameSize()))
       .put("useAlpn", useAlpn)
       .put("sslEngine", sslEngine.name())
-      .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()));
+      .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     HttpServerOptions options = new HttpServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -873,6 +883,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(initialSettings, options.getInitialSettings());
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
     assertEquals(alpnVersions, options.getAlpnVersions());
 
     // Test other keystore/truststore types

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -198,6 +198,10 @@ public class NetTest extends VertxTestBase {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     testComplete();
   }
 
@@ -301,6 +305,10 @@ public class NetTest extends VertxTestBase {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     testComplete();
   }
 
@@ -333,6 +341,8 @@ public class NetTest extends VertxTestBase {
     int reconnectAttempts = TestUtils.randomPositiveInt();
     long reconnectInterval = TestUtils.randomPositiveInt();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
+
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -356,6 +366,8 @@ public class NetTest extends VertxTestBase {
     options.setUseAlpn(useAlpn);
     options.setSslEngine(sslEngine);
     options.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
+
     NetClientOptions copy = new NetClientOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -384,6 +396,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(hostnameVerificationAlgorithm, copy.getHostnameVerificationAlgorithm());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -404,6 +417,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getHostnameVerificationAlgorithm(), json.getHostnameVerificationAlgorithm());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -438,6 +452,7 @@ public class NetTest extends VertxTestBase {
     boolean useAlpn = TestUtils.randomBoolean();
     String hostnameVerificationAlgorithm = TestUtils.randomAlphaString(10);
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -460,7 +475,8 @@ public class NetTest extends VertxTestBase {
         .put("reconnectInterval", reconnectInterval)
         .put("useAlpn", useAlpn)
         .put("sslEngine", sslEngine.name())
-        .put("hostnameVerificationAlgorithm", hostnameVerificationAlgorithm);
+        .put("hostnameVerificationAlgorithm", hostnameVerificationAlgorithm)
+        .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     NetClientOptions options = new NetClientOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -490,6 +506,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
     assertEquals(hostnameVerificationAlgorithm, options.getHostnameVerificationAlgorithm());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");
@@ -536,7 +553,9 @@ public class NetTest extends VertxTestBase {
     String host = TestUtils.randomAlphaString(100);
     int acceptBacklog = TestUtils.randomPortInt();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
+
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
     options.setReuseAddress(reuseAddress);
@@ -557,6 +576,8 @@ public class NetTest extends VertxTestBase {
     options.setAcceptBacklog(acceptBacklog);
     options.setUseAlpn(useAlpn);
     options.setSslEngine(sslEngine);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
+
     NetServerOptions copy = new NetServerOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -583,6 +604,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(acceptBacklog, copy.getAcceptBacklog());
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -608,6 +630,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(def.isSsl(), json.isSsl());
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -639,6 +662,7 @@ public class NetTest extends VertxTestBase {
     String host = TestUtils.randomAlphaString(100);
     int acceptBacklog = TestUtils.randomPortInt();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
 
     JsonObject json = new JsonObject();
@@ -660,7 +684,8 @@ public class NetTest extends VertxTestBase {
       .put("host", host)
       .put("acceptBacklog", acceptBacklog)
       .put("useAlpn", useAlpn)
-      .put("sslEngine", sslEngine.name());
+      .put("sslEngine", sslEngine.name())
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     NetServerOptions options = new NetServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -688,6 +713,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(acceptBacklog, options.getAcceptBacklog());
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");


### PR DESCRIPTION
Per @vietj request moved the open SSL cache mode setting up to TCPSSLOptions.

See the following thread in the groups: 
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/vertx/UUMJ4Y4uMcc

Previous PR:
https://github.com/eclipse/vert.x/pull/1448