### PR TITLE
Improve watcher performances

### DIFF
--- a/src/test/java/io/vertx/core/impl/launcher/commands/CommandTestBase.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/CommandTestBase.java
@@ -97,7 +97,7 @@ public class CommandTestBase {
   }
 
   protected void waitUntil(BooleanSupplier supplier) {
-    waitUntil(supplier, 10000);
+    waitUntil(supplier, 20000);
   }
 
   protected void waitUntil(BooleanSupplier supplier, long timeout) {

--- a/src/test/java/io/vertx/core/impl/launcher/commands/WatcherAbsolutePathTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/WatcherAbsolutePathTest.java
@@ -33,13 +33,16 @@ public class WatcherAbsolutePathTest extends WatcherTest {
   @Before
   public void prepare() {
     root = new File("target/junk/watcher");
+    File otherRoot = new File(root.getParentFile(), "abs-test");
+    deleteRecursive(otherRoot);
     deleteRecursive(root);
+    otherRoot.mkdirs();
     root.mkdirs();
 
     deploy = new AtomicInteger();
     undeploy = new AtomicInteger();
 
-    watcher = new Watcher(root, Collections.unmodifiableList(
+    watcher = new Watcher(otherRoot, Collections.unmodifiableList(
         Arrays.asList(
             root.getAbsolutePath() + File.separator + "**" + File.separator + "*.txt",
             root.getAbsolutePath() + File.separator + "windows\\*.win",


### PR DESCRIPTION
* change how the watching is made to not watch the full root, but watch individual roots. It avoids issues when watching huge directories
* add performance tests

This PR is related to https://github.com/vert-x3/vertx-examples/issues/150