### PR TITLE
Fix message producer

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -61,6 +61,9 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public synchronized MessageProducer<T> deliveryOptions(DeliveryOptions options) {
+    if (creditConsumer != null) {
+      options.addHeader(CREDIT_ADDRESS_HEADER_NAME, this.options.getHeaders().get(CREDIT_ADDRESS_HEADER_NAME));
+    }
     this.options = options;
     return this;
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -62,6 +62,7 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
   @Override
   public synchronized MessageProducer<T> deliveryOptions(DeliveryOptions options) {
     if (creditConsumer != null) {
+      options = new DeliveryOptions(options);
       options.addHeader(CREDIT_ADDRESS_HEADER_NAME, this.options.getHeaders().get(CREDIT_ADDRESS_HEADER_NAME));
     }
     this.options = options;

--- a/src/test/java/io/vertx/test/core/EventBusFlowControlTest.java
+++ b/src/test/java/io/vertx/test/core/EventBusFlowControlTest.java
@@ -19,7 +19,6 @@ public class EventBusFlowControlTest extends VertxTestBase {
 
   @Test
   public void testFlowControl() {
-
     MessageProducer<String> prod = eb.sender("some-address");
     int numBatches = 1000;
     int wqms = 2000;


### PR DESCRIPTION
Motivation:
We forget to add credit header in MessageProducer when we set it with deliveryOptions.
As a result the drain handler will never be call.

Modification:
Add credit header when we set delivery options.

Result:
The drain handler will be call in every situation.

Signed-off-by: amannocci adrien.mannocci@gmail.com