### PR TITLE
Add closeable hook to VertxInternal to allow extension to make cleanu…

### DIFF
--- a/src/main/java/io/vertx/core/impl/CloseHooks.java
+++ b/src/main/java/io/vertx/core/impl/CloseHooks.java
@@ -24,6 +24,11 @@ class CloseHooks {
     this.log = log;
   }
 
+  /**
+   * Add a close hook, notified when the {@link #run(Handler)} method is called.
+   *
+   * @param hook the hook to add
+   */
   synchronized void add(Closeable hook) {
     if (closeHooks == null) {
       // Has to be concurrent as can be removed from non context thread
@@ -32,12 +37,22 @@ class CloseHooks {
     closeHooks.add(hook);
   }
 
+  /**
+   * Remove an existing hook.
+   *
+   * @param hook the hook to remove
+   */
   synchronized void remove(Closeable hook) {
     if (closeHooks != null) {
       closeHooks.remove(hook);
     }
   }
 
+  /**
+   * Run the close hooks.
+   *
+   * @param completionHandler called when all hooks have beene executed
+   */
   void run(Handler<AsyncResult<Void>> completionHandler) {
     Set<Closeable> copy = null;
     synchronized (this) {

--- a/src/main/java/io/vertx/core/impl/CloseHooks.java
+++ b/src/main/java/io/vertx/core/impl/CloseHooks.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 class CloseHooks {
 
   private final Logger log;
-  private volatile boolean closeHooksRun;
+  private boolean closeHooksRun;
   private Set<Closeable> closeHooks;
 
   CloseHooks(Logger log) {
@@ -51,7 +51,7 @@ class CloseHooks {
         copy = new HashSet<>(closeHooks);
       }
     }
-    if (copy != null && !closeHooks.isEmpty()) {
+    if (copy != null && !copy.isEmpty()) {
       int num = copy.size();
       if (num != 0) {
         AtomicInteger count = new AtomicInteger();

--- a/src/main/java/io/vertx/core/impl/CloseHooks.java
+++ b/src/main/java/io/vertx/core/impl/CloseHooks.java
@@ -1,0 +1,86 @@
+package io.vertx.core.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+class CloseHooks {
+
+  private final Logger log;
+  private volatile boolean closeHooksRun;
+  private Set<Closeable> closeHooks;
+
+  CloseHooks(Logger log) {
+    this.log = log;
+  }
+
+  void add(Closeable hook) {
+    if (closeHooks == null) {
+      // Has to be concurrent as can be removed from non context thread
+      closeHooks = new ConcurrentHashSet<>();
+    }
+    closeHooks.add(hook);
+  }
+
+  void remove(Closeable hook) {
+    if (closeHooks != null) {
+      closeHooks.remove(hook);
+    }
+  }
+
+  void run(Handler<AsyncResult<Void>> completionHandler) {
+    if (closeHooksRun) {
+      // Sanity check
+      throw new IllegalStateException("Close hooks already run");
+    }
+    closeHooksRun = true;
+    if (closeHooks != null && !closeHooks.isEmpty()) {
+      // Must copy before looping as can be removed during loop otherwise
+      Set<Closeable> copy = new HashSet<>(closeHooks);
+      int num = copy.size();
+      if (num != 0) {
+        AtomicInteger count = new AtomicInteger();
+        AtomicBoolean failed = new AtomicBoolean();
+        for (Closeable hook : copy) {
+          Future<Void> a = Future.future();
+          a.setHandler(ar -> {
+            if (ar.failed()) {
+              if (failed.compareAndSet(false, true)) {
+                // Only report one failure
+                completionHandler.handle(Future.failedFuture(ar.cause()));
+              }
+            } else {
+              if (count.incrementAndGet() == num) {
+                // closeHooksRun = true;
+                completionHandler.handle(Future.succeededFuture());
+              }
+            }
+          });
+          try {
+            hook.close(a.completer());
+          } catch (Throwable t) {
+            log.warn("Failed to run close hooks", t);
+            if (!a.isComplete()) {
+              a.fail(t);
+            }
+          }
+        }
+      } else {
+        completionHandler.handle(Future.succeededFuture());
+      }
+    } else {
+      completionHandler.handle(Future.succeededFuture());
+    }
+  }
+
+}

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -112,6 +112,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final Map<String, SharedWorkerPool> namedWorkerPools;
   private final int defaultWorkerPoolSize;
   private final long defaultWorkerMaxExecTime;
+  private final CloseHooks closeHooks;
 
   VertxImpl() {
     this(new VertxOptions());
@@ -126,6 +127,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     if (Vertx.currentContext() != null) {
       log.warn("You're already on a Vert.x context, are you sure you want to create a new Vertx instance?");
     }
+    closeHooks = new CloseHooks(log);
     checker = new BlockedThreadChecker(options.getBlockedThreadCheckInterval(), options.getWarningExceptionTime());
     eventLoopThreadFactory = new VertxThreadFactory("vert.x-eventloop-thread-", checker, false, options.getMaxEventLoopExecuteTime());
     eventLoopGroup = new NioEventLoopGroup(options.getEventLoopPoolSize(), eventLoopThreadFactory);
@@ -476,41 +478,43 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     closed = true;
 
-    deploymentManager.undeployAll(ar -> {
-      if (haManager() != null) {
-        haManager().stop();
-      }
-      addressResolver.close(ar1 -> {
-        eventBus.close(ar2 -> {
-          closeClusterManager(ar3 -> {
-            // Copy set to prevent ConcurrentModificationException
-            Set<HttpServer> httpServers = new HashSet<>(sharedHttpServers.values());
-            Set<NetServer> netServers = new HashSet<>(sharedNetServers.values());
-            sharedHttpServers.clear();
-            sharedNetServers.clear();
+    closeHooks.run(ar -> {
+      deploymentManager.undeployAll(ar1 -> {
+        if (haManager() != null) {
+          haManager().stop();
+        }
+        addressResolver.close(ar2 -> {
+          eventBus.close(ar3 -> {
+            closeClusterManager(ar4 -> {
+              // Copy set to prevent ConcurrentModificationException
+              Set<HttpServer> httpServers = new HashSet<>(sharedHttpServers.values());
+              Set<NetServer> netServers = new HashSet<>(sharedNetServers.values());
+              sharedHttpServers.clear();
+              sharedNetServers.clear();
 
-            int serverCount = httpServers.size() + netServers.size();
+              int serverCount = httpServers.size() + netServers.size();
 
-            AtomicInteger serverCloseCount = new AtomicInteger();
+              AtomicInteger serverCloseCount = new AtomicInteger();
 
-            Handler<AsyncResult<Void>> serverCloseHandler = res -> {
-              if (res.failed()) {
-                log.error("Failure in shutting down server", res.cause());
+              Handler<AsyncResult<Void>> serverCloseHandler = res -> {
+                if (res.failed()) {
+                  log.error("Failure in shutting down server", res.cause());
+                }
+                if (serverCloseCount.incrementAndGet() == serverCount) {
+                  deleteCacheDirAndShutdown(completionHandler);
+                }
+              };
+
+              for (HttpServer server : httpServers) {
+                server.close(serverCloseHandler);
               }
-              if (serverCloseCount.incrementAndGet() == serverCount) {
+              for (NetServer server : netServers) {
+                server.close(serverCloseHandler);
+              }
+              if (serverCount == 0) {
                 deleteCacheDirAndShutdown(completionHandler);
               }
-            };
-
-            for (HttpServer server : httpServers) {
-              server.close(serverCloseHandler);
-            }
-            for (NetServer server : netServers) {
-              server.close(serverCloseHandler);
-            }
-            if (serverCount == 0) {
-              deleteCacheDirAndShutdown(completionHandler);
-            }
+            });
           });
         });
       });
@@ -951,5 +955,15 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   @Override
   public Handler<Throwable> exceptionHandler() {
     return exceptionHandler;
+  }
+
+  @Override
+  public void addCloseHook(Closeable hook) {
+    closeHooks.add(hook);
+  }
+
+  @Override
+  public void removeCloseHook(Closeable hook) {
+    closeHooks.remove(hook);
   }
 }

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -19,7 +19,9 @@ package io.vertx.core.impl;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.resolver.AddressResolverGroup;
+import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.impl.HttpServerImpl;
@@ -120,4 +122,9 @@ public interface VertxInternal extends Vertx {
    */
   AddressResolverGroup<InetSocketAddress> nettyAddressResolverGroup();
 
+  @GenIgnore
+  void addCloseHook(Closeable hook);
+
+  @GenIgnore
+  void removeCloseHook(Closeable hook);
 }

--- a/src/test/java/io/vertx/test/core/VertxTest.java
+++ b/src/test/java/io/vertx/test/core/VertxTest.java
@@ -1,0 +1,91 @@
+package io.vertx.test.core;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VertxTest extends AsyncTestBase {
+
+  @Test
+  public void testCloseHooksCalled() throws Exception {
+    AtomicInteger closedCount = new AtomicInteger();
+    Closeable myCloseable1 = completionHandler -> {
+      closedCount.incrementAndGet();
+      completionHandler.handle(Future.succeededFuture());
+    };
+    Closeable myCloseable2 = completionHandler -> {
+      closedCount.incrementAndGet();
+      completionHandler.handle(Future.succeededFuture());
+    };
+    VertxInternal vertx = (VertxInternal) Vertx.vertx();
+    vertx.addCloseHook(myCloseable1);
+    vertx.addCloseHook(myCloseable2);
+    // Now undeploy
+    vertx.close(ar -> {
+      assertTrue(ar.succeeded());
+      assertEquals(2, closedCount.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testCloseHookFailure1() throws Exception {
+    AtomicInteger closedCount = new AtomicInteger();
+    class Hook implements Closeable {
+      @Override
+      public void close(Handler<AsyncResult<Void>> completionHandler) {
+        if (closedCount.incrementAndGet() == 1) {
+          throw new RuntimeException();
+        } else {
+          completionHandler.handle(Future.succeededFuture());
+        }
+      }
+    }
+    VertxInternal vertx = (VertxInternal) Vertx.vertx();
+    vertx.addCloseHook(new Hook());
+    vertx.addCloseHook(new Hook());
+    // Now undeploy
+    vertx.close(ar -> {
+      assertTrue(ar.succeeded());
+      assertEquals(2, closedCount.get());
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testCloseHookFailure2() throws Exception {
+    AtomicInteger closedCount = new AtomicInteger();
+    class Hook implements Closeable {
+      @Override
+      public void close(Handler<AsyncResult<Void>> completionHandler) {
+        if (closedCount.incrementAndGet() == 1) {
+          completionHandler.handle(Future.succeededFuture());
+          throw new RuntimeException();
+        } else {
+          completionHandler.handle(Future.succeededFuture());
+        }
+      }
+    }
+    VertxInternal vertx = (VertxInternal) Vertx.vertx();
+    vertx.addCloseHook(new Hook());
+    vertx.addCloseHook(new Hook());
+    // Now undeploy
+    vertx.close(ar -> {
+      assertTrue(ar.succeeded());
+      assertEquals(2, closedCount.get());
+      testComplete();
+    });
+    await();
+  }
+}


### PR DESCRIPTION
…p when Vertx closes

We do have this feature on Context that is useful for cleaning up Deployments, but we don't have a global one for Vertx. It is currently needed in vertx-shell that deploys a _fake_ verticle to monitor when Vert.x is closed which is somewhat an hack and hard to test (https://github.com/vert-x3/vertx-shell/blob/master/src/main/java/io/vertx/ext/shell/command/impl/CommandRegistryImpl.java#L59)

This allows vertx extension to be aware when Vert.x closes.