### PR TITLE
Added Json#decodeValue with generic types support

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -18,6 +18,7 @@ package io.vertx.core.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -77,8 +78,15 @@ public class Json {
   public static <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
     try {
       return mapper.readValue(str, clazz);
+    } catch (Exception e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage());
     }
-    catch (Exception e) {
+  }
+
+  public static <T> T decodeValue(String str, TypeReference<T> type) throws DecodeException {
+    try {
+      return mapper.readValue(str, type);
+    } catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage());
     }
   }

--- a/src/test/java/io/vertx/test/core/JsonMapperTest.java
+++ b/src/test/java/io/vertx/test/core/JsonMapperTest.java
@@ -16,9 +16,15 @@
 
 package io.vertx.test.core;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.json.Json;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -43,5 +49,27 @@ public class JsonMapperTest extends VertxTestBase {
     Json.prettyMapper = newMapper;
     assertSame(newMapper, Json.prettyMapper);
     Json.prettyMapper = mapper;
+  }
+
+  @Test
+  public void testGenericDecoding() {
+    Pojo original = new Pojo();
+    original.value = "test";
+
+    String json = Json.encode(Collections.singletonList(original));
+
+    List<Pojo> correct = Json.decodeValue(json, new TypeReference<List<Pojo>>() {});
+    assertTrue(((List)correct).get(0) instanceof Pojo);
+    assertEquals(original.value, correct.get(0).value);
+
+    List incorrect = Json.decodeValue(json, List.class);
+    assertFalse(incorrect.get(0) instanceof Pojo);
+    assertTrue(incorrect.get(0) instanceof Map);
+    assertEquals(original.value, ((Map)(incorrect.get(0))).get("value"));
+  }
+
+  private static class Pojo {
+    @JsonProperty
+    String value;
   }
 }


### PR DESCRIPTION
See also #539

Usage:

``` java
Map<String, List<String>> map = Json.decodeValue(str, new TypeReference<Map<String, List<String>>(){});
```

Signed-off-by: Konstantin Gribov grossws@gmail.com
