### PR TITLE
fixes vert-x3/issues#129

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
       <version>${netty.version}</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -2040,8 +2040,6 @@ _SOCKS4a_ or _SOCKS5_ proxy. The http proxy protocol uses HTTP/1.x but can conne
 The proxy can be configured in the `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html[HttpClientOptions]` by setting a
 `link:../../apidocs/io/vertx/core/net/ProxyOptions.html[ProxyOptions]` object containing proxy type, hostname, port and optionally username and password.
 
-For this feature, the jar `io.netty:netty-handler-proxy` has to be present on the classpath.
-
 Here's an example:
 
 [source,java]

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -2034,7 +2034,7 @@ used with binary frames that are no split over multiple frames.
 
 === Using a proxy for HTTPS connections
 
-The http client supports accessing https server via an HTTPS proxy (HTTP/1.x _CONNECT_ method), e.g. Squid or
+The http client supports accessing https servers via a HTTPS proxy (HTTP/1.x _CONNECT_ method, e.g. Squid) or
 _SOCKS4a_ or _SOCKS5_ proxy. The http proxy protocol uses HTTP/1.x but can connect to HTTP/1.x and HTTP/2 servers.
 
 The proxy can be configured in the `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html[HttpClientOptions]` by setting a
@@ -2050,7 +2050,7 @@ HttpClientOptions options = new HttpClientOptions()
         .setUsername("username").setPassword("secret"));
 HttpClient client = vertx.createHttpClient(options);
 ----
-or using a SOCKS5 proxy
+or using SOCKS5 proxy
 
 [source,java]
 ----

--- a/src/main/asciidoc/java/net.adoc
+++ b/src/main/asciidoc/java/net.adoc
@@ -923,7 +923,7 @@ ALPN version for the JVM running it:
 
 === Using a proxy for client connections
 
-The `link:../../apidocs/io/vertx/core/net/NetClient.html[NetClient]` supports configuring an HTTP/1.x _CONNECT_ proxy or _SOCKS4a_ or _SOCKS5_ proxy.
+The `link:../../apidocs/io/vertx/core/net/NetClient.html[NetClient]` supports either a HTTP/1.x _CONNECT_, _SOCKS4a_ or _SOCKS5_ proxy.
 
 The proxy can be configured in the `link:../../apidocs/io/vertx/core/net/NetClientOptions.html[NetClientOptions]` by setting a
 `link:../../apidocs/io/vertx/core/net/ProxyOptions.html[ProxyOptions]` object containing proxy type, hostname, port and optionally username and password.

--- a/src/main/asciidoc/java/net.adoc
+++ b/src/main/asciidoc/java/net.adoc
@@ -928,8 +928,6 @@ The `link:../../apidocs/io/vertx/core/net/NetClient.html[NetClient]` supports co
 The proxy can be configured in the `link:../../apidocs/io/vertx/core/net/NetClientOptions.html[NetClientOptions]` by setting a
 `link:../../apidocs/io/vertx/core/net/ProxyOptions.html[ProxyOptions]` object containing proxy type, hostname, port and optionally username and password.
 
-For this feature, the jar `io.netty:netty-handler-proxy` has to be present on the classpath.
-
 Here's an example:
 
 [source,java]

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -1591,7 +1591,7 @@
  *
  * === Using a proxy for HTTPS connections
  *
- * The http client supports accessing https server via an HTTPS proxy (HTTP/1.x _CONNECT_ method), e.g. Squid or
+ * The http client supports accessing https servers via a HTTPS proxy (HTTP/1.x _CONNECT_ method, e.g. Squid) or
  * _SOCKS4a_ or _SOCKS5_ proxy. The http proxy protocol uses HTTP/1.x but can connect to HTTP/1.x and HTTP/2 servers.
  *
  * The proxy can be configured in the {@link io.vertx.core.http.HttpClientOptions} by setting a
