### PR TITLE
Implement High Fault Tolerance: Vertx Cluster is fault tolerant when several nodes are killed

### DIFF
--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -114,6 +114,16 @@ public class VertxOptions {
   public static final boolean DEFAULT_HA_ENABLED = false;
 
   /**
+   * The default value of HFT enabled = false
+   */
+  public static final boolean DEFAULT_HFT_ENABLED = false;
+  
+  /**
+   * The default value of the HFT messages when HFT is enabled, in millis
+   */
+  public static final long DEFAULT_HFT_INTERVAL = 10000;
+
+  /**
    * The default value of warning exception time 5000000000 ns (5 seconds)
    * If a thread is blocked longer than this threshold, the warning log
    * contains a stack trace
@@ -523,6 +533,48 @@ public class VertxOptions {
    */
   public VertxOptions setHAEnabled(boolean haEnabled) {
     this.haEnabled = haEnabled;
+    return this;
+  }
+  
+  /**
+   * Will HFT (High Fault Tolerance) be enabled on the Vert.x instance?
+   *
+   * @return true if HFT enabled, false otherwise
+   */
+  public boolean isHFTEnabled() {
+    return eventBusOptions.isHFTEnabled();
+  }
+  
+  /**
+   * Set whether HFT (High Fault Tolerance) will be enabled on the Vert.x instance.
+   *
+   * @param hftEnabled true if enabled, false if not.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setHFTEnabled(boolean hftEnabled) {
+	  eventBusOptions.setHFTEnabled(hftEnabled);
+	  return this;
+  }
+  
+  /**
+   * Get the value of cluster HFT (High Fault Tolerance) messages interval, in ms.
+   * <p>
+   * In order to guarantee consistency of vertx internal maps (HFT enabled), cluster map and subscribers map need to be constantly resynchronized, at each interval
+   *
+   * @return the value of cluster ping reply interval
+   */
+  public long getHFTInterval() {
+	  return eventBusOptions.getHFTInterval();
+  }
+  
+  /**
+   * When HFT (High Fault Tolerance) is enabled, set the interval between internal vertx synchronization
+   *
+   * @param hftInterval interval in miliis
+   * @return a reference to this, so the API can be used fluently
+   */
+  public VertxOptions setHFTInterval(long hftInterval) {
+    eventBusOptions.setHFTInterval(hftInterval);
     return this;
   }
 

--- a/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/EventBusOptions.java
@@ -37,6 +37,8 @@ public class EventBusOptions extends TCPSSLOptions {
   private int clusterPublicPort = VertxOptions.DEFAULT_CLUSTER_PUBLIC_PORT;
   private long clusterPingInterval = VertxOptions.DEFAULT_CLUSTER_PING_INTERVAL;
   private long clusterPingReplyInterval = VertxOptions.DEFAULT_CLUSTER_PING_REPLY_INTERVAL;
+  private boolean hftEnabled = VertxOptions.DEFAULT_HFT_ENABLED;
+  private long hftInterval = VertxOptions.DEFAULT_HFT_INTERVAL;
 
   // Attributes used to configure the server of the event bus when the event bus is clustered.
 
@@ -126,6 +128,9 @@ public class EventBusOptions extends TCPSSLOptions {
     this.clusterPublicPort = other.clusterPublicPort;
     this.clusterPingInterval = other.clusterPingInterval;
     this.clusterPingReplyInterval = other.clusterPingReplyInterval;
+    
+    this.hftEnabled = other.hftEnabled;
+    this.hftInterval = other.hftInterval;
 
     this.port = other.port;
     this.host = other.host;
@@ -579,6 +584,48 @@ public class EventBusOptions extends TCPSSLOptions {
       throw new IllegalArgumentException("clusterPublicPort p must be in range 0 <= p <= 65535");
     }
     this.clusterPublicPort = clusterPublicPort;
+    return this;
+  }
+
+  /**
+   * Will HFT (High Fault Tolerance) be enabled on the Vert.x instance?
+   *
+   * @return true if HFT enabled, false otherwise
+   */
+  public boolean isHFTEnabled() {
+    return hftEnabled;
+  }
+  
+  /**
+   * Set whether HFT (High Fault Tolerance) will be enabled on the Vert.x instance.
+   *
+   * @param hftEnabled true if enabled, false if not.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EventBusOptions setHFTEnabled(boolean hftEnabled) {
+    this.hftEnabled = hftEnabled;
+    return this;
+  }
+  
+  /**
+   * Get the value of cluster HFT (High Fault Tolerance) messages interval, in ms.
+   * <p>
+   * In order to guarantee consistency of vertx internal maps (HFT enabled), cluster map and subscribers map need to be constantly resynchronized, at each interval
+   *
+   * @return the value of cluster ping reply interval
+   */
+  public long getHFTInterval() {
+	  return hftInterval;
+  }
+  
+  /**
+   * When HFT (High Fault Tolerance) is enabled, set the interval between internal vertx synchronization
+   *
+   * @param hftInterval interval in miliis
+   * @return a reference to this, so the API can be used fluently
+   */
+  public EventBusOptions setHFTInterval(long hftInterval) {
+    this.hftInterval = hftInterval;
     return this;
   }
 }

--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -16,19 +16,28 @@
 
 package io.vertx.core.impl;
 
-import io.vertx.core.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.AsyncResultHandler;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
+import io.vertx.core.VertxException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeListener;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  *
@@ -98,6 +107,7 @@ public class HAManager {
 
   private static final String CLUSTER_MAP_NAME = "__vertx.haInfo";
   private static final long QUORUM_CHECK_PERIOD = 1000;
+  private static final int HFT_CLUSTER_MAP_SNAPSHOTS = 3;
 
   private final VertxInternal vertx;
   private final DeploymentManager deploymentManager;
@@ -111,6 +121,9 @@ public class HAManager {
   private final boolean enabled;
 
   private long quorumTimerID;
+  private SnapshotsClusterMap snapshotClusterMap;
+  private boolean hftEnabled;
+  private long hftInterval;
   private volatile boolean attainedQuorum;
   private volatile FailoverCompleteHandler failoverCompleteHandler;
   private volatile FailoverCompleteHandler nodeCrashedHandler;
@@ -119,7 +132,7 @@ public class HAManager {
   private volatile boolean killed;
 
   public HAManager(VertxInternal vertx, DeploymentManager deploymentManager,
-                   ClusterManager clusterManager, int quorumSize, String group, boolean enabled) {
+                   ClusterManager clusterManager, int quorumSize, String group, boolean enabled, boolean hftEnabled, long hftInterval) {
     this.vertx = vertx;
     this.deploymentManager = deploymentManager;
     this.clusterManager = clusterManager;
@@ -144,6 +157,19 @@ public class HAManager {
     });
     clusterMap.put(nodeID, haInfo.encode());
     quorumTimerID = vertx.setPeriodic(QUORUM_CHECK_PERIOD, tid -> checkHADeployments());
+    
+    this.hftEnabled = hftEnabled;
+    this.hftInterval = hftInterval;
+    if (hftEnabled) {
+	    snapshotClusterMap = new SnapshotsClusterMap(vertx, () -> {
+			final Map<String, String> freshClusterMap = new HashMap<String, String>();
+	    	for (Map.Entry<String, String> entry: clusterMap.entrySet()) {
+	    		freshClusterMap.put(entry.getKey(), entry.getValue());
+	        }
+	    	return freshClusterMap;
+	    }, HFT_CLUSTER_MAP_SNAPSHOTS, hftInterval);
+    }
+    
     // Call check quorum to compute whether we have an initial quorum
     synchronized (this) {
       checkQuorum();
@@ -173,7 +199,20 @@ public class HAManager {
   public void addDataToAHAInfo(String key, JsonObject value) {
     synchronized (haInfo) {
       haInfo.put(key, value);
-      clusterMap.put(nodeID, haInfo.encode());
+      final String encoded = haInfo.encode();
+      clusterMap.put(nodeID, encoded);
+      
+      if (hftEnabled) {
+    	  // Honor the High Fault Tolerance: put in clusterMap at every HFTInterval the description of this node
+    	  vertx.setPeriodic(hftInterval, handler -> {
+    		  vertx.executeBlocking(blocking -> {
+    			  try {
+        			  clusterMap.put(nodeID, encoded);
+        		  } catch (final Throwable t) {
+        		  }
+    		  }, r -> {});
+    	  });
+      }
     }
   }
   // Deploy an HA verticle
@@ -260,13 +299,17 @@ public class HAManager {
   // A node has left the cluster
   // synchronize this in case the cluster manager is naughty and calls it concurrently
   private synchronized void nodeLeft(String leftNodeID) {
-
     checkQuorum();
     if (attainedQuorum) {
 
       // Check for failover
       String sclusterInfo = clusterMap.get(leftNodeID);
 
+      // If not found in current clusterMap, try to see if we can find it in previous snapshots
+      if (sclusterInfo == null && snapshotClusterMap != null) {
+    	  sclusterInfo = snapshotClusterMap.getValueFromAllSnapshots(leftNodeID);
+      }
+      
       if (sclusterInfo == null) {
         // Clean close - do nothing
       } else {
@@ -283,6 +326,17 @@ public class HAManager {
         if (!leftNodeID.equals(entry.getKey()) && !nodes.contains(entry.getKey())) {
           checkFailover(entry.getKey(), new JsonObject(entry.getValue()));
         }
+      }
+      
+      // make sure that previously seen server ids have been cleanup
+      if (snapshotClusterMap != null) {
+    	  for(final Map<String, String> snapshot : snapshotClusterMap.getAllSnapshots()) {
+    		  for (Map.Entry<String, String> entry: snapshot.entrySet()) {
+    			  if (!leftNodeID.equals(entry.getKey()) && !nodes.contains(entry.getKey())) {
+    				  checkFailover(entry.getKey(), new JsonObject(entry.getValue()));
+    			  }
+    		  }
+    	  }
       }
     }
   }
@@ -460,10 +514,8 @@ public class HAManager {
   }
 
   private void checkRemoveSubs(String failedNodeID, JsonObject theHAInfo) {
-    String chosen = chooseHashedNode(null, failedNodeID.hashCode());
-    if (chosen != null && chosen.equals(this.nodeID)) {
+	  // Each node need to callback the crash handler, and not only a specific node since it can crashes itself
       callFailoverCompleteHandler(nodeCrashedHandler, failedNodeID, theHAInfo, true);
-    }
   }
 
   private void callFailoverCompleteHandler(String nodeID, JsonObject haInfo, boolean result) {

--- a/src/main/java/io/vertx/core/impl/SnapshotsClusterMap.java
+++ b/src/main/java/io/vertx/core/impl/SnapshotsClusterMap.java
@@ -1,0 +1,85 @@
+package io.vertx.core.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Vertx;
+
+/**
+ * Thread Safe without any locks and blocking code, used to keep track of several old version of the ClusterMap<br>
+ * From the given size of the snapshot, we maintain internally an additional place for the new value processed and not already shift<br>
+ * It allows us to shit elemenbt
+ * @author lbuttigieg
+ *
+ */
+public final class SnapshotsClusterMap {
+	private final List<Map<String, String>> snapshots;
+	
+	@SuppressWarnings("unchecked")
+	public SnapshotsClusterMap(final Vertx vertx, final SnapshotsClusterMapLoader loader, final int snapshotsMaxCount, final long loaderCallDelayInMillis) {
+		this.snapshots = new ArrayList<>(snapshotsMaxCount + 1);
+		
+		// Add a supplementary space for temporary updates
+		for(int c = 0; c < snapshotsMaxCount + 1; c++) {
+			this.snapshots.add(null);
+		}
+		
+		final AtomicInteger fillCount = new AtomicInteger();
+		
+		vertx.setPeriodic(loaderCallDelayInMillis, h -> {
+			vertx.executeBlocking(blocking -> {
+				Map<String, String> map = null;
+				try {
+					map = loader.get();
+				} catch (final Throwable t) {
+				}
+				blocking.complete(map);
+  		    }, r -> {
+  		    	final Map<String, String> map = (Map<String, String>)r.result();
+  		    	if (map == null) return;
+
+  				// Not full
+  				if (fillCount.get() < snapshotsMaxCount) {
+  					this.snapshots.set(fillCount.getAndIncrement(), map);
+  					return;
+  				}
+  				
+  				// Full
+  				this.snapshots.set(snapshots.size()-1, map);
+  				for(int c = 0; c < snapshots.size()-1; c++) {
+  					this.snapshots.set(c, this.snapshots.get(c+1));
+  				}
+  				this.snapshots.set(snapshots.size()-1, null);
+  		    });
+		});
+	}
+	
+	/**
+	 * Try to find and return the value associated with the top most fresh snapshot or {@code null}
+	 * @param key
+	 * @return the value associated with the top most fresh snapshot or {@code null}
+	 */
+	@Nullable
+	public String getValueFromAllSnapshots(final String key) {
+		for(int c = snapshots.size() - 1; c >= 0; c--) {
+			final Map<String, String> map = this.snapshots.get(c);
+			if (map == null) continue;
+			final String value = map.get(key);
+			if (value != null) return value;
+		}
+		return null;
+	}
+	
+	public List<Map<String, String>> getAllSnapshots() {
+		final List<Map<String, String>> allSnapshots = new ArrayList<>(snapshots.size());
+		for(int c = snapshots.size() - 1; c >= 0; c--) {
+			final Map<String, String> map = this.snapshots.get(c);
+			if (map == null) continue;
+			allSnapshots.add(map);
+		}
+		return allSnapshots;
+	}
+}

--- a/src/main/java/io/vertx/core/impl/SnapshotsClusterMapLoader.java
+++ b/src/main/java/io/vertx/core/impl/SnapshotsClusterMapLoader.java
@@ -1,0 +1,8 @@
+package io.vertx.core.impl;
+
+import java.util.Map;
+
+@FunctionalInterface
+public interface SnapshotsClusterMapLoader {
+	Map<String, String> get();
+}

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -166,7 +166,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
           // Provide a memory barrier as we are setting from a different thread
           synchronized (VertxImpl.this) {
             haManager = new HAManager(this, deploymentManager, clusterManager, options.getQuorumSize(),
-                                      options.getHAGroup(), haEnabled);
+                                      options.getHAGroup(), haEnabled, options.isHFTEnabled(), options.getHFTInterval());
             createAndStartEventBus(options, resultHandler);
           }
         }

--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -123,6 +123,14 @@ public class BareCommand extends ClasspathHandler {
   public boolean getHA() {
     return true;
   }
+  
+  /**
+   * @return whether or not the vert.x instance should be launched in high fault tolerance mode. This
+   * implementation returns {@code true}.
+   */
+  public boolean getHft() {
+	return true;
+}
 
   /**
    * Starts the vert.x instance.
@@ -167,6 +175,9 @@ public class BareCommand extends ClasspathHandler {
         if (quorum != -1) {
           options.setQuorumSize(quorum);
         }
+      }
+      if (getHft()) {
+    	  options.setHFTEnabled(true);
       }
 
       create(options, ar -> {

--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -46,6 +46,7 @@ public class RunCommand extends BareCommand {
 
   protected boolean cluster;
   protected boolean ha;
+  protected boolean hft;
 
   protected int instances;
   protected String config;
@@ -72,6 +73,18 @@ public class RunCommand extends BareCommand {
       "fail over to any other nodes in the cluster started with the same HA group.")
   public void setHighAvailability(boolean ha) {
     this.ha = ha;
+  }
+  
+  /**
+   * Enables / disables the high fault tolerance
+   *
+   * @param hft whether or not to enable the HFT.
+   */
+  @Option(longName = "hft", acceptValue = false, flag = true)
+  @Description("If specified the verticle will be deployed as a high availability (HA) deployment. This means it can " +
+      "fail over to any other nodes in the cluster started with the same HA group.")
+  public void setHighFaultTolerance(boolean hft) {
+    this.hft = hft;
   }
 
   /**
@@ -237,6 +250,11 @@ public class RunCommand extends BareCommand {
   public boolean getHA() {
     return ha;
   }
+  
+  @Override
+  public boolean getHft() {
+	return hft;
+}
 
   /**
    * Starts vert.x and deploy the verticle.
@@ -357,6 +375,9 @@ public class RunCommand extends BareCommand {
     }
     if (quorum != -1) {
       args.add("--quorum=" + quorum);
+    }
+    if (hft) {
+        args.add("--hft");
     }
     if (classpath != null && !classpath.isEmpty()) {
       args.add("--classpath=" + classpath.stream().collect(Collectors.joining(File.pathSeparator)));

--- a/src/test/java/io/vertx/test/core/SnapshotsClusterMapTest.java
+++ b/src/test/java/io/vertx/test/core/SnapshotsClusterMapTest.java
@@ -1,0 +1,42 @@
+package io.vertx.test.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.vertx.core.impl.SnapshotsClusterMap;
+import io.vertx.core.impl.SnapshotsClusterMapLoader;
+
+public class SnapshotsClusterMapTest extends VertxTestBase {
+	@Test(timeout=1000)
+	public void testOneSnap() throws Exception {
+		final Map<String, String> newmap = new HashMap<String, String>();
+		newmap.put("found", "found-value");
+		final SnapshotsClusterMap map = new SnapshotsClusterMap(vertx(), () -> newmap, 1, 30);
+		Assert.assertNull(map.getValueFromAllSnapshots("notfound"));
+		while(map.getValueFromAllSnapshots("found") == null);
+	}
+	
+	@Test(timeout=1000)
+	public void testTenSnapsOverFive() throws Exception {
+		final AtomicInteger counter = new AtomicInteger();
+		final SnapshotsClusterMapLoader loader = () -> {
+			final int count = counter.incrementAndGet();
+			final Map<String, String> newmap = new HashMap<String, String>();
+			for(int i = 0; i < count; i++) {
+				newmap.put("key"+i, "value"+i);
+			}
+			return newmap;
+		};
+		
+		final SnapshotsClusterMap map = new SnapshotsClusterMap(vertx(), loader, 5, 30);
+		Assert.assertNull(map.getValueFromAllSnapshots("key10"));
+		for(int i = 1; i <= 10; i++) {
+			while(map.getValueFromAllSnapshots("key"+i) == null);	
+		}
+		Assert.assertNotNull(map.getValueFromAllSnapshots("key10"));
+	}
+}


### PR DESCRIPTION
Hi all,

We are big fans of VertX! We are working on setuping a cluster of at least 20 Vertx JVM in a single cluster. When starting playing killing nodes, more than one node in few seconds, we found that the vertx event bus cluster becomes unstable. After drilling down into the code, we found that the clusterMap of HAManager, and subs multimap of the ClusteredEventBus are often corrupted:
- sometimes, references on nodes killed are still present in clusterMap and subs multimap
- sometimes, references on nodes still running are missing in clusterMap and subs multimap

So we suggest to make sure to clean the maps from each node and not only from an elligible node. And we also suggest that each node is sending every 10 seconds their key/value into the clusterMap and subs multimap. 

The main benefits are that when the nodes are killed, after few seconds, the map are correctly cleaned-up, and running nodes are populating again the maps. Even under load (we tested it), the cluster becomes available again and 100% operational. We tested up to 20 running nodes and 80% of nodes loss, while the system were under load.
The main drawback is that each node is responsible for sending (every 10s) their key/value constantly in the clusterMap and the subs multimap.

So we propose to enable this behavior when the HFT is enabled from VertxOptions (High Fault Tolerance), since it will add additional traffic on the cluster which is not always necessary depending the deployment. (by default set to false). We have also the capability to change the delay of sending data to maps (HFTInterval) which is 10s by default.

Please comment, accept, deny or anything else about this pull request. We are strongly considering Vertx at the heart of our new infra for deploying micro-services, and the fault tolerance is only thing that we see as a showstopper.

Same issue already raised by other users: 
- https://github.com/eclipse/vert.x/pull/1593
- https://github.com/vert-x3/vertx-hazelcast/issues/13
