### PR TITLE
custom launcher - set clustered and avoid NPE on afterConfigParsed

### DIFF
--- a/src/main/java/io/vertx/core/Launcher.java
+++ b/src/main/java/io/vertx/core/Launcher.java
@@ -60,14 +60,17 @@ public class Launcher extends VertxCommandLauncher implements VertxLifecycleHook
   }
 
   /**
-   *
    * Hook for sub-classes of {@link Launcher} after the config has been parsed.
+   *
+   * @param config the read config, empty if none are provided.
    */
   public void afterConfigParsed(JsonObject config) {
   }
 
   /**
    * Hook for sub-classes of {@link Launcher} before the vertx instance is started.
+   *
+   * @param options the configured Vert.x options. Modify them to customize the Vert.x instance.
    */
   public void beforeStartingVertx(VertxOptions options) {
 
@@ -75,6 +78,8 @@ public class Launcher extends VertxCommandLauncher implements VertxLifecycleHook
 
   /**
    * Hook for sub-classes of {@link Launcher} after the vertx instance is started.
+   *
+   * @param vertx the created Vert.x instance
    */
   public void afterStartingVertx(Vertx vertx) {
 
@@ -82,6 +87,8 @@ public class Launcher extends VertxCommandLauncher implements VertxLifecycleHook
 
   /**
    * Hook for sub-classes of {@link Launcher} before the verticle is deployed.
+   *
+   * @param deploymentOptions the current deployment options. Modify them to customize the deployment.
    */
   public void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {
 
@@ -90,6 +97,11 @@ public class Launcher extends VertxCommandLauncher implements VertxLifecycleHook
   /**
    * A deployment failure has been encountered. You can override this method to customize the behavior.
    * By default it closes the `vertx` instance.
+   *
+   * @param vertx             the vert.x instance
+   * @param mainVerticle      the verticle
+   * @param deploymentOptions the verticle deployment options
+   * @param cause             the cause of the failure
    */
   public void handleDeployFailed(Vertx vertx, String mainVerticle, DeploymentOptions deploymentOptions, Throwable cause) {
     // Default behaviour is to close Vert.x if the deploy failed

--- a/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
+++ b/src/main/java/io/vertx/core/impl/launcher/VertxLifecycleHooks.java
@@ -30,7 +30,7 @@ public interface VertxLifecycleHooks {
   /**
    * Hook for sub-classes of the starter class before the vertx instance is started. Options can still be updated.
    *
-   * @param config the json config file passed via -conf on the command line
+   * @param config the json config file passed via -conf on the command line, an empty json object is not set.
    */
   void afterConfigParsed(JsonObject config);
 

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -142,6 +142,7 @@ public class BareCommand extends ClasspathHandler {
     MetricsOptions metricsOptions = getMetricsOptions();
     options = new VertxOptions().setMetricsOptions(metricsOptions);
     configureFromSystemProperties(options, VERTX_OPTIONS_PROP_PREFIX);
+    beforeStartingVertx(options);
     Vertx instance;
     if (isClustered()) {
       log.info("Starting clustering...");
@@ -168,7 +169,6 @@ public class BareCommand extends ClasspathHandler {
         }
       }
 
-      beforeStartingVertx(options);
       create(options, ar -> {
         result.set(ar);
         latch.countDown();
@@ -190,7 +190,6 @@ public class BareCommand extends ClasspathHandler {
       }
       instance = result.get().result();
     } else {
-      beforeStartingVertx(options);
       instance = create(options);
     }
     addShutdownHook();

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -225,11 +225,12 @@ public class RunCommand extends BareCommand {
   }
 
   /**
-   * @return whether the {@code cluster} option or the {@code ha} option are enabled.
+   * @return whether the {@code cluster} option or the {@code ha} option are enabled. Also {@code true} when a custom
+   * launcher modifies the Vert.x options to set `clustered` to {@code true}
    */
   @Override
   public boolean isClustered() {
-    return cluster || ha;
+    return cluster || ha || (options != null  && options.isClustered());
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -245,6 +245,9 @@ public class RunCommand extends BareCommand {
   public void run() {
     if (redeploy == null || redeploy.isEmpty()) {
       JsonObject conf = getConfiguration();
+      if (conf == null) {
+        conf = new JsonObject();
+      }
       afterConfigParsed(conf);
 
       super.run();


### PR DESCRIPTION
Allow custom launcher to:

* set whether or not the vert.x instance is clustered (this was not possible before, clearly a bug)
* improve the afterConfigParsed callback to not call the method with a `null` object

