### PR TITLE
test for #1511 Proxying - Host header not formed properly

### DIFF
--- a/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
+++ b/src/test/java/io/vertx/test/core/ConnectHttpProxy.java
@@ -3,6 +3,7 @@ package io.vertx.test.core;
 import java.util.Base64;
 
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
@@ -37,6 +38,16 @@ public class ConnectHttpProxy extends TestProxyBase {
   private HttpServer server;
 
   private int error = 0;
+
+  private MultiMap lastRequestHeaders = null;
+
+  /**
+   * @return the lastRequestHeaders
+   */
+  @Override
+  public MultiMap getLastRequestHeaders() {
+    return lastRequestHeaders;
+  }
 
   public ConnectHttpProxy(String username) {
     super(username);
@@ -75,6 +86,7 @@ public class ConnectHttpProxy extends TestProxyBase {
         if (forceUri != null) {
           uri = forceUri;
         }
+        lastRequestHeaders = MultiMap.caseInsensitiveMultiMap().addAll(request.headers());
         String[] split = uri.split(":");
         String host = split[0];
         int port;

--- a/src/test/java/io/vertx/test/core/HttpTLSTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTLSTest.java
@@ -755,6 +755,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
     testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy().pass();
     assertNotNull("connection didn't access the proxy", proxy.getLastUri());
     assertEquals("hostname resolved but it shouldn't be", "localhost:4043", proxy.getLastUri());
+    assertEquals("Host header doesn't contain target host", "localhost:4043", proxy.getLastRequestHeaders().get("Host"));
   }
 
   @Test
@@ -771,6 +772,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
     testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy().useProxyAuth().pass();
     assertNotNull("connection didn't access the proxy", proxy.getLastUri());
     assertEquals("hostname resolved but it shouldn't be", "localhost:4043", proxy.getLastUri());
+    assertEquals("Host header doesn't contain target host", "localhost:4043", proxy.getLastRequestHeaders().get("Host"));
   }
 
   @Test
@@ -780,10 +782,11 @@ public abstract class HttpTLSTest extends HttpTestBase {
   public void testHttpsProxyUnknownHost() throws Exception {
     startProxy(null, ProxyType.HTTP);
     proxy.setForceUri("localhost:4043");
-    testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy().useProxyAuth()
+    testTLS(TLSCert.NONE, TLSCert.JKS, TLSCert.JKS, TLSCert.NONE).useProxy()
         .connectHostname("doesnt-resolve.host-name").clientTrustAll().clientVerifyHost(false).pass();
     assertNotNull("connection didn't access the proxy", proxy.getLastUri());
     assertEquals("hostname resolved but it shouldn't be", "doesnt-resolve.host-name:4043", proxy.getLastUri());
+    assertEquals("Host header doesn't contain target host", "doesnt-resolve.host-name:4043", proxy.getLastRequestHeaders().get("Host"));
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/TestProxyBase.java
+++ b/src/test/java/io/vertx/test/core/TestProxyBase.java
@@ -4,6 +4,7 @@
 package io.vertx.test.core;
 
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 
 /**
@@ -35,6 +36,10 @@ public abstract class TestProxyBase {
    */
   public void setForceUri(String uri) {
     forceUri = uri;
+  }
+
+  public MultiMap getLastRequestHeaders() {
+    throw new UnsupportedOperationException();
   }
 
   public abstract int getPort();


### PR DESCRIPTION
test that proxy connect requests have the Host header set to the target host, not the the proxy host

issue was fixed in netty, this is only the unit test for it.

Signed-off-by: alexlehm <alexlehm@gmail.com>