### PR TITLE
pr issue#1498 Implement HTTP Proxy for non SSL HttpClient 

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -406,7 +406,7 @@ public class ConnectionManager {
       applyConnectionOptions(options, bootstrap);
 
       ChannelProvider channelProvider;
-      if (options.getProxyOptions() == null) {
+      if (!options.isSsl() || options.getProxyOptions() == null) {
         channelProvider = ChannelProvider.INSTANCE;
       } else {
         channelProvider = ProxyChannelProvider.INSTANCE;

--- a/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
+++ b/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
@@ -5,7 +5,6 @@ import java.util.Base64;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.CaseInsensitiveHeaders;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
@@ -60,15 +59,12 @@ public class ConnectHttpProxy extends TestProxyBase {
     options.setHost("localhost").setPort(PORT);
     server = vertx.createHttpServer(options);
     server.requestHandler(request -> {
-      log.debug("request "+request.absoluteURI());
-      log.debug("headers "+new CaseInsensitiveHeaders().addAll(request.headers()).toString());
       HttpMethod method = request.method();
       String uri = request.uri();
       if (username != null) {
         String auth = request.getHeader("Proxy-Authorization");
         String expected = "Basic " + Base64.getEncoder().encodeToString((username + ":" + username).getBytes());
         if (auth == null || !auth.equals(expected)) {
-          log.debug("auth failed "+auth+"/"+expected);
           request.response().setStatusCode(407).end("proxy authentication failed");
           return;
         }
@@ -80,7 +76,6 @@ public class ConnectHttpProxy extends TestProxyBase {
           request.response().setStatusCode(403).end("invalid request");
         } else {
           lastUri = uri;
-          log.info("uri: " + uri);
           if (forceUri != null) {
             uri = forceUri;
           }
@@ -110,7 +105,6 @@ public class ConnectHttpProxy extends TestProxyBase {
               Pump.pump(serverSocket, clientSocket).start();
               Pump.pump(clientSocket, serverSocket).start();
             } else {
-              log.debug("connect() failed", result.cause());
               request.response().setStatusCode(403).end("request failed");
             }
           });
@@ -131,7 +125,6 @@ public class ConnectHttpProxy extends TestProxyBase {
             clientRequest.putHeader(name, request.headers().getAll(name));
           }
         }
-        log.debug("client request headers " + clientRequest.headers().toString());
         clientRequest.exceptionHandler(e -> {
           log.debug("exception", e);
           int status;

--- a/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
+++ b/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
@@ -1,9 +1,13 @@
 package io.vertx.test.core;
 
+import java.net.UnknownHostException;
 import java.util.Base64;
 
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -56,49 +60,91 @@ public class ConnectHttpProxy extends TestProxyBase {
     options.setHost("localhost").setPort(PORT);
     server = vertx.createHttpServer(options);
     server.requestHandler(request -> {
+      log.debug("request "+request.absoluteURI());
+      log.debug("headers "+new CaseInsensitiveHeaders().addAll(request.headers()).toString());
       HttpMethod method = request.method();
       String uri = request.uri();
-      if (username  != null) {
+      if (username != null) {
         String auth = request.getHeader("Proxy-Authorization");
         String expected = "Basic " + Base64.getEncoder().encodeToString((username + ":" + username).getBytes());
         if (auth == null || !auth.equals(expected)) {
+          log.debug("auth failed "+auth+"/"+expected);
           request.response().setStatusCode(407).end("proxy authentication failed");
           return;
         }
       }
       if (error != 0) {
         request.response().setStatusCode(error).end("proxy request failed");
-      } else if (method != HttpMethod.CONNECT || !uri.contains(":")) {
-        request.response().setStatusCode(405).end("method not allowed");
-      } else {
-        lastUri = uri;
-        if (forceUri != null) {
-          uri = forceUri;
-        }
-        String[] split = uri.split(":");
-        String host = split[0];
-        int port;
-        try {
-          port = Integer.parseInt(split[1]);
-        } catch (NumberFormatException ex) {
-          port = 443;
-        }
-        NetSocket serverSocket = request.netSocket();
-        NetClientOptions netOptions = new NetClientOptions();
-        NetClient netClient = vertx.createNetClient(netOptions);
-        netClient.connect(port, host, result -> {
-          if (result.succeeded()) {
-            NetSocket clientSocket = result.result();
-            serverSocket.write("HTTP/1.0 200 Connection established\n\n");
-            serverSocket.closeHandler(v -> clientSocket.close());
-            clientSocket.closeHandler(v -> serverSocket.close());
-            Pump.pump(serverSocket, clientSocket).start();
-            Pump.pump(clientSocket, serverSocket).start();
-          } else {
-            log.error("connect() failed", result.cause());
-            request.response().setStatusCode(403).end("request failed");
+      } else if (method == HttpMethod.CONNECT) {
+        if (!uri.contains(":")) {
+          request.response().setStatusCode(403).end("invalid request");
+        } else {
+          lastUri = uri;
+          log.info("uri: " + uri);
+          if (forceUri != null) {
+            uri = forceUri;
           }
+          String[] split = uri.split(":");
+          String host = split[0];
+          int port;
+          try {
+            port = Integer.parseInt(split[1]);
+          } catch (NumberFormatException ex) {
+            port = 443;
+          }
+          // deny ports not considered safe to connect
+          // this will deny access to e.g. smtp port 25 to avoid spammers
+          if (port == 8080 || port < 1024 && port != 443) {
+            request.response().setStatusCode(403).end("access to port denied");
+            return;
+          }
+          NetSocket serverSocket = request.netSocket();
+          NetClientOptions netOptions = new NetClientOptions();
+          NetClient netClient = vertx.createNetClient(netOptions);
+          netClient.connect(port, host, result -> {
+            if (result.succeeded()) {
+              NetSocket clientSocket = result.result();
+              serverSocket.write("HTTP/1.0 200 Connection established\n\n");
+              serverSocket.closeHandler(v -> clientSocket.close());
+              clientSocket.closeHandler(v -> serverSocket.close());
+              Pump.pump(serverSocket, clientSocket).start();
+              Pump.pump(clientSocket, serverSocket).start();
+            } else {
+              log.debug("connect() failed", result.cause());
+              request.response().setStatusCode(403).end("request failed");
+            }
+          });
+        }
+      } else if (method == HttpMethod.GET) {
+        lastUri = request.uri();
+        HttpClient client = vertx.createHttpClient();
+        HttpClientRequest clientRequest = client.getAbs(request.uri(), resp -> {
+          for (String name : resp.headers().names()) {
+            request.response().putHeader(name, resp.headers().getAll(name));
+          }
+          resp.bodyHandler(body -> {
+            request.response().end(body);
+          });
         });
+        for (String name : request.headers().names()) {
+          if (!name.equals("Proxy-Authorization")) {
+            clientRequest.putHeader(name, request.headers().getAll(name));
+          }
+        }
+        log.debug("client request headers " + clientRequest.headers().toString());
+        clientRequest.exceptionHandler(e -> {
+          log.debug("exception", e);
+          int status;
+          if (e instanceof UnknownHostException) {
+            status = 504;
+          } else {
+            status = 400;
+          }
+          request.response().setStatusCode(status).end(e.toString()+" on client request");
+        });
+        clientRequest.end();
+      } else {
+        request.response().setStatusCode(405).end("method not supported");
       }
     });
     server.listen(server -> {
@@ -125,7 +171,7 @@ public class ConnectHttpProxy extends TestProxyBase {
   }
 
   public ConnectHttpProxy setError(int error) {
-    this.error  = error;
+    this.error = error;
     return this;
   }
 }

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -2459,4 +2459,50 @@ public class Http1xTest extends HttpTest {
     req.sendHead();
     await();
   }
+
+  @Test
+  public void testHttpProxyRequest() throws Exception {
+    startProxy(null, ProxyType.HTTP);
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions()
+        .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP).setHost("localhost").setPort(proxy.getPort())));
+
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+
+    server.listen(onSuccess(s -> {
+      client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/", resp -> {
+        assertEquals(200, resp.statusCode());
+        assertNotNull("request did not go through proxy", proxy.getLastUri());
+        testComplete();
+      }).exceptionHandler(th -> fail(th)).end();
+    }));
+    await();
+  }
+
+  @Test
+  public void testHttpProxyRequestAuth() throws Exception {
+    startProxy("user", ProxyType.HTTP);
+
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions()
+        .setProxyOptions(new ProxyOptions().setType(ProxyType.HTTP).setHost("localhost").setPort(proxy.getPort())
+            .setUsername("user").setPassword("user")));
+
+    server.requestHandler(req -> {
+      req.response().end();
+    });
+
+    server.listen(onSuccess(s -> {
+      client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/", resp -> {
+        assertEquals(200, resp.statusCode());
+        assertNotNull("request did not go through proxy", proxy.getLastUri());
+        testComplete();
+      }).exceptionHandler(th -> fail(th)).end();
+    }));
+    await();
+  }
+
 }

--- a/src/test/java/io/vertx/test/core/HttpTLSTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTLSTest.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -40,7 +39,6 @@ public abstract class HttpTLSTest extends HttpTestBase {
 
   @Rule
   public TemporaryFolder testFolder = new TemporaryFolder();
-  private TestProxyBase proxy;
 
   @Override
   protected void tearDown() throws Exception {
@@ -48,17 +46,6 @@ public abstract class HttpTLSTest extends HttpTestBase {
       proxy.stop();
     }
     super.tearDown();
-  }
-
-  private void startProxy(String username, ProxyType proxyType) throws InterruptedException {
-    CountDownLatch latch = new CountDownLatch(1);
-    if (proxyType == ProxyType.HTTP) {
-      proxy = new ConnectHttpProxy(username);
-    } else {
-      proxy = new SocksProxy(username);
-    }
-    proxy.start(vertx, v -> latch.countDown());
-    awaitLatch(latch);
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/HttpTestBase.java
+++ b/src/test/java/io/vertx/test/core/HttpTestBase.java
@@ -21,6 +21,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.net.ProxyType;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -39,6 +40,7 @@ public class HttpTestBase extends VertxTestBase {
 
   protected HttpServer server;
   protected HttpClient client;
+  protected TestProxyBase proxy;
 
   public void setUp() throws Exception {
     super.setUp();
@@ -61,6 +63,9 @@ public class HttpTestBase extends VertxTestBase {
       });
       awaitLatch(latch);
     }
+    if (proxy != null) {
+      proxy.stop();
+    }
     super.tearDown();
   }
 
@@ -81,6 +86,17 @@ public class HttpTestBase extends VertxTestBase {
     context.runOnContext(v -> {
       server.listen(onSuccess(s -> latch.countDown()));
     });
+    awaitLatch(latch);
+  }
+
+  protected void startProxy(String username, ProxyType proxyType) throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(1);
+    if (proxyType == ProxyType.HTTP) {
+      proxy = new ConnectHttpProxy(username);
+    } else {
+      proxy = new SocksProxy(username);
+    }
+    proxy.start(vertx, v -> latch.countDown());
     awaitLatch(latch);
   }
 }

--- a/src/test/java/io/vertx/test/core/ProxyErrorTest.java
+++ b/src/test/java/io/vertx/test/core/ProxyErrorTest.java
@@ -4,22 +4,30 @@ import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
 
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.test.core.ConnectHttpProxy;
 import io.vertx.test.core.VertxTestBase;
 
 /**
+ * Test all kinds of errors raised by the proxy
+ *
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  *
  */
 public class ProxyErrorTest extends VertxTestBase {
 
+  private static final Logger log = LoggerFactory.getLogger(ProxyErrorTest.class);
+
   private ConnectHttpProxy proxy = null;
 
-  // we don't start a https server, due to the error, it will not be queried 
+  // we don't start http/https servers, due to the error, they will not be queried
 
   private void startProxy(int error, String username) throws InterruptedException {
     CountDownLatch latch = new CountDownLatch(1);
@@ -38,63 +46,71 @@ public class ProxyErrorTest extends VertxTestBase {
   }
 
   @Test
+  public void testProxyHttpsError() throws Exception {
+    expectProxyException(403, null, "https://localhost/");
+  }
+
+  @Test
+  public void testProxyHttpsAuthFail() throws Exception {
+    expectProxyException(0, "user", "https://localhost/");
+  }
+
+  @Test
+  public void testProxyHttpsHostUnknown() throws Exception {
+    expectProxyException(0, null, "https://unknown.hostname/");
+  }
+
+  @Test
   public void testProxyError() throws Exception {
-    startProxy(403, null);
-
-    final HttpClientOptions options = new HttpClientOptions()
-        .setProxyOptions(new ProxyOptions()
-            .setType(ProxyType.HTTP)
-            .setHost("localhost")
-            .setPort(proxy.getPort()));
-    HttpClient client = vertx.createHttpClient(options);
-
-    client.getAbs("https://localhost/", resp -> {
-      // request is supposed to fail
-      fail();
-    })
-    .exceptionHandler(e -> testComplete())
-    .end();
-
-    await();
+    expectStatusError(403, 403, null, "http://localhost/");
   }
 
   @Test
   public void testProxyAuthFail() throws Exception {
-    startProxy(0, "user");
-
-    final HttpClientOptions options = new HttpClientOptions()
-        .setProxyOptions(new ProxyOptions()
-            .setType(ProxyType.HTTP)
-            .setHost("localhost")
-            .setPort(proxy.getPort()));
-    HttpClient client = vertx.createHttpClient(options);
-
-    client.getAbs("https://localhost/", resp -> {
-      // request is supposed to fail
-      fail();
-    })
-    .exceptionHandler(e -> testComplete())
-    .end();
-
-    await();
+    expectStatusError(0, 407, "user", "http://localhost/");
   }
 
   @Test
   public void testProxyHostUnknown() throws Exception {
-    startProxy(0, null);
+    expectStatusError(0, 504, null, "http://unknown.hostname/");
+  }
+
+  // we expect the request to fail with a ProxyConnectException if we use https
+  // so we fail the test when it succeeds
+  private void expectProxyException(int error, String username, String url) throws Exception {
+    proxyTest(error, username, url, resp -> {
+      log.info("request is supposed to fail but response is " + resp.statusCode() + " " + resp.statusMessage());
+      fail("request is supposed to fail");
+    }, true);
+  }
+
+  // we expect the request to fail with a http status error if we use http (behaviour is similar to Squid)
+  private void expectStatusError(int error, int responseStatus, String username, String url) throws Exception {
+    proxyTest(error, username, url, resp -> {
+      assertEquals(responseStatus, resp.statusCode());
+      testComplete();
+    }, false);
+  }
+
+  private void proxyTest(int error, String username, String url, Handler<HttpClientResponse> assertResponse, boolean completeOnException) throws Exception {
+    startProxy(error, username);
 
     final HttpClientOptions options = new HttpClientOptions()
+        .setSsl(url.startsWith("https"))
         .setProxyOptions(new ProxyOptions()
             .setType(ProxyType.HTTP)
             .setHost("localhost")
             .setPort(proxy.getPort()));
     HttpClient client = vertx.createHttpClient(options);
 
-    client.getAbs("https://unknown.hostname/", resp -> {
-      // request is supposed to fail
-      fail();
+    client.getAbs(url, assertResponse)
+    .exceptionHandler(e -> {
+      if (completeOnException) {
+        testComplete(); 
+      } else {
+        fail(e);
+      }
     })
-    .exceptionHandler(e -> testComplete())
     .end();
 
     await();


### PR DESCRIPTION
fixes #1498

Squash commits into new branch:

Implement http proxy requests, add unit test, add support for GET proxy requests
to ConnectHttpProxy

fix ProxyErrorTest which was missing setSsl(true)

add tests for proxy errors for http, refactor the ProxyError tests a bit
handle DNS errors in Proxy for GET properly

add ProxyAuthentication to http proxy proxy requests

change test support methods to private, remove one unused method, clarify comments a bit
