### PR TITLE
Find Jackson modules from SPI and register in Json

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -19,6 +19,7 @@ package io.vertx.core.json;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -50,6 +51,14 @@ public class Json {
 
     prettyMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
     prettyMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+
+    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+    if (cl == null) {
+      cl = Json.class.getClassLoader();
+    }
+    List<Module> modules = ObjectMapper.findModules(cl);
+    mapper.registerModules(modules);
+    prettyMapper.registerModules(modules);
 
     SimpleModule module = new SimpleModule();
     module.addSerializer(JsonObject.class, new JsonObjectSerializer());


### PR DESCRIPTION
Use jackson SPI for modules to find and register them in `Json#mapper` and `Json#prettyMapper`. This allows user to add things like `com.fasterxml.jackson.datatype:jackson-datatype-guava` or `com.fasterxml.jackson.module:jackson-module-jaxb-annotations` to classpath and get serializers/deserializers/introspectors/etc available from `Json`. 

Currently `Json#decodeValue` fails on things like guava types and `mapper`/`prettyMapper` customization is quite inconvenient.

Related to #1558

Signed-off-by: Konstantin Gribov grossws@gmail.com
