### PR TITLE
catch NoClassDefFoundError and give a warning

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -417,7 +417,13 @@ public class ConnectionManager {
       if (options.getProxyOptions() == null) {
         channelProvider = ChannelProvider.INSTANCE;
       } else {
-        channelProvider = ProxyChannelProvider.INSTANCE;
+        try {
+          channelProvider = ProxyChannelProvider.INSTANCE;
+        } catch (NoClassDefFoundError ex) {
+          log.warn("Dependency io.netty:netty-handler-proxy missing - check your classpath");
+          queue.connectionFailed(context, null, waiter::handleFailure, ex);
+          return;
+        }
       }
 
       Handler<Channel> channelInitializer = ch -> {

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -164,7 +164,13 @@ public class NetClientImpl implements NetClient, MetricsProvider {
     if (options.getProxyOptions() == null) {
       channelProvider = ChannelProvider.INSTANCE;
     } else {
-      channelProvider = ProxyChannelProvider.INSTANCE;
+      try {
+        channelProvider = ProxyChannelProvider.INSTANCE;
+      } catch (NoClassDefFoundError ex) {
+        log.warn("Dependency io.netty:netty-handler-proxy missing - check your classpath");
+        failed(context, null, ex, connectHandler);
+        return;
+      }
     }
 
     Handler<Channel> channelInitializer = ch -> {


### PR DESCRIPTION
fix for vert-x3/issues#129

catch NoClassDefFoundError exception when getting the ProxyChannel instance, give a warning and pass the exception to the correct handler
