### PR TITLE
Fixes #1469 HttpClientMetrics#createEndpoint may be called multiple times for the same endpoint

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -8,7 +8,7 @@ project descriptor to access the Vert.x Core API:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-core</artifactId>
-  <version>3.3.0.CR2</version>
+  <version>3.3.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -16,5 +16,5 @@ project descriptor to access the Vert.x Core API:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-core:3.3.0.CR2
+compile io.vertx:vertx-core:3.3.0-SNAPSHOT
 ----

--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -45,10 +45,10 @@ import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.impl.ChannelProvider;
 import io.vertx.core.net.impl.PartialPooledByteBufAllocator;
 import io.vertx.core.net.impl.ProxyChannelProvider;
 import io.vertx.core.net.impl.SSLHelper;
-import io.vertx.core.net.impl.ChannelProvider;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -109,15 +109,7 @@ public class ConnectionManager {
     private final Map<TargetAddress, ConnQueue> queueMap = new ConcurrentHashMap<>();
 
     ConnQueue getConnQueue(TargetAddress address, HttpVersion version) {
-      ConnQueue connQueue = queueMap.get(address);
-      if (connQueue == null) {
-        connQueue = new ConnQueue(version, this, address);
-        ConnQueue prev = queueMap.putIfAbsent(address, connQueue);
-        if (prev != null) {
-          connQueue = prev;
-        }
-      }
-      return connQueue;
+      return queueMap.computeIfAbsent(address, targetAddress -> new ConnQueue(version, this, targetAddress));
     }
 
     public void close() {


### PR DESCRIPTION
Make sure we build it once - since #createEndpoint is called in the constructor of the queue