### PR TITLE
SharedDataImpl: Use computeIfAbsent to atomically get-or-create objects

### DIFF
--- a/src/main/java/io/vertx/core/shareddata/impl/LocalMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalMapImpl.java
@@ -33,11 +33,11 @@ import static io.vertx.core.shareddata.impl.Checker.*;
  */
 class LocalMapImpl<K, V> implements LocalMap<K, V> {
 
-  private final ConcurrentMap<Object, LocalMap<?, ?>> maps;
+  private final ConcurrentMap<String, LocalMap<?, ?>> maps;
   private final String name;
   private final ConcurrentMap<K, V> map = new ConcurrentHashMap<>();
 
-  LocalMapImpl(String name, ConcurrentMap<Object, LocalMap<?, ?>> maps) {
+  LocalMapImpl(String name, ConcurrentMap<String, LocalMap<?, ?>> maps) {
     this.name = name;
     this.maps = maps;
   }


### PR DESCRIPTION
* Adjust LocalMapImpl ctor and SharedDataImpl.localMaps such that the key parameter of the latter is a String

* Use computeIfAbsent for all getLocalXXX implementations. This avoids the overhead associated with creating a speculative object for use as an arg in putIfAbsent, while retaining operation atomicity. This implementation is also more concise