### PR TITLE
better logging when eventbus failed

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -57,6 +57,7 @@ class ConnectionHolder {
       if (res.succeeded()) {
         connected(res.result());
       } else {
+    	log.warn("Cannot connect to "+serverID, res.cause());
         close();
       }
     });


### PR DESCRIPTION
Currently exception is "eaten" when event bus connecting to another node in cluster failed and is no way to find error reason without remote debuggging of application. This makes it very difficult to find bugs like #1525 or configuration and network problems. It's very annoying, so i suggest to log it. if you're not interested, you can disable login for class ConnectionHolder by configuration (although I do not know why).
