### PR TITLE
Add the ability to chain bodyEndHandlers

### DIFF
--- a/src/main/java/io/vertx/core/FunctionHandler.java
+++ b/src/main/java/io/vertx/core/FunctionHandler.java
@@ -1,0 +1,40 @@
+package io.vertx.core;
+
+import io.vertx.codegen.annotations.VertxGen;
+import java.util.Objects;
+
+/**
+ *  A generic FunctionHandler interface
+ *  <p>
+ *  This interface is copy of the JDK FunctionHandler interface to support VertxGen and
+ *  composing {@link Handler}
+ *  <p>
+ *
+ *  @author <a href="http://fzakaria.com">Farid Zakaria</a>
+ */
+@VertxGen
+@FunctionalInterface
+public interface FunctionHandler<E> {
+
+    Handler<E> apply(Handler<E> var1);
+
+    default <V> FunctionHandler<E> compose(FunctionHandler<E> var1) {
+        Objects.requireNonNull(var1);
+        return (var2) -> {
+            return this.apply(var1.apply(var2));
+        };
+    }
+
+    default <V> FunctionHandler<E> andThen(FunctionHandler<E> var1) {
+        Objects.requireNonNull(var1);
+        return (var2) -> {
+            return var1.apply(this.apply(var2));
+        };
+    }
+
+    static <E> FunctionHandler<E> identity() {
+        return (var0) -> {
+            return var0;
+        };
+    }
+}

--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -22,6 +22,7 @@ import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.FunctionHandler;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
@@ -370,6 +371,19 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
    */
   @Fluent
   HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler);
+
+  /**
+   * Provide a handler that will be called just before the last part of the body is written to the wire
+   * and the response is ended.<p>
+   * This provides a hook allowing you to do any more operations before this occurs.
+   * This version provides the existing bodyEndHandler if it exists allowing you to chain the two handlers
+   * as you see fit.
+   *
+   * @param composingHandler  a function to compose the handlers
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServerResponse bodyEndHandler(FunctionHandler<Void> composingHandler);
 
   /**
    * @return the total number of bytes written for the body of the response.

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.FunctionHandler;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -41,6 +42,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.ClosedChannelException;
+import java.util.Objects;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -569,6 +571,15 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse bodyEndHandler(@Nullable Handler<Void> handler) {
     synchronized (conn) {
       bodyEndHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
+  public HttpServerResponse bodyEndHandler(FunctionHandler<Void> composingHandler) {
+    Objects.requireNonNull(composingHandler, "no null key accepted");
+    synchronized (conn) {
+      this.bodyEndHandler = composingHandler.apply(bodyEndHandler);
       return this;
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpVersion;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.FunctionHandler;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -38,6 +39,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.Objects;
 
 /**
  *
@@ -383,6 +385,15 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse bodyEndHandler(Handler<Void> handler) {
     synchronized (conn) {
       this.bodyEndHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
+  public HttpServerResponse bodyEndHandler(FunctionHandler<Void> composingHandler) {
+    Objects.requireNonNull(composingHandler, "no null key accepted");
+    synchronized (conn) {
+      this.bodyEndHandler = composingHandler.apply(bodyEndHandler);
       return this;
     }
   }


### PR DESCRIPTION
It is useful sometimes to register more than 1 bodyEndHandler at various parts of the
Router (in the case of Vert.x Web).

This change will allow users to compose multiple bodyEndHandlers as they see fit.
There is an example provided in the test case that demonstrates such a scenario.

If this change is accepted I think similar changes should occur for all methods that register a Handler.

I'm not too attached to the name of the `FunctionHandler` class and open to change.