### PR TITLE
Fixes #1573 Blocked thread warning when opening or closing an AsyncFile

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -2032,15 +2032,18 @@ The `link:../../apidocs/io/vertx/core/http/WebSocket.html[WebSocket]` instance i
 When using a WebSocket as a write stream or a read stream it can only be used with WebSockets connections that are
 used with binary frames that are no split over multiple frames.
 
-=== Using a proxy for HTTPS connections
+=== Using a proxy for HTTP/HTTPS connections
 
-The http client supports accessing https servers via a HTTPS proxy (HTTP/1.x _CONNECT_ method, e.g. Squid) or
-_SOCKS4a_ or _SOCKS5_ proxy. The http proxy protocol uses HTTP/1.x but can connect to HTTP/1.x and HTTP/2 servers.
+The http client supports accessing http/https URLs via a HTTP proxy (e.g. Squid) or _SOCKS4a_ or _SOCKS5_ proxy.
+The CONNECT protocol uses HTTP/1.x but can connect to HTTP/1.x and HTTP/2 servers.
+
+Connecting to h2c (unencrypted HTTP/2 servers) is likely not supported by http proxies since they will support
+HTTP/1.1 only.
 
 The proxy can be configured in the `link:../../apidocs/io/vertx/core/http/HttpClientOptions.html[HttpClientOptions]` by setting a
 `link:../../apidocs/io/vertx/core/net/ProxyOptions.html[ProxyOptions]` object containing proxy type, hostname, port and optionally username and password.
 
-Here's an example:
+Here's an example of using an HTTP proxy:
 
 [source,java]
 ----
@@ -2050,7 +2053,14 @@ HttpClientOptions options = new HttpClientOptions()
         .setUsername("username").setPassword("secret"));
 HttpClient client = vertx.createHttpClient(options);
 ----
-or using SOCKS5 proxy
+
+When the client connects to an http URL, it connects to the proxy server and provides the full URL in the
+HTTP request ("GET http://www.somehost.com/path/file.html HTTP/1.1").
+
+When the client connects to an https URL, it asks the proxy to create a tunnel to the remote host with
+the CONNECT method.
+
+For a SOCKS5 proxy:
 
 [source,java]
 ----
@@ -2063,18 +2073,6 @@ HttpClient client = vertx.createHttpClient(options);
 
 The DNS resolution is always done on the proxy server, to achieve the functionality of a SOCKS4 client, it is necessary
 to resolve the DNS address locally.
-
-Please note: When using `link:../../apidocs/io/vertx/core/net/ProxyType.html#HTTP[HTTP]` currently http requests are sent as CONNECT requests to the proxy, which will almost
-certainly not work since a properly configured proxy will deny connections to non-secure ports.
-
-This feature will be implemented differently in next version, allowing for a normal proxy request for non-http requests 
-
-As a workaround, a http proxy request can be executed like this:
-
-[source,java]
-----
-client.get(80, "the-proxy", "http://www.google.com", resp -> {});
-----
 
 === Automatic clean-up in verticles
 

--- a/src/main/asciidoc/java/net.adoc
+++ b/src/main/asciidoc/java/net.adoc
@@ -925,9 +925,6 @@ OpenSSL requires to configure `link:../../apidocs/io/vertx/core/net/TCPSSLOption
 and use http://netty.io/wiki/forked-tomcat-native.html[netty-tcnative] jar on the classpath. Using tcnative may require
 OpenSSL to be installed on your OS depending on the tcnative implementation.
 
-OpenSSL restricts the key/certificate configuration to `.pem` files. However it is still possible to use any trust
-configuration.
-
 ===== Jetty-ALPN support
 
 Jetty-ALPN is a small jar that overrides a few classes of Java 8 distribution to support ALPN.

--- a/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/AsyncFileImpl.java
@@ -460,18 +460,14 @@ public class AsyncFileImpl implements AsyncFile {
 
   private void doClose(Handler<AsyncResult<Void>> handler) {
     ContextImpl handlerContext = vertx.getOrCreateContext();
-    context.executeBlocking((Future<Void> res) -> {
+    handlerContext.executeBlocking(res -> {
       try {
         ch.close();
         res.complete(null);
       } catch (IOException e) {
         res.fail(e);
       }
-    }, ar -> {
-      if (handler != null) {
-        handlerContext.runOnContext(v -> handler.handle(ar));
-      }
-    });
+    }, handler);
   }
 
   private synchronized void closeInternal(Handler<AsyncResult<Void>> handler) {

--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -25,9 +25,9 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.FileSystemException;
 import io.vertx.core.file.FileSystemProps;
 import io.vertx.core.file.OpenOptions;
+import io.vertx.core.impl.Action;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.impl.Action;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -733,8 +733,8 @@ public class FileSystemImpl implements FileSystem {
     Objects.requireNonNull(p);
     Objects.requireNonNull(options);
     return new BlockingAction<AsyncFile>(handler) {
-      String path = vertx.resolveFile(p).getAbsolutePath();
       public AsyncFile perform() {
+        String path = vertx.resolveFile(p).getAbsolutePath();
         return doOpen(path, options, context);
       }
     };


### PR DESCRIPTION
Resolving a file is a blocking operation. When creating path as a field, the value is computed when the anonymous class is created (wrong thread), not when the blocking action is executed.

AsyncFileChannel#close operation is also blocking and must executed on a worker thread.
