### PR TITLE
Exposing session cache mode setting in HttpServerOptions for Open SSL…

### DIFF
--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -71,6 +71,11 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     */
   public static final SSLEngine DEFAULT_SSL_ENGINE = SSLEngine.JDK;
 
+  /**
+   * Default value of whether session cache is enabled in open SSL session server context
+   */
+  public static final boolean DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED = true;
+
 
   private boolean tcpNoDelay;
   private boolean tcpKeepAlive;
@@ -86,6 +91,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
   private boolean useAlpn;
   private SSLEngine sslEngine;
   private Set<String> enabledSecureTransportProtocols = new HashSet<>();
+  private boolean openSslSessionCacheEnabled;
 
   /**
    * Default constructor
@@ -116,6 +122,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     this.useAlpn = other.useAlpn;
     this.sslEngine = other.sslEngine;
     this.enabledSecureTransportProtocols = other.getEnabledSecureTransportProtocols() == null ? new HashSet<>() : new HashSet<>(other.getEnabledSecureTransportProtocols());
+    this.openSslSessionCacheEnabled = other.isOpenSslSessionCacheEnabled();
   }
 
   /**
@@ -140,6 +147,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     crlValues = new ArrayList<>();
     useAlpn = DEFAULT_USE_ALPN;
     sslEngine = DEFAULT_SSL_ENGINE;
+    openSslSessionCacheEnabled = DEFAULT_OPEN_SSL_SESSION_CACHE_ENABLED;
   }
 
   /**
@@ -477,6 +485,26 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     return (TCPSSLOptions) super.setLogActivity(logEnabled);
   }
 
+  /**
+   * Set whether session cache is enabled in open SSL session server context
+   *
+   * @param sessionCacheEnabled true if session cache is enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public TCPSSLOptions setOpenSslSessionCacheEnabled(boolean sessionCacheEnabled) {
+    this.openSslSessionCacheEnabled = sessionCacheEnabled;
+    return this;
+  }
+
+  /**
+   * Whether session cache is enabled in open SSL session server context
+   *
+   * @return true if session cache is enabled
+   */
+  public boolean isOpenSslSessionCacheEnabled() {
+    return openSslSessionCacheEnabled;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -499,6 +527,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     if (trustOptions != null ? !trustOptions.equals(that.trustOptions) : that.trustOptions != null) return false;
     if (useAlpn != that.useAlpn) return false;
     if (sslEngine != that.sslEngine) return false;
+    if (openSslSessionCacheEnabled != that.openSslSessionCacheEnabled) return false;
     if (!enabledSecureTransportProtocols.equals(that.enabledSecureTransportProtocols)) return false;
 
     return true;
@@ -522,6 +551,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     result = 31 * result + (sslEngine != null ? sslEngine.hashCode() : 0);
     result = 31 * result + (enabledSecureTransportProtocols != null ? enabledSecureTransportProtocols
         .hashCode() : 0);
+    result = 31 * result + (openSslSessionCacheEnabled ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -17,12 +17,7 @@
 package io.vertx.core.net.impl;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.OpenSsl;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
@@ -39,13 +34,7 @@ import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import io.vertx.core.net.TrustOptions;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.ManagerFactoryParameters;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.*;
 import java.io.ByteArrayInputStream;
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -56,8 +45,6 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.net.ssl.SSLContext;
 
 /**
  *
@@ -111,6 +98,7 @@ public class SSLHelper {
   private String endpointIdentificationAlgorithm = "";
 
   private SslContext sslContext;
+  private boolean openSslSessionCacheEnabled = true;
 
   public SSLHelper(HttpClientOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
     this.ssl = options.isSsl();
@@ -127,6 +115,7 @@ public class SSLHelper {
     if (options.isVerifyHost()) {
       this.endpointIdentificationAlgorithm = "HTTPS";
     }
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public SSLHelper(HttpServerOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
@@ -141,6 +130,7 @@ public class SSLHelper {
     this.client = false;
     this.useAlpn = options.isUseAlpn();
     this.enabledProtocols = options.getEnabledSecureTransportProtocols();
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public SSLHelper(NetClientOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
@@ -156,6 +146,7 @@ public class SSLHelper {
     this.useAlpn = false;
     this.enabledProtocols = options.getEnabledSecureTransportProtocols();
     this.endpointIdentificationAlgorithm = options.getHostnameVerificationAlgorithm();
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public SSLHelper(NetServerOptions options, KeyCertOptions keyCertOptions, TrustOptions trustOptions) {
@@ -170,6 +161,7 @@ public class SSLHelper {
     this.client = false;
     this.useAlpn = false;
     this.enabledProtocols = options.getEnabledSecureTransportProtocols();
+    this.openSslSessionCacheEnabled = options.isOpenSslSessionCacheEnabled();
   }
 
   public boolean isSSL() {
@@ -420,6 +412,12 @@ public class SSLHelper {
   public SslContext getContext(VertxInternal vertx) {
     if (sslContext == null) {
       sslContext = createContext(vertx);
+      if (sslContext instanceof OpenSslServerContext){
+        SSLSessionContext sslSessionContext = sslContext.sessionContext();
+        if (sslSessionContext instanceof OpenSslServerSessionContext){
+          ((OpenSslServerSessionContext)sslSessionContext).setSessionCacheEnabled(openSslSessionCacheEnabled);
+        }
+      }
     }
     return sslContext;
   }

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static io.vertx.test.core.TestUtils.*;
@@ -146,6 +147,27 @@ public class Http1xTest extends HttpTest {
     assertFalse(options.isPipelining());
     assertEquals(options, options.setPipelining(true));
     assertTrue(options.isPipelining());
+
+    assertEquals(HttpClientOptions.DEFAULT_PIPELINING_LIMIT, options.getPipeliningLimit());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setPipeliningLimit(rand));
+    assertEquals(rand, options.getPipeliningLimit());
+    assertIllegalArgumentException(() -> options.setPipeliningLimit(0));
+    assertIllegalArgumentException(() -> options.setPipeliningLimit(-1));
+
+    assertEquals(HttpClientOptions.DEFAULT_HTTP2_MAX_POOL_SIZE, options.getHttp2MaxPoolSize());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setHttp2MaxPoolSize(rand));
+    assertEquals(rand, options.getHttp2MaxPoolSize());
+    assertIllegalArgumentException(() -> options.setHttp2MaxPoolSize(0));
+    assertIllegalArgumentException(() -> options.setHttp2MaxPoolSize(-1));
+
+    assertEquals(HttpClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT, options.getHttp2MultiplexingLimit());
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setHttp2MultiplexingLimit(rand));
+    assertEquals(rand, options.getHttp2MultiplexingLimit());
+    assertIllegalArgumentException(() -> options.setHttp2MultiplexingLimit(0));
+    assertIllegalArgumentException(() -> options.setHttp2MultiplexingLimit(-1));
 
     assertEquals(60000, options.getConnectTimeout());
     rand = TestUtils.randomPositiveInt();
@@ -316,6 +338,10 @@ public class Http1xTest extends HttpTest {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     Http2Settings initialSettings = randomHttp2Settings();
     assertEquals(new Http2Settings().setMaxConcurrentStreams(HttpServerOptions.DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS), options.getInitialSettings());
     assertEquals(options, options.setInitialSettings(initialSettings));
@@ -357,6 +383,9 @@ public class Http1xTest extends HttpTest {
     int maxPoolSize = TestUtils.randomPositiveInt();
     boolean keepAlive = rand.nextBoolean();
     boolean pipelining = rand.nextBoolean();
+    int pipeliningLimit = TestUtils.randomPositiveInt();
+    int http2MaxPoolSize = TestUtils.randomPositiveInt();
+    int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     boolean tryUseCompression = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_0;
     int maxWaitQueueSize = TestUtils.randomPositiveInt();
@@ -365,6 +394,7 @@ public class Http1xTest extends HttpTest {
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     boolean h2cUpgrade = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
 
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -387,6 +417,9 @@ public class Http1xTest extends HttpTest {
     options.setMaxPoolSize(maxPoolSize);
     options.setKeepAlive(keepAlive);
     options.setPipelining(pipelining);
+    options.setPipeliningLimit(pipeliningLimit);
+    options.setHttp2MaxPoolSize(http2MaxPoolSize);
+    options.setHttp2MultiplexingLimit(http2MultiplexingLimit);
     options.setTryUseCompression(tryUseCompression);
     options.setProtocolVersion(protocolVersion);
     options.setMaxWaitQueueSize(maxWaitQueueSize);
@@ -395,6 +428,8 @@ public class Http1xTest extends HttpTest {
     options.setSslEngine(sslEngine);
     options.setAlpnVersions(alpnVersions);
     options.setH2cUpgrade(h2cUpgrade);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
+
     HttpClientOptions copy = new HttpClientOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -422,6 +457,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(maxPoolSize, copy.getMaxPoolSize());
     assertEquals(keepAlive, copy.isKeepAlive());
     assertEquals(pipelining, copy.isPipelining());
+    assertEquals(pipeliningLimit, copy.getPipeliningLimit());
+    assertEquals(http2MaxPoolSize, copy.getHttp2MaxPoolSize());
+    assertEquals(http2MultiplexingLimit, copy.getHttp2MultiplexingLimit());
     assertEquals(tryUseCompression, copy.isTryUseCompression());
     assertEquals(protocolVersion, copy.getProtocolVersion());
     assertEquals(maxWaitQueueSize, copy.getMaxWaitQueueSize());
@@ -430,6 +468,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(alpnVersions, copy.getAlpnVersions());
     assertEquals(h2cUpgrade, copy.isH2cUpgrade());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -439,6 +478,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getMaxPoolSize(), json.getMaxPoolSize());
     assertEquals(def.isKeepAlive(), json.isKeepAlive());
     assertEquals(def.isPipelining(), json.isPipelining());
+    assertEquals(def.getPipeliningLimit(), json.getPipeliningLimit());
+    assertEquals(def.getHttp2MaxPoolSize(), json.getHttp2MaxPoolSize());
+    assertEquals(def.getHttp2MultiplexingLimit(), json.getHttp2MultiplexingLimit());
     assertEquals(def.isVerifyHost(), json.isVerifyHost());
     assertEquals(def.isTryUseCompression(), json.isTryUseCompression());
     assertEquals(def.isTrustAll(), json.isTrustAll());
@@ -457,6 +499,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getAlpnVersions(), json.getAlpnVersions());
     assertEquals(def.isH2cUpgrade(), json.isH2cUpgrade());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -490,6 +533,9 @@ public class Http1xTest extends HttpTest {
     int maxPoolSize = TestUtils.randomPositiveInt();
     boolean keepAlive = rand.nextBoolean();
     boolean pipelining = rand.nextBoolean();
+    int pipeliningLimit = TestUtils.randomPositiveInt();
+    int http2MaxPoolSize = TestUtils.randomPositiveInt();
+    int http2MultiplexingLimit = TestUtils.randomPositiveInt();
     boolean tryUseCompression = rand.nextBoolean();
     HttpVersion protocolVersion = HttpVersion.HTTP_1_1;
     int maxWaitQueueSize = TestUtils.randomPositiveInt();
@@ -498,6 +544,7 @@ public class Http1xTest extends HttpTest {
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     boolean h2cUpgrade = rand.nextBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -520,6 +567,9 @@ public class Http1xTest extends HttpTest {
       .put("maxPoolSize", maxPoolSize)
       .put("keepAlive", keepAlive)
       .put("pipelining", pipelining)
+      .put("pipeliningLimit", pipeliningLimit)
+      .put("http2MaxPoolSize", http2MaxPoolSize)
+      .put("http2MultiplexingLimit", http2MultiplexingLimit)
       .put("tryUseCompression", tryUseCompression)
       .put("protocolVersion", protocolVersion.name())
       .put("maxWaitQueueSize", maxWaitQueueSize)
@@ -533,7 +583,8 @@ public class Http1xTest extends HttpTest {
       .put("useAlpn", useAlpn)
       .put("sslEngine", sslEngine.name())
       .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
-      .put("h2cUpgrade", h2cUpgrade);
+      .put("h2cUpgrade", h2cUpgrade)
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     HttpClientOptions options = new HttpClientOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -562,6 +613,9 @@ public class Http1xTest extends HttpTest {
     assertEquals(maxPoolSize, options.getMaxPoolSize());
     assertEquals(keepAlive, options.isKeepAlive());
     assertEquals(pipelining, options.isPipelining());
+    assertEquals(pipeliningLimit, options.getPipeliningLimit());
+    assertEquals(http2MaxPoolSize, options.getHttp2MaxPoolSize());
+    assertEquals(http2MultiplexingLimit, options.getHttp2MultiplexingLimit());
     assertEquals(tryUseCompression, options.isTryUseCompression());
     assertEquals(protocolVersion, options.getProtocolVersion());
     assertEquals(maxWaitQueueSize, options.getMaxWaitQueueSize());
@@ -570,6 +624,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(sslEngine, options.getSslEngine());
     assertEquals(alpnVersions, options.getAlpnVersions());
     assertEquals(h2cUpgrade, options.isH2cUpgrade());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");
@@ -626,6 +681,7 @@ public class Http1xTest extends HttpTest {
     int maxChunkSize = rand.nextInt(10000);
     Http2Settings initialSettings = randomHttp2Settings();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     options.setSendBufferSize(sendBufferSize);
@@ -655,6 +711,7 @@ public class Http1xTest extends HttpTest {
     options.setSslEngine(sslEngine);
     options.setInitialSettings(initialSettings);
     options.setAlpnVersions(alpnVersions);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
     HttpServerOptions copy = new HttpServerOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -688,6 +745,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(alpnVersions, copy.getAlpnVersions());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -716,6 +774,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getAlpnVersions(), json.getAlpnVersions());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -758,6 +817,7 @@ public class Http1xTest extends HttpTest {
     boolean useAlpn = TestUtils.randomBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
+    boolean openSslSessionCacheEnabled = TestUtils.randomBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -794,7 +854,8 @@ public class Http1xTest extends HttpTest {
           .put("maxFrameSize", initialSettings.getMaxFrameSize()))
       .put("useAlpn", useAlpn)
       .put("sslEngine", sslEngine.name())
-      .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()));
+      .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     HttpServerOptions options = new HttpServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -830,6 +891,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(initialSettings, options.getInitialSettings());
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
     assertEquals(alpnVersions, options.getAlpnVersions());
 
     // Test other keystore/truststore types
@@ -885,7 +947,9 @@ public class Http1xTest extends HttpTest {
         // (requests + 1 / 2) connect attempts
         if (count % 2 == 1) {
           req.setTimeout(responseDelay / 2);
-          req.exceptionHandler(ex -> latch.countDown());
+          req.exceptionHandler(ex -> {
+            latch.countDown();
+          });
         }
         req.end();
       }
@@ -946,6 +1010,57 @@ public class Http1xTest extends HttpTest {
 
     awaitLatch(latch);
 
+  }
+
+  @Test
+  public void testPipeliningLimit() throws Exception {
+    int limit = 25;
+    int requests = limit * 4;
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().
+        setKeepAlive(true).
+        setPipelining(true).
+        setPipeliningLimit(limit).
+        setMaxPoolSize(1));
+    AtomicInteger count = new AtomicInteger();
+    String data = "GET /somepath HTTP/1.1\r\n" +
+        "Host: localhost:8080\r\n" +
+        "\r\n";
+    NetServer server = vertx.createNetServer(new NetServerOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTPS_HOST));
+    server.connectHandler(so -> {
+      StringBuilder total = new StringBuilder();
+      so.handler(buff -> {
+        total.append(buff);
+        while (total.indexOf(data) == 0) {
+          total.delete(0, data.length());
+          if (count.incrementAndGet() == limit) {
+            vertx.setTimer(100, timerID -> {
+              assertEquals(limit, count.get());
+              count.set(0);
+              for (int i = 0;i < limit;i++) {
+                so.write("HTTP/1.1 200 OK\r\nContent-Length : 0\r\n\r\n");
+              }
+            });
+          }
+        }
+      });
+    });
+    CountDownLatch listenLatch = new CountDownLatch(1);
+    server.listen(onSuccess(v -> {
+      listenLatch.countDown();
+    }));
+    awaitLatch(listenLatch);
+
+    AtomicInteger responses = new AtomicInteger();
+    for (int i = 0;i < requests;i++) {
+      client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
+        assertEquals(200, resp.statusCode());
+        if (responses.incrementAndGet() == requests) {
+          testComplete();
+        }
+      });
+    }
+    await();
   }
 
   @Test
@@ -1579,30 +1694,47 @@ public class Http1xTest extends HttpTest {
     awaitLatch(serverLatch);
     CountDownLatch req1Latch = new CountDownLatch(1);
     AtomicReference<Context> c = new AtomicReference<>();
-    client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/1", res -> {
+    HttpClientRequest req1 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/1");
+    req1.handler(res -> {
       c.set(Vertx.currentContext());
       res.endHandler(v -> req1Latch.countDown());
     });
+    req1.end();
+    Consumer<HttpClientRequest> checker = req -> {
+      assertSame(Vertx.currentContext(), c.get());
+      assertSame(req1.connection(), req.connection());
+    };
     awaitLatch(req1Latch);
     CountDownLatch req2Latch = new CountDownLatch(2);
-    HttpClientRequest req2 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/2", res -> {
-      assertSame(Vertx.currentContext(), c.get());
+    HttpClientRequest req2 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/2");
+    req2.handler(res -> {
+      checker.accept(req2);
       req2Latch.countDown();
-    }).exceptionHandler(this::fail).sendHead();
-    HttpClientRequest req3 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/3", res -> {
-      assertSame(Vertx.currentContext(), c.get());
+    }).exceptionHandler(err -> {
+      fail(err);
+    }).sendHead();
+    HttpClientRequest req3 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/3");
+    req3.handler(res -> {
+      checker.accept(req3);
       req2Latch.countDown();
-    }).exceptionHandler(this::fail);
+    }).exceptionHandler(err -> {
+      fail(err);
+    });
     req3.end();
     req2.end();
     awaitLatch(req2Latch);
     vertx.getOrCreateContext().runOnContext(v -> {
-      client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/4", res -> {
+      HttpClientRequest req4 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/4");
+      req4.handler(res -> {
         // This should warn in the log (console) as we are called back on the connection context
         // and not on the context doing the request
-        assertSame(Vertx.currentContext(), c.get());
+        checker.accept(req4);
         testComplete();
       });
+      req4.exceptionHandler(err -> {
+        fail(err);
+      });
+      req4.end();
     });
     await();
   }
@@ -1977,16 +2109,16 @@ public class Http1xTest extends HttpTest {
           content.delete(0, match.length());
           switch (count.getAndIncrement()) {
             case 0:
-              // Send an invalid response
               sendResp.thenAccept(v -> {
-                so.write(Buffer.buffer(TestUtils.randomAlphaString(40) + "\r\n"));
               });
               break;
             case 1:
+              // Send an invalid response
+              Buffer resp1 = Buffer.buffer(TestUtils.randomAlphaString(40) + "\r\n");
               // Send a valid response even though it will be ignored by Netty decoder
-              sendResp.thenAccept(v -> {
-                so.write(Buffer.buffer("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
-              });
+              Buffer resp2 = Buffer.buffer("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+              // Send at once
+              so.write(Buffer.buffer().appendBuffer(resp1).appendBuffer(resp2));
               break;
             default:
               fail();
@@ -2001,13 +2133,12 @@ public class Http1xTest extends HttpTest {
 
       AtomicBoolean fail1 = new AtomicBoolean();
       HttpClientRequest req1 = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
-        assertEquals(999, resp.statusCode()); // Netty specific for invalid responses
-        resp.exceptionHandler(err -> {
-          if (fail1.compareAndSet(false, true)) {
-            assertEquals(IllegalArgumentException.class, err.getClass()); // invalid version format
-            complete();
-          }
-        });
+        fail();
+      }).exceptionHandler(err -> {
+        if (fail1.compareAndSet(false, true)) {
+          assertEquals(IllegalArgumentException.class, err.getClass()); // invalid version format
+          complete();
+        }
       });
 
       AtomicBoolean fail2 = new AtomicBoolean();
@@ -2025,12 +2156,35 @@ public class Http1xTest extends HttpTest {
 
       req1.end();
       req2.end();
-      sendResp.complete(null);
     }));
 
     await();
   }
 
+  @Test
+  public void testHandleInvalid204Response() throws Exception {
+    int numReq = 3;
+    waitFor(3);
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setPipelining(true).setKeepAlive(true).setMaxPoolSize(1));
+    List<HttpServerRequest> received = new ArrayList<>();
+    vertx.createHttpServer().requestHandler(r -> {
+      // Generate an invalid response for the pipe-lined
+      r.response().setChunked(true).setStatusCode(204).end();
+    }).listen(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, onSuccess(v1 -> {
+      for (int i = 0;i < numReq;i++) {
+        HttpClientRequest post = client.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath");
+        post.handler(r -> {
+          r.endHandler(v2 -> {
+            complete();
+          });
+        }).exceptionHandler(err -> {
+          complete();
+        }).end();
+      }
+    }));
+    await();
+  }
 
   @Test
   public void testConnectionCloseHttp_1_0_NoClose() throws Exception {

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -198,6 +198,10 @@ public class NetTest extends VertxTestBase {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     testComplete();
   }
 
@@ -301,6 +305,10 @@ public class NetTest extends VertxTestBase {
     assertEquals(options, options.setSslEngine(SSLEngine.OPENSSL));
     assertEquals(SSLEngine.OPENSSL, options.getSslEngine());
 
+    assertEquals(true, options.isOpenSslSessionCacheEnabled());
+    assertEquals(options, options.setOpenSslSessionCacheEnabled(false));
+    assertEquals(false, options.isOpenSslSessionCacheEnabled());
+
     testComplete();
   }
 
@@ -333,6 +341,8 @@ public class NetTest extends VertxTestBase {
     int reconnectAttempts = TestUtils.randomPositiveInt();
     long reconnectInterval = TestUtils.randomPositiveInt();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
+
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -356,6 +366,8 @@ public class NetTest extends VertxTestBase {
     options.setUseAlpn(useAlpn);
     options.setSslEngine(sslEngine);
     options.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
+
     NetClientOptions copy = new NetClientOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -384,6 +396,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
     assertEquals(hostnameVerificationAlgorithm, copy.getHostnameVerificationAlgorithm());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -404,6 +417,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
     assertEquals(def.getHostnameVerificationAlgorithm(), json.getHostnameVerificationAlgorithm());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -438,6 +452,7 @@ public class NetTest extends VertxTestBase {
     boolean useAlpn = TestUtils.randomBoolean();
     String hostnameVerificationAlgorithm = TestUtils.randomAlphaString(10);
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -460,7 +475,8 @@ public class NetTest extends VertxTestBase {
         .put("reconnectInterval", reconnectInterval)
         .put("useAlpn", useAlpn)
         .put("sslEngine", sslEngine.name())
-        .put("hostnameVerificationAlgorithm", hostnameVerificationAlgorithm);
+        .put("hostnameVerificationAlgorithm", hostnameVerificationAlgorithm)
+        .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     NetClientOptions options = new NetClientOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -490,6 +506,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
     assertEquals(hostnameVerificationAlgorithm, options.getHostnameVerificationAlgorithm());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");
@@ -536,7 +553,9 @@ public class NetTest extends VertxTestBase {
     String host = TestUtils.randomAlphaString(100);
     int acceptBacklog = TestUtils.randomPortInt();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
+
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
     options.setReuseAddress(reuseAddress);
@@ -557,6 +576,8 @@ public class NetTest extends VertxTestBase {
     options.setAcceptBacklog(acceptBacklog);
     options.setUseAlpn(useAlpn);
     options.setSslEngine(sslEngine);
+    options.setOpenSslSessionCacheEnabled(openSslSessionCacheEnabled);
+
     NetServerOptions copy = new NetServerOptions(options);
     assertEquals(sendBufferSize, copy.getSendBufferSize());
     assertEquals(receiverBufferSize, copy.getReceiveBufferSize());
@@ -583,6 +604,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(acceptBacklog, copy.getAcceptBacklog());
     assertEquals(useAlpn, copy.isUseAlpn());
     assertEquals(sslEngine, copy.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, copy.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -608,6 +630,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(def.isSsl(), json.isSsl());
     assertEquals(def.isUseAlpn(), json.isUseAlpn());
     assertEquals(def.getSslEngine(), json.getSslEngine());
+    assertEquals(def.isOpenSslSessionCacheEnabled(), json.isOpenSslSessionCacheEnabled());
   }
 
   @Test
@@ -639,6 +662,7 @@ public class NetTest extends VertxTestBase {
     String host = TestUtils.randomAlphaString(100);
     int acceptBacklog = TestUtils.randomPortInt();
     boolean useAlpn = TestUtils.randomBoolean();
+    boolean openSslSessionCacheEnabled = rand.nextBoolean();
     SSLEngine sslEngine = TestUtils.randomBoolean() ? SSLEngine.JDK : SSLEngine.OPENSSL;
 
     JsonObject json = new JsonObject();
@@ -660,7 +684,8 @@ public class NetTest extends VertxTestBase {
       .put("host", host)
       .put("acceptBacklog", acceptBacklog)
       .put("useAlpn", useAlpn)
-      .put("sslEngine", sslEngine.name());
+      .put("sslEngine", sslEngine.name())
+      .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled);
 
     NetServerOptions options = new NetServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -688,6 +713,7 @@ public class NetTest extends VertxTestBase {
     assertEquals(acceptBacklog, options.getAcceptBacklog());
     assertEquals(useAlpn, options.isUseAlpn());
     assertEquals(sslEngine, options.getSslEngine());
+    assertEquals(openSslSessionCacheEnabled, options.isOpenSslSessionCacheEnabled());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");


### PR DESCRIPTION
… based HTTP servers (see org.apache.tomcat.jni.SSLContext.setSessionCacheMode)

Signed-off-by: ustinovvladi <ustinovvladi@gmail.com>

Trying once again to commit the changes from a clean branch in order to achieve CLA verification