### PR TITLE
always remove subs when removing node in clusterMap

### DIFF
--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -281,7 +281,9 @@ public class HAManager {
 
       for (Map.Entry<String, String> entry: clusterMap.entrySet()) {
         if (!leftNodeID.equals(entry.getKey()) && !nodes.contains(entry.getKey())) {
-          checkFailover(entry.getKey(), new JsonObject(entry.getValue()));
+          JsonObject haInfo = new JsonObject(entry.getValue());
+          checkRemoveSubs(entry.getKey(), haInfo);
+          checkFailover(entry.getKey(), haInfo);
         }
       }
     }


### PR DESCRIPTION
When killing multiple nodes with kill -9, all registered message consumers for the killed nodes aren't removed from the distributes subs map.

Further information is in this issue:
https://github.com/vert-x3/vertx-hazelcast/issues/13

Signed-off-by: pontushellgren <phellgren@gmail.com>