### PR TITLE
Fix how is passed inlined configuration in redeploy mode.

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -118,7 +118,14 @@ public class RunCommand extends BareCommand {
   @Description("Specifies configuration that should be provided to the verticle. <config> should reference either a " +
       "text file containing a valid JSON object which represents the configuration OR be a JSON string.")
   public void setConfig(String configuration) {
-    this.config = configuration;
+    if (configuration != null) {
+      // For inlined configuration remove first and end single and double quotes if any
+      this.config = configuration.trim()
+          .replaceAll("^\"|\"$", "")
+          .replaceAll("^'|'$", "");
+    } else {
+      this.config = null;
+    }
   }
 
   /**
@@ -142,6 +149,7 @@ public class RunCommand extends BareCommand {
 
   /**
    * Sets the user command executed during redeployment.
+   *
    * @param command the on redeploy command
    * @deprecated Use 'on-redeploy' instead. It will be removed in vert.x 3.3
    */
@@ -350,7 +358,9 @@ public class RunCommand extends BareCommand {
       args.add("--classpath=" + classpath.stream().collect(Collectors.joining(File.pathSeparator)));
     }
     if (config != null) {
-      args.add("--conf=" + config);
+      // Pass the configuration in 2 steps to quote correctly the configuration if it's an inlined json string
+      args.add("--conf");
+      args.add(config);
     }
     if (instances != 1) {
       args.add("--instances=" + instances);
@@ -405,6 +415,7 @@ public class RunCommand extends BareCommand {
         } catch (DecodeException e2) {
           // The configuration is not printed for security purpose, it can contain sensitive data.
           log.error("The -conf option does not point to an existing file or is not a valid JSON object");
+          e2.printStackTrace();
           return null;
         }
       }

--- a/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/RedeployTest.java
@@ -17,9 +17,9 @@ package io.vertx.core.impl.launcher.commands;
 
 import io.vertx.core.Launcher;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.test.fakecluster.FakeClusterManager;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -74,6 +74,88 @@ public class RedeployTest extends CommandTestBase {
         return false;
       }
     });
+  }
+
+  @Test
+  public void testStartingApplicationInRedeployModeWithInlineConf() throws IOException {
+    int random = (int) (Math.random() * 100);
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
+        "--launcher-class=" + Launcher.class.getName(),
+        "--conf", "{\"random\":" + random + "}"
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+
+    JsonObject conf = RunCommandTest.getContent().getJsonObject("conf");
+    assertThat(conf).isNotNull().isNotEmpty();
+    assertThat(conf.getInteger("random")).isEqualTo(random);
+  }
+
+  @Test
+  public void testStartingApplicationInRedeployModeWithInlineConf2() throws IOException {
+    int random = (int) (Math.random() * 100);
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
+        "--launcher-class=" + Launcher.class.getName(),
+        "--conf={\"random\":" + random + "}"
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+
+    JsonObject conf = RunCommandTest.getContent().getJsonObject("conf");
+    assertThat(conf).isNotNull().isNotEmpty();
+    assertThat(conf.getInteger("random")).isEqualTo(random);
+  }
+
+  @Test
+  public void testStartingApplicationInRedeployModeWithFileConf() throws IOException {
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
+        "--launcher-class=" + Launcher.class.getName(),
+        "--conf", new File("src/test/resources/conf.json").getAbsolutePath()
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+
+    JsonObject conf = RunCommandTest.getContent().getJsonObject("conf");
+    assertThat(conf).isNotNull().isNotEmpty();
+    assertThat(conf.getString("name")).isEqualTo("vertx");
+  }
+
+  @Test
+  public void testStartingApplicationInRedeployModeWithFileConf2() throws IOException {
+    cli.dispatch(new Launcher(), new String[]{"run",
+        HttpTestVerticle.class.getName(), "--redeploy=**" + File.separator + "*.txt",
+        "--launcher-class=" + Launcher.class.getName(),
+        "--conf=" + new File("src/test/resources/conf.json").getAbsolutePath()
+    });
+    waitUntil(() -> {
+      try {
+        return RunCommandTest.getHttpCode() == 200;
+      } catch (IOException e) {
+        return false;
+      }
+    });
+
+    JsonObject conf = RunCommandTest.getContent().getJsonObject("conf");
+    assertThat(conf).isNotNull().isNotEmpty();
+    assertThat(conf.getString("name")).isEqualTo("vertx");
   }
 
   @Test


### PR DESCRIPTION
The inlined configuration was not quoted correctly when passed to the spawn process, and so could not be interpreted as valid json.

Initial discussion here: https://groups.google.com/d/msgid/vertx/a28558c2-345c-4427-9aab-21853ba0ff43%40googlegroups.com?utm_medium=email&utm_source=footer