### PR TITLE
Fix message producer

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageProducerImpl.java
@@ -62,6 +62,10 @@ public class MessageProducerImpl<T> implements MessageProducer<T> {
 
   @Override
   public synchronized MessageProducer<T> deliveryOptions(DeliveryOptions options) {
+    if (creditConsumer != null) {
+      options = new DeliveryOptions(options);
+      options.addHeader(CREDIT_ADDRESS_HEADER_NAME, this.options.getHeaders().get(CREDIT_ADDRESS_HEADER_NAME));
+    }
     this.options = options;
     return this;
   }


### PR DESCRIPTION
Motivation:
We forget to add credit header in MessageProducer when we set it with deliveryOptions.
As a result the drain handler will never be call.

Modification:
Add credit header when we set delivery options.

Result:
The drain handler will be call in every situation.

Signed-off-by: amannocci <adrien.mannocci@gmail.com>