### PR TITLE
Overloads of CompositeFuture that collect results before completion (#1532)

### DIFF
--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -8,7 +8,7 @@ project descriptor to access the Vert.x Core API:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-core</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -16,5 +16,5 @@ project descriptor to access the Vert.x Core API:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-core:3.3.2
+compile io.vertx:vertx-core:3.4.0-SNAPSHOT
 ----

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -22,13 +22,13 @@ import io.vertx.core.impl.CompositeFutureImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * The composite future wraps a list of {@link Future futures}, it is useful when several futures
  * needs to be coordinated.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
  */
 @VertxGen
 public interface CompositeFuture extends Future<CompositeFuture> {
@@ -43,35 +43,35 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * @return the composite future
    */
   static <T1, T2> CompositeFuture all(Future<T1> f1, Future<T2> f2) {
-    return CompositeFutureImpl.all(f1, f2);
+    return CompositeFutureImpl.all(false, f1, f2);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 3 futures.
    */
   static <T1, T2, T3> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3) {
-    return CompositeFutureImpl.all(f1, f2, f3);
+    return CompositeFutureImpl.all(false, f1, f2, f3);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 4 futures.
    */
   static <T1, T2, T3, T4> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
-    return CompositeFutureImpl.all(f1, f2, f3, f4);
+    return CompositeFutureImpl.all(false, f1, f2, f3, f4);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 5 futures.
    */
   static <T1, T2, T3, T4, T5> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
-    return CompositeFutureImpl.all(f1, f2, f3, f4, f5);
+    return CompositeFutureImpl.all(false, f1, f2, f3, f4, f5);
   }
 
   /**
    * Like {@link #all(Future, Future)} but with 6 futures.
    */
   static <T1, T2, T3, T4, T5, T6> CompositeFuture all(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
-    return CompositeFutureImpl.all(f1, f2, f3, f4, f5, f6);
+    return CompositeFutureImpl.all(false, f1, f2, f3, f4, f5, f6);
   }
 
   /**
@@ -80,11 +80,70 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture all(List<Future> futures) {
-    return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.all(false, futures.toArray(new Future[futures.size()]));
   }
 
   /**
-   * Return a composite future, succeeded when any futures is succeeded, failed when all futures are failed.
+   * Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.
+   * <p/>
+   * The returned future fails if either {@code f1} or {@code f2} fails. The {@code collectResults} flag determines when
+   * the composite future completes.
+   * <p/>
+   * If {@code collectResults = false} the composite future fails and completes as soon as the first future fails. This
+   * is equivalent to calling {@link #all(Future, Future)} without the parameter.
+   * <p/>
+   * On the other hand, if {@code collectResults = true} the composite future completes only after both {@code f1} and {@code f2} have
+   * completed. This allows you to inspect each individual outcome. In case of failure the {@code cause()} returned in the
+   * composite future result handler will hold the last failure that occurred on its constituent futures.
+   *
+   * @param collectResults whether or not to collect results
+   * @param f1 future
+   * @param f2 future
+   * @return the composite future
+   */
+  static <T1, T2> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2) {
+    return CompositeFutureImpl.all(collectResults, f1, f2);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future)} but with 3 futures.
+   */
+  static <T1, T2, T3> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future)} but with 4 futures.
+   */
+  static <T1, T2, T3, T4> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future)} but with 5 futures.
+   */
+  static <T1, T2, T3, T4, T5> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4, f5);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future)} but with 6 futures.
+   */
+  static <T1, T2, T3, T4, T5, T6> CompositeFuture all(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
+    return CompositeFutureImpl.all(collectResults, f1, f2, f3, f4, f5, f6);
+  }
+
+  /**
+   * Like {@link #all(boolean, Future, Future)} but with a list of futures.<p>
+   *
+   * When the list is empty, the returned future will be already completed.
+   */
+  static CompositeFuture all(boolean collectResults, List<Future> futures) {
+    return CompositeFutureImpl.all(collectResults, futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded when any future is succeeded, failed when all futures are failed.
    * <p/>
    * The returned future succeeds as soon as one of {@code f1} or {@code f2} succeeds.
    *
@@ -93,35 +152,35 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * @return the composite future
    */
   static <T1, T2> CompositeFuture any(Future<T1> f1, Future<T2> f2) {
-    return CompositeFutureImpl.any(f1, f2);
+    return CompositeFutureImpl.any(false, f1, f2);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 3 futures.
    */
   static <T1, T2, T3> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3) {
-    return CompositeFutureImpl.any(f1, f2, f3);
+    return CompositeFutureImpl.any(false, f1, f2, f3);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 4 futures.
    */
   static <T1, T2, T3, T4> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
-    return CompositeFutureImpl.any(f1, f2, f3, f4);
+    return CompositeFutureImpl.any(false, f1, f2, f3, f4);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 5 futures.
    */
   static <T1, T2, T3, T4, T5> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
-    return CompositeFutureImpl.any(f1, f2, f3, f4, f5);
+    return CompositeFutureImpl.any(false, f1, f2, f3, f4, f5);
   }
 
   /**
    * Like {@link #any(Future, Future)} but with 6 futures.
    */
   static <T1, T2, T3, T4, T5, T6> CompositeFuture any(Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
-    return CompositeFutureImpl.any(f1, f2, f3, f4, f5, f6);
+    return CompositeFutureImpl.any(false, f1, f2, f3, f4, f5, f6);
   }
 
   /**
@@ -130,7 +189,66 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    * When the list is empty, the returned future will be already completed.
    */
   static CompositeFuture any(List<Future> futures) {
-    return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
+    return CompositeFutureImpl.any(false, futures.toArray(new Future[futures.size()]));
+  }
+
+  /**
+   * Return a composite future, succeeded when any futures are succeeded, failed when all futures are failed.
+   * <p/>
+   * The returned future succeeds when either {@code f1} or {@code f2} succeeds. The {@code collectResults} flag determines when
+   * the composite future itself completes.
+   * <p/>
+   * If {@code collectResults = false} the composite future completes as soon as the first future succeeds. This
+   * is equivalent to calling {@link #any(Future, Future)} without the parameter.
+   * <p/>
+   * On the other hand, if {@code collectResults = true} the composite future completes only after both {@code f1} and {@code f2} have
+   * completed. This allows you to inspect each individual outcome. In the case where all futures fail the {@code cause()} returned in the
+   * composite future result handler will hold the last failure that occurred.
+   *
+   * @param collectResults whether or not to collect results
+   * @param f1 future
+   * @param f2 future
+   * @return the composite future
+   */
+  static <T1, T2> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2) {
+    return CompositeFutureImpl.any(collectResults, f1, f2);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 3 futures.
+   */
+  static <T1, T2, T3> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 4 futures.
+   */
+  static <T1, T2, T3, T4> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3, f4);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 5 futures.
+   */
+  static <T1, T2, T3, T4, T5> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3, f4, f5);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with 6 futures.
+   */
+  static <T1, T2, T3, T4, T5, T6> CompositeFuture any(boolean collectResults, Future<T1> f1, Future<T2> f2, Future<T3> f3, Future<T4> f4, Future<T5> f5, Future<T6> f6) {
+    return CompositeFutureImpl.any(collectResults, f1, f2, f3, f4, f5, f6);
+  }
+
+  /**
+   * Like {@link #any(boolean, Future, Future)} but with a list of futures.<p>
+   *
+   * When the list is empty, the returned future will be already completed.
+   */
+  static CompositeFuture any(boolean collectResults, List<Future> futures) {
+    return CompositeFutureImpl.any(collectResults, futures.toArray(new Future[futures.size()]));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
@@ -17,18 +17,19 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
  */
 public class CompositeFutureImpl implements CompositeFuture, Handler<AsyncResult<CompositeFuture>> {
 
-  public static CompositeFuture all(Future<?>... results) {
+  public static CompositeFuture all(boolean collectResults, Future<?>... results) {
     CompositeFutureImpl composite = new CompositeFutureImpl(results);
-    int len = results.length;
+    final int len = results.length;
     for (int i = 0; i < len; i++) {
       results[i].setHandler(ar -> {
         Handler<AsyncResult<CompositeFuture>> handler = null;
@@ -36,12 +37,13 @@ public class CompositeFutureImpl implements CompositeFuture, Handler<AsyncResult
           synchronized (composite) {
             composite.count++;
             if (!composite.isComplete() && composite.count == len) {
-              handler = composite.setSucceeded();
+              handler = collectResultsAll(composite, collectResults, results);
             }
           }
         } else {
           synchronized (composite) {
-            if (!composite.isComplete()) {
+            composite.count++;
+            if (!composite.isComplete() && (!collectResults || composite.count == len)) {
               handler = composite.setFailed(ar.cause());
             }
           }
@@ -57,23 +59,38 @@ public class CompositeFutureImpl implements CompositeFuture, Handler<AsyncResult
     return composite;
   }
 
-  public static CompositeFuture any(Future<?>... results) {
+  private static Handler<AsyncResult<CompositeFuture>> collectResultsAll(
+          CompositeFutureImpl composite, boolean collectResults, Future<?>... results) {
+    if (!collectResults) {
+      return composite.setSucceeded();
+    } else {
+      for (int j = results.length; j > 0; j--) {
+        if (results[j - 1].failed()) {
+          return composite.setFailed(results[j - 1].cause());
+        }
+      }
+      return composite.setSucceeded();
+    }
+  }
+
+  public static CompositeFuture any(boolean collectResults, Future<?>... results) {
     CompositeFutureImpl composite = new CompositeFutureImpl(results);
-    int len = results.length;
+    final int len = results.length;
     for (int i = 0;i < len;i++) {
       results[i].setHandler(ar -> {
         Handler<AsyncResult<CompositeFuture>> handler = null;
         if (ar.succeeded()) {
           synchronized (composite) {
-            if (!composite.isComplete()) {
-              handler = composite.setSucceeded();
+            composite.count++;
+            if (!composite.isComplete() && (!collectResults || composite.count == len)) {
+                handler = composite.setSucceeded();
             }
           }
         } else {
           synchronized (composite) {
             composite.count++;
             if (!composite.isComplete() && composite.count == len) {
-              handler = composite.setFailed(ar.cause());
+              handler = collectResultsAny(composite, collectResults, ar.cause(), results);
             }
           }
         }
@@ -82,10 +99,25 @@ public class CompositeFutureImpl implements CompositeFuture, Handler<AsyncResult
         }
       });
     }
-    if (results.length == 0) {
+    if (len == 0) {
       composite.setSucceeded();
     }
     return composite;
+  }
+
+  private static Handler<AsyncResult<CompositeFuture>> collectResultsAny(
+          CompositeFutureImpl composite, boolean collectResults, Throwable cause, Future<?>... results) {
+    if (!collectResults) {
+      return composite.setFailed(cause);
+    } else {
+      for (int j = results.length; j > 0; j--) {
+        if (results[j - 1].succeeded()) {
+          return composite.setSucceeded();
+        }
+      }
+      return composite.setFailed(cause);
+    }
+
   }
 
   private final Future[] results;

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -34,6 +34,7 @@ import java.util.function.Consumer;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ * @author <a href="https://github.com/aschrijver/">Arnold Schrijver</a>
  */
 public class FutureTest extends VertxTestBase {
 
@@ -214,6 +215,16 @@ public class FutureTest extends VertxTestBase {
     testAllSucceeded((f1, f2) -> CompositeFuture.all(Arrays.asList(f1, f2)));
   }
 
+  @Test
+  public void testAllSucceededCollectResults() {
+    testAllSucceeded((f1, f2) -> CompositeFuture.all(true, f1, f2));
+  }
+
+  @Test
+  public void testAllSucceededCollectResultsWithList() {
+    testAllSucceeded((f1, f2) -> CompositeFuture.all(true, Arrays.asList(f1, f2)));
+  }
+
   private void testAllSucceeded(BiFunction<Future<String>, Future<Integer>, CompositeFuture> all) {
     Future<String> f1 = Future.future();
     Future<Integer> f2 = Future.future();
@@ -239,6 +250,12 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testAllCollectResultsWithEmptyList() {
+    CompositeFuture composite = CompositeFuture.all(true, Collections.emptyList());
+    assertTrue(composite.isComplete());
+  }
+
+  @Test
   public void testAllFailed() {
     testAllFailed(CompositeFuture::all);
   }
@@ -246,6 +263,16 @@ public class FutureTest extends VertxTestBase {
   @Test
   public void testAllFailedWithList() {
     testAllFailed((f1, f2) -> CompositeFuture.all(Arrays.asList(f1, f2)));
+  }
+
+  @Test
+  public void testAllFailedCollectResults() {
+    testAllFailedCollectResults((f1, f2) -> CompositeFuture.all(true, f1, f2));
+  }
+
+  @Test
+  public void testAllFailedCollectResultsWithList() {
+    testAllFailedCollectResults((f1, f2) -> CompositeFuture.all(true, Arrays.asList(f1, f2)));
   }
 
   private void testAllFailed(BiFunction<Future<String>, Future<Integer>, CompositeFuture> all) {
@@ -261,20 +288,86 @@ public class FutureTest extends VertxTestBase {
     assertEquals(null, composite.<Integer>result(1));
   }
 
-  @Test
-  public void testAllLargeList() {
-    testAllLargeList(63);
-    testAllLargeList(64);
-    testAllLargeList(65);
-    testAllLargeList(100);
+
+  private void testAllFailedCollectResults(BiFunction<Future<Integer>, Future<String>, CompositeFuture> all) {
+    Future<Integer> f1 = Future.future();
+    Future<String> f2 = Future.future();
+    CompositeFuture composite = all.apply(f1, f2);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    Exception cause = new Exception();
+    f1.fail(cause);
+    checker.assertNotCompleted();
+    assertEquals(null, composite.<Integer>result(0));
+    f2.complete("s");
+    checker.assertFailed(cause);
+    assertEquals(cause, composite.cause(0));
+    assertEquals("s", composite.result(1));
   }
 
-  private void testAllLargeList(int size) {
+  @Test
+  public void testAllFailedCollectResults3Futures1() {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    Future<String> f3 = Future.future();
+    CompositeFuture composite = CompositeFuture.all(true, f1, f2, f3);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    Exception cause1 = new Exception();
+    f1.fail(cause1);
+    checker.assertNotCompleted();
+    Exception cause2 = new Exception();
+    f2.fail(cause2);
+    checker.assertNotCompleted();
+    f3.complete("s");
+    checker.assertFailed(cause2);
+    assertEquals(cause1, composite.cause(0));
+    assertEquals(cause2, composite.cause(1));
+    assertEquals("s", composite.result(2));
+  }
+
+
+  @Test
+  public void testAllFailedCollectResults3Futures2() {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    Future<String> f3 = Future.future();
+    CompositeFuture composite = CompositeFuture.all(true, f1, f2, f3);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    Exception cause1 = new Exception();
+    f1.fail(cause1);
+    checker.assertNotCompleted();
+    Exception cause2 = new Exception();
+    f2.fail(cause2);
+    checker.assertNotCompleted();
+    Exception cause3 = new Exception();
+    f3.fail(cause3);
+    checker.assertFailed(cause3);
+    assertEquals(cause1, composite.cause(0));
+    assertEquals(cause2, composite.cause(1));
+    assertEquals(cause3, composite.cause(2));
+  }
+
+  @Test
+  public void testAllLargeList() {
+    testAllLargeList(false, 63);
+    testAllLargeList(false, 64);
+    testAllLargeList(false, 65);
+    testAllLargeList(false, 100);
+  }
+
+  @Test
+  public void testAllCollectResultsLargeList() {
+    testAllLargeList(true, 63);
+    testAllLargeList(true, 64);
+    testAllLargeList(true, 65);
+    testAllLargeList(true, 100);
+  }
+
+  private void testAllLargeList(boolean collectResults, int size) {
     List<Future> list = new ArrayList<>();
     for (int i = 0;i < size;i++) {
       list.add(Future.succeededFuture());
     }
-    CompositeFuture composite = CompositeFuture.all(list);
+    CompositeFuture composite = CompositeFuture.all(collectResults, list);
     Checker<CompositeFuture> checker = new Checker<>(composite);
     checker.assertSucceeded(composite);
     for (int i = 0;i < size;i++) {
@@ -306,6 +399,16 @@ public class FutureTest extends VertxTestBase {
     testAnySucceeded1((f1, f2) -> CompositeFuture.any(Arrays.asList(f1, f2)));
   }
 
+  @Test
+  public void testAnySucceeded1CollectResults() {
+    testAnySucceeded1CollectResults((f1, f2) -> CompositeFuture.any(true, f1, f2));
+  }
+
+  @Test
+  public void testAnySucceeded1CollectResultsWithList() {
+    testAnySucceeded1CollectResults((f1, f2) -> CompositeFuture.any(true, Arrays.asList(f1, f2)));
+  }
+
   private void testAnySucceeded1(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
     Future<String> f1 = Future.future();
     Future<Integer> f2 = Future.future();
@@ -320,9 +423,29 @@ public class FutureTest extends VertxTestBase {
     checker.assertSucceeded(composite);
   }
 
+  private void testAnySucceeded1CollectResults(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    CompositeFuture composite = any.apply(f1, f2);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    checker.assertNotCompleted();
+    assertEquals(null, composite.<String>result(0));
+    assertEquals(null, composite.<Integer>result(1));
+    f1.complete("something");
+    checker.assertNotCompleted();
+    f2.complete(3);
+    checker.assertSucceeded(composite);
+  }
+
   @Test
   public void testAnyWithEmptyList() {
     CompositeFuture composite = CompositeFuture.any(Collections.emptyList());
+    assertTrue(composite.isComplete());
+  }
+
+  @Test
+  public void testAnyCollectResultsWithEmptyList() {
+    CompositeFuture composite = CompositeFuture.any(true, Collections.emptyList());
     assertTrue(composite.isComplete());
   }
 
@@ -334,6 +457,16 @@ public class FutureTest extends VertxTestBase {
   @Test
   public void testAnySucceeded2WithList() {
     testAnySucceeded2(CompositeFuture::any);
+  }
+
+  @Test
+  public void testAnySucceeded2CollectResults() {
+    testAnySucceeded2((f1, f2) -> CompositeFuture.any(true, f1, f2));
+  }
+
+  @Test
+  public void testAnySucceeded2CollectResultsWithList() {
+    testAnySucceeded2((f1, f2) -> CompositeFuture.any(true, Arrays.asList(f1, f2)));
   }
 
   private void testAnySucceeded2(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
@@ -348,6 +481,24 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testAnySucceeded3CollectResults() {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    Future<String> f3 = Future.future();
+    CompositeFuture composite = CompositeFuture.any(true, f1, f2, f3);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    f1.fail("failure");
+    checker.assertNotCompleted();
+    f2.fail("failure");
+    checker.assertNotCompleted();
+    f3.complete("something");
+    checker.assertSucceeded(composite);
+    assertNull(composite.result(0));
+    assertNull(composite.result(1));
+    assertEquals("something", composite.result(2));
+  }
+
+  @Test
   public void testAnyFailed() {
     testAnyFailed(CompositeFuture::any);
   }
@@ -355,6 +506,17 @@ public class FutureTest extends VertxTestBase {
   @Test
   public void testAnyFailedWithList() {
     testAnyFailed((f1, f2) -> CompositeFuture.any(Arrays.asList(f1, f2)));
+  }
+
+
+  @Test
+  public void testAnyFailedCollectResults() {
+    testAnyFailed((f1, f2) -> CompositeFuture.any(true, f1, f2));
+  }
+
+  @Test
+  public void testAnyFailedCollectResultsWithList() {
+    testAnyFailed((f1, f2) -> CompositeFuture.any(true, Arrays.asList(f1, f2)));
   }
 
   private void testAnyFailed(BiFunction<Future<String>, Future<Integer>, CompositeFuture> any) {
@@ -370,19 +532,43 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
-  public void testAnyLargeList() {
-    testAnyLargeList(63);
-    testAnyLargeList(64);
-    testAnyLargeList(65);
-    testAnyLargeList(100);
+  public void testAnyFailedCollectResults2() {
+    Future<String> f1 = Future.future();
+    Future<Integer> f2 = Future.future();
+    Future<String> f3 = Future.future();
+    CompositeFuture composite = CompositeFuture.any(true, f1, f2, f3);
+    Checker<CompositeFuture> checker = new Checker<>(composite);
+    RuntimeException cause1 = new RuntimeException();
+    f1.fail(cause1);
+    RuntimeException cause2 = new RuntimeException();
+    f2.fail(cause2);
+    RuntimeException cause3 = new RuntimeException();
+    f3.fail(cause3);
+    checker.assertFailed(cause3);
   }
 
-  private void testAnyLargeList(int size) {
+  @Test
+  public void testAnyLargeList() {
+    testAnyLargeList(false, 63);
+    testAnyLargeList(false, 64);
+    testAnyLargeList(false, 65);
+    testAnyLargeList(false, 100);
+  }
+
+  @Test
+  public void testAnyCollectResultsLargeList() {
+    testAnyLargeList(true, 63);
+    testAnyLargeList(true, 64);
+    testAnyLargeList(true, 65);
+    testAnyLargeList(true, 100);
+  }
+
+  private void testAnyLargeList(boolean collectResults, int size) {
     List<Future> list = new ArrayList<>();
     for (int i = 0;i < size;i++) {
       list.add(Future.failedFuture(new Exception()));
     }
-    CompositeFuture composite = CompositeFuture.any(list);
+    CompositeFuture composite = CompositeFuture.any(collectResults, list);
     Checker<CompositeFuture> checker = new Checker<>(composite);
     checker.assertFailed();
     for (int i = 0;i < size;i++) {
@@ -405,9 +591,18 @@ public class FutureTest extends VertxTestBase {
 
   @Test
   public void testCompositeFutureToList() {
+    testCompositeFutureToList(false);
+  }
+
+  @Test
+  public void testCompositeFutureToListCollectResults() {
+    testCompositeFutureToList(true);
+  }
+
+  private void testCompositeFutureToList(boolean collectResults) {
     Future<String> f1 = Future.future();
     Future<Integer> f2 = Future.future();
-    CompositeFuture composite = CompositeFuture.all(f1, f2);
+    CompositeFuture composite = CompositeFuture.all(collectResults, f1, f2);
     assertEquals(Arrays.asList(null, null), composite.list());
     f1.complete("foo");
     assertEquals(Arrays.asList("foo", null), composite.list());


### PR DESCRIPTION
This PR extends `CompositeFuture` with static method overloads of the `any()` and `all()` methods that operate in the same way, but complete only after all individual futures have been completed.

See also issue: #1532

(Note: This request replaces [a previous one](https://github.com/eclipse/vert.x/pull/1533), where I had trouble amending commits with Eclipse CLA)