@@ -1603,7 +1603,7 @@
  * ----
  * {@link examples.HTTPExamples#example58}
  * ----
- * or using a SOCKS5 proxy
+ * or using SOCKS5 proxy
  *
  * [source,$lang]
  * ----

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -1597,8 +1597,6 @@
  * The proxy can be configured in the {@link io.vertx.core.http.HttpClientOptions} by setting a
  * {@link io.vertx.core.net.ProxyOptions} object containing proxy type, hostname, port and optionally username and password.
  *
- * For this feature, the jar `io.netty:netty-handler-proxy` has to be present on the classpath.
- *
  * Here's an example:
  *
  * [source,$lang]

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -25,7 +25,7 @@ public class ChannelProvider {
   protected ChannelProvider() {
   }
 
-  protected void connect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
+  public void connect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
       Handler<Channel> channelInitializer, Handler<AsyncResult<Channel>> channelHandler) {
     bootstrap.resolver(vertx.addressResolver().nettyAddressResolverGroup());
     bootstrap.handler(new ChannelInitializer<Channel>() {

--- a/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ChannelProvider.java
@@ -8,8 +8,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.ProxyOptions;
 
 /**
@@ -27,31 +25,8 @@ public class ChannelProvider {
   protected ChannelProvider() {
   }
 
-  static final Logger log = LoggerFactory.getLogger(NetClientImpl.class);
-
-  public void connect(VertxInternal vertx,
-                      Bootstrap bootstrap,
-                      ProxyOptions options,
-                      String host,
-                      int port,
-                      Handler<Channel> channelInitializer,
-                      Handler<AsyncResult<Channel>> channelHandler) {
-    try {
-      doConnect(vertx, bootstrap, options, host, port, channelInitializer, channelHandler);
-    } catch (NoClassDefFoundError e) {
-      if (e.getMessage().contains("io/netty/handler/proxy")) {
-        log.warn("Dependency io.netty:netty-handler-proxy missing - check your classpath");
-        channelHandler.handle(Future.failedFuture(e));
-      }
-    }
-  }
-
-  protected void doConnect(VertxInternal vertx,
-                           Bootstrap bootstrap,
-                           ProxyOptions options,
-                           String host,
-                           int port,
-                           Handler<Channel> channelInitializer, Handler<AsyncResult<Channel>> channelHandler) {
+  protected void connect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
+      Handler<Channel> channelInitializer, Handler<AsyncResult<Channel>> channelHandler) {
     bootstrap.resolver(vertx.addressResolver().nettyAddressResolverGroup());
     bootstrap.handler(new ChannelInitializer<Channel>() {
       @Override

--- a/src/main/java/io/vertx/core/net/impl/ProxyChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ProxyChannelProvider.java
@@ -24,7 +24,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 /**
- * A channel provider that connects via a Proxy : HTTP or Socks
+ * A channel provider that connects via a Proxy : HTTP or SOCKS
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -36,7 +36,7 @@ public class ProxyChannelProvider extends ChannelProvider {
   }
 
   @Override
-  protected void doConnect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
+  protected void connect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
                            Handler<Channel> channelInitializer, Handler<AsyncResult<Channel>> channelHandler) {
 
     final String proxyHost = options.getHost();
@@ -62,7 +62,7 @@ public class ProxyChannelProvider extends ChannelProvider {
                 ? new Socks5ProxyHandler(proxyAddr, proxyUsername, proxyPassword) : new Socks5ProxyHandler(proxyAddr);
             break;
           case SOCKS4:
-            // apparently SOCKS4 only supports a username?
+            // SOCKS4 only supports a username and could authenticate the user via Ident
             proxy = proxyUsername != null ? new Socks4ProxyHandler(proxyAddr, proxyUsername)
                 : new Socks4ProxyHandler(proxyAddr);
             break;

--- a/src/main/java/io/vertx/core/net/impl/ProxyChannelProvider.java
+++ b/src/main/java/io/vertx/core/net/impl/ProxyChannelProvider.java
@@ -36,7 +36,7 @@ public class ProxyChannelProvider extends ChannelProvider {
   }
 
   @Override
-  protected void connect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
+  public void connect(VertxInternal vertx, Bootstrap bootstrap, ProxyOptions options, String host, int port,
                            Handler<Channel> channelInitializer, Handler<AsyncResult<Channel>> channelHandler) {
 
     final String proxyHost = options.getHost();

--- a/src/main/java/io/vertx/core/net/package-info.java
+++ b/src/main/java/io/vertx/core/net/package-info.java
@@ -684,8 +684,6 @@
  * The proxy can be configured in the {@link io.vertx.core.net.NetClientOptions} by setting a
  * {@link io.vertx.core.net.ProxyOptions} object containing proxy type, hostname, port and optionally username and password.
  *
- * For this feature, the jar `io.netty:netty-handler-proxy` has to be present on the classpath.
- *
  * Here's an example:
  *
  * [source,$lang]

--- a/src/main/java/io/vertx/core/net/package-info.java
+++ b/src/main/java/io/vertx/core/net/package-info.java
@@ -679,7 +679,7 @@
  *
  * === Using a proxy for client connections
  *
- * The {@link io.vertx.core.net.NetClient} supports configuring an HTTP/1.x _CONNECT_ proxy or _SOCKS4a_ or _SOCKS5_ proxy.
+ * The {@link io.vertx.core.net.NetClient} supports either a HTTP/1.x _CONNECT_, _SOCKS4a_ or _SOCKS5_ proxy.
  *
  * The proxy can be configured in the {@link io.vertx.core.net.NetClientOptions} by setting a
  * {@link io.vertx.core.net.ProxyOptions} object containing proxy type, hostname, port and optionally username and password.


### PR DESCRIPTION
change netty-handler-proxy to a direct dependency, remove the documentation lines about it being optional

(this replaces PR#1454, which handled the error)

