### PR TITLE
Additional CompositeFuture.any() and CompositeFuture.all() overloads (issue #1532)

### DIFF
--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -8,7 +8,7 @@ project descriptor to access the Vert.x Core API:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-core</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -16,5 +16,5 @@ project descriptor to access the Vert.x Core API:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-core:3.3.2
+compile io.vertx:vertx-core:3.4.0-SNAPSHOT
 ----

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -106,35 +106,35 @@ public interface CompositeFuture extends Future<CompositeFuture> {
   }
 
   /**
-   * Like {@link #all(boolean, Future, Future, Future)} but with 3 futures.
+   * Like {@link #all(boolean, Future, Future)} but with 3 futures.
    */
   static <T1, T2, T3> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3) {
     return CompositeFutureImpl.all(collectResults, f1, f2, f3);
   }
 
   /**
-   * Like {@link #all(boolean, Future, Future, Future)} but with 4 futures.
+   * Like {@link #all(boolean, Future, Future)} but with 4 futures.
    */
   static <T1, T2, T3, T4> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
     return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4);
   }
 
   /**
-   * Like {@link #all(boolean, Future, Future, Future)} but with 5 futures.
+   * Like {@link #all(boolean, Future, Future)} but with 5 futures.
    */
   static <T1, T2, T3, T4, T5> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
     return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4, f5);
   }
 
   /**
-   * Like {@link #all(boolean, Future, Future, Future)} but with 6 futures.
+   * Like {@link #all(boolean, Future, Future)} but with 6 futures.
    */
   static <T1, T2, T3, T4, T5, T6> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
     return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4, f5, f6);
   }
 
   /**
-   * Like {@link #all(boolean, Future, Future, Future)} but with a list of futures.<p>
+   * Like {@link #all(boolean, Future, Future)} but with a list of futures.<p>
    *
    * When the list is empty, the returned future will be already completed.
    */

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -86,15 +86,17 @@ public interface CompositeFuture extends Future<CompositeFuture> {
   /**
    * Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.
    * <p/>
-   * The returned future fails if either {@code f1} or {@code f2} fails. The {@code collectResults} flag determines how
+   * The returned future fails if either {@code f1} or {@code f2} fails. The {@code collectResults} flag determines when
    * the composite future completes.
    * <p/>
-   * If {@code collectResults = false} the composite future fails as soon as either of its futures fails. This is the
-   * default and is equivalent to {@link #all(Future, Future)} without the parameter. On the other hand if
-   * {@code collectResults = true} the composite feature completes only when both {@code f1} and {@code f2} have
-   * completed, thereby allowing inspection of all failures, not just the first.
+   * If {@code collectResults = false} the composite future fails and completes as soon as the first future fails. This
+   * is equivalent to calling {@link #all(Future, Future)} without the parameter.
+   * <p/>
+   * On the other hand, if {@code collectResults = true} the composite future completes only after both {@code f1} and {@code f2} have
+   * completed. This allows you to inspect each individual outcome. In case of failure the {@code cause()} returned in the
+   * composite future result handler will hold the last failure that occurred on its constituent futures.
    *
-   * @param collectResults whether to collect results or not
+   * @param collectResults whether or not to collect results
    * @param f1 future
    * @param f2 future
    * @return the composite future
@@ -141,7 +143,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
   }
 
   /**
-   * Return a composite future, succeeded when any futures is succeeded, failed when all futures are failed.
+   * Return a composite future, succeeded when any future is succeeded, failed when all futures are failed.
    * <p/>
    * The returned future succeeds as soon as one of {@code f1} or {@code f2} succeeds.
    *
@@ -188,6 +190,65 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    */
   static CompositeFuture any(List<Future> futures) {
     return CompositeFutureImpl.any(false, futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded when any futures are succeeded, failed when all futures are failed.
+   * <p/>
+   * The returned future succeeds when either {@code f1} or {@code f2} succeeds. The {@code collectResults} flag determines when
+   * the composite future itself completes.
+   * <p/>
+   * If {@code collectResults = false} the composite future completes as soon as the first future succeeds. This
+   * is equivalent to calling {@link #any(Future, Future)} without the parameter.
+   * <p/>
+   * On the other hand, if {@code collectResults = true} the composite future completes only after both {@code f1} and {@code f2} have
+   * completed. This allows you to inspect each individual outcome. In the case where all futures fail the {@code cause()} returned in the
+   * composite future result handler will hold the last failure that occurred.
+   *
+   * @param collectResults whether or not to collect results
+   * @param f1 future
+   * @param f2 future
+   * @return the composite future
+   */
+  static <T1, T2> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2) {
+    return CompositeFutureImpl.any(collectResults, f1, f2);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 3 futures.
+   */
+  static <T1, T2, T3> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 4 futures.
+   */
+  static <T1, T2, T3, T4> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3, f4);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 5 futures.
+   */
+  static <T1, T2, T3, T4, T5> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3, f4, f5);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 6 futures.
+   */
+  static <T1, T2, T3, T4, T5, T6> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3, f4, f5, f6);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with a list of futures.<p>
+   *
+   * When the list is empty, the returned future will be already completed.
+   */
+  static CompositeFuture any(boolean collectResults, List<Future> futures) {
+    return CompositeFutureImpl.any(collectResults, futures.toArray(new Future[futures.size()]));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -43,35 +43,35 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * @return the composite future
    */
   static <T1, T2> CompositeFuture all(Future<T1> f1, Future<T2> f2) {
-    return CompositeFutureImpl.all(f1, f2);
+    return CompositeFutureImpl.all(false, f1, f2);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 3 futures.
    */
   static <T1, T2, T3> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3) {
-    return CompositeFutureImpl.all(f1, f2, f3);
+    return CompositeFutureImpl.all(false, f1, f2, f3);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 4 futures.
    */
   static <T1, T2, T3, T4> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
-    return CompositeFutureImpl.all(f1, f2, f3, f4);
+    return CompositeFutureImpl.all(false, f1, f2, f3, f4);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 5 futures.
    */
   static <T1, T2, T3, T4, T5> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
-    return CompositeFutureImpl.all(f1, f2, f3, f4, f5);
+    return CompositeFutureImpl.all(false, f1, f2, f3, f4, f5);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 6 futures.
    */
   static <T1, T2, T3, T4, T5, T6> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
-    return CompositeFutureImpl.all(f1, f2, f3, f4, f5, f6);
+    return CompositeFutureImpl.all(false, f1, f2, f3, f4, f5, f6);
   }
 
   /**
@@ -80,7 +80,64 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture all(List<Future> futures) {
-    return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.all(false, futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.
+   * <p/>
+   * The returned future fails if either {@code f1} or {@code f2} fails. The {@code collectResults} flag determines how
+   * the composite future completes.
+   * <p/>
+   * If {@code collectResults = false} the composite future fails as soon as either of its futures fails. This is the
+   * default and is equivalent to {@link #all(Future, Future)} without the parameter. On the other hand if
+   * {@code collectResults = true} the composite feature completes only when both {@code f1} and {@code f2} have
+   * completed, thereby allowing inspection of all failures, not just the first.
+   *
+   * @param collectResults whether to collect results or not
+   * @param f1 future
+   * @param f2 future
+   * @return the composite future
+   */
+  static <T1, T2> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2) {
+    return CompositeFutureImpl.all(collectResults, f1, f2);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future, Future)} but with 3 futures.
+   */
+  static <T1, T2, T3> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future, Future)} but with 4 futures.
+   */
+  static <T1, T2, T3, T4> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future, Future)} but with 5 futures.
+   */
+  static <T1, T2, T3, T4, T5> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4, f5);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future, Future)} but with 6 futures.
+   */
+  static <T1, T2, T3, T4, T5, T6> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4, f5, f6);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future, Future)} but with a list of futures.<p>
+   *
+   * When the list is empty, the returned future will be already completed.
+   */
+  static CompositeFuture all(boolean collectResults, List<Future> futures) {
+    return CompositeFutureImpl.all(collectResults, futures.toArray(new Future[futures.size()]));
   }
 
   /**
@@ -93,35 +150,35 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * @return the composite future
    */
   static <T1, T2> CompositeFuture any(Future<T1> f1, Future<T2> f2) {
-    return CompositeFutureImpl.any(f1, f2);
+    return CompositeFutureImpl.any(false, f1, f2);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 3 futures.
    */
   static <T1, T2, T3> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3) {
-    return CompositeFutureImpl.any(f1, f2, f3);
+    return CompositeFutureImpl.any(false, f1, f2, f3);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 4 futures.
    */
   static <T1, T2, T3, T4> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
-    return CompositeFutureImpl.any(f1, f2, f3, f4);
+    return CompositeFutureImpl.any(false, f1, f2, f3, f4);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 5 futures.
    */
   static <T1, T2, T3, T4, T5> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
-    return CompositeFutureImpl.any(f1, f2, f3, f4, f5);
+    return CompositeFutureImpl.any(false, f1, f2, f3, f4, f5);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 6 futures.
    */
   static <T1, T2, T3, T4, T5, T6> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
-    return CompositeFutureImpl.any(f1, f2, f3, f4, f5, f6);
+    return CompositeFutureImpl.any(false, f1, f2, f3, f4, f5, f6);
   }
 
   /**
@@ -130,7 +187,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture any(List<Future> futures) {
-    return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.any(false, futures.toArray(new Future[futures.size()]));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -22,13 +22,13 @@ import io.vertx.core.impl.CompositeFutureImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * The composite future wraps a list of {@link Future futures}, it is useful when several futures
  * needs to be coordinated.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
  */
 @VertxGen
 public interface CompositeFuture extends Future<CompositeFuture> {

--- a/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
@@ -17,8 +17,8 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 /**

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -214,6 +214,16 @@ public class FutureTest extends VertxTestBase {
     testAllSucceeded((f1, f2) -> CompositeFuture.all(Arrays.asList(f1, f2)));
   }
 
+  @Test
+  public void testAllSucceededCollectResults() {
+    testAllSucceeded((f1, f2) -> CompositeFuture.all(true, f1, f2));
+  }
+
+  @Test
+  public void testAllSucceededCollectResultsWithList() {
+    testAllSucceeded((f1, f2) -> CompositeFuture.all(true, Arrays.asList(f1, f2)));
+  }
+
   private void testAllSucceeded(BiFunction<Future<String>, Future<Integer>, CompositeFuture> all) {
     Future<String> f1 = Future.future();
     Future<Integer> f2 = Future.future();
@@ -239,6 +249,12 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testAllCollectResultsWithEmptyList() {
+    CompositeFuture composite = CompositeFuture.all(true, Collections.emptyList());
+    assertTrue(composite.isComplete());
+  }
+
+  @Test
   public void testAllFailed() {
     testAllFailed(CompositeFuture::all);
   }
@@ -246,6 +262,16 @@ public class FutureTest extends VertxTestBase {
   @Test
   public void testAllFailedWithList() {
     testAllFailed((f1, f2) -> CompositeFuture.all(Arrays.asList(f1, f2)));
+  }
+
+  @Test
+  public void testAllFailedCollectResults() {
+    testAllFailedCollectResults((f1, f2) -> CompositeFuture.all(true, f1, f2));
+  }
+
+  @Test
+  public void testAllFailedCollectResultsWithList() {
+    testAllFailedCollectResults((f1, f2) -> CompositeFuture.all(true, Arrays.asList(f1, f2)));
   }
 
   private void testAllFailed(BiFunction<Future<String>, Future<Integer>, CompositeFuture> all) {
@@ -261,20 +287,86 @@ public class FutureTest extends VertxTestBase {
     assertEquals(null, composite.<Integer>result(1));
   }
 
-  @Test
-  public void testAllLargeList() {
-    testAllLargeList(63);
-    testAllLargeList(64);
-    testAllLargeList(65);
-    testAllLargeList(100);
+
+  private void testAllFailedCollectResults(BiFunction<Future<Integer>, Future<String>, CompositeFuture> all) {
+    Future<Integer> f1 = Future.future();
+    Future<String> f2 = Future.future();
+    CompositeFuture composite = all.apply(f1, f2);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    Exception cause = new Exception();
+    f1.fail(cause);
+    checker.assertNotCompleted();
+    assertEquals(null, composite.<Integer>result(0));
+    f2.complete("s");
+    checker.assertFailed(cause);
+    assertEquals(cause, composite.cause(0));
+    assertEquals("s", composite.result(1));
   }
 
-  private void testAllLargeList(int size) {
+  @Test
+  public void testAllFailedCollectResults3Futures1() {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    Future<String> f3 = Future.future();
+    CompositeFuture composite = CompositeFuture.all(true, f1, f2, f3);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    Exception cause1 = new Exception();
+    f1.fail(cause1);
+    checker.assertNotCompleted();
+    Exception cause2 = new Exception();
+    f2.fail(cause2);
+    checker.assertNotCompleted();
+    f3.complete("s");
+    checker.assertFailed(cause2);
+    assertEquals(cause1, composite.cause(0));
+    assertEquals(cause2, composite.cause(1));
+    assertEquals("s", composite.result(2));
+  }
+
+
+  @Test
+  public void testAllFailedCollectResults3Futures2() {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    Future<String> f3 = Future.future();
+    CompositeFuture composite = CompositeFuture.all(true, f1, f2, f3);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    Exception cause1 = new Exception();
+    f1.fail(cause1);
+    checker.assertNotCompleted();
+    Exception cause2 = new Exception();
+    f2.fail(cause2);
+    checker.assertNotCompleted();
+    Exception cause3 = new Exception();
+    f3.fail(cause3);
+    checker.assertFailed(cause3);
+    assertEquals(cause1, composite.cause(0));
+    assertEquals(cause2, composite.cause(1));
+    assertEquals(cause3, composite.cause(2));
+  }
+
+  @Test
+  public void testAllLargeList() {
+    testAllLargeList(false, 63);
+    testAllLargeList(false, 64);
+    testAllLargeList(false, 65);
+    testAllLargeList(false, 100);
+  }
+
+  @Test
+  public void testAllCollectResultsLargeList() {
+    testAllLargeList(true, 63);
+    testAllLargeList(true, 64);
+    testAllLargeList(true, 65);
+    testAllLargeList(true, 100);
+  }
+
+  private void testAllLargeList(boolean collectResults, int size) {
     List<Future> list = new ArrayList<>();
     for (int i = 0;i < size;i++) {
       list.add(Future.succeededFuture());
     }
-    CompositeFuture composite = CompositeFuture.all(list);
+    CompositeFuture composite = CompositeFuture.all(collectResults, list);
     Checker<CompositeFuture> checker = new Checker<>(composite);
     checker.assertSucceeded(composite);
     for (int i = 0;i < size;i++) {
@@ -306,6 +398,16 @@ public class FutureTest extends VertxTestBase {
     testAnySucceeded1((f1, f2) -> CompositeFuture.any(Arrays.asList(f1, f2)));
   }
 
+  @Test
+  public void testAnySucceeded1CollectResults() {
+    // TODO
+  }
+
+  @Test
+  public void testAnySucceeded1CollectResultsWithList() {
+    // TODO
+  }
+
   private void testAnySucceeded1(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
     Future<String> f1 = Future.future();
     Future<Integer> f2 = Future.future();
@@ -327,6 +429,11 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testAnyCollectResultsWithEmptyList() {
+
+  }
+
+  @Test
   public void testAnySucceeded2() {
     testAnySucceeded2(CompositeFuture::any);
   }
@@ -334,6 +441,16 @@ public class FutureTest extends VertxTestBase {
   @Test
   public void testAnySucceeded2WithList() {
     testAnySucceeded2(CompositeFuture::any);
+  }
+
+  @Test
+  public void testAnySucceeded2CollectResults() {
+    // TODO
+  }
+
+  @Test
+  public void testAnySucceeded2CollectResultsWithList() {
+    // TODO
   }
 
   private void testAnySucceeded2(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
@@ -357,6 +474,17 @@ public class FutureTest extends VertxTestBase {
     testAnyFailed((f1, f2) -> CompositeFuture.any(Arrays.asList(f1, f2)));
   }
 
+
+  @Test
+  public void testAnyFailedCollectResults() {
+    // TODO
+  }
+
+  @Test
+  public void testAnyFailedCollectResultsWithList() {
+    // TODO
+  }
+
   private void testAnyFailed(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
     Future<String> f1 = Future.future();
     Future<Integer> f2 = Future.future();
@@ -375,6 +503,11 @@ public class FutureTest extends VertxTestBase {
     testAnyLargeList(64);
     testAnyLargeList(65);
     testAnyLargeList(100);
+  }
+
+  @Test
+  public void testAnyCollectResultsLargeList() {
+    // TODO
   }
 
   private void testAnyLargeList(int size) {


### PR DESCRIPTION
This PR extends `CompositeFuture` with static method overloads of the `any()` and `all()` methods that operate in the same way, but complete only after all individual futures have been completed.

See also issue: #1532 