### PR TITLE
Load multiple certificates into keystore

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/KeyStoreHelper.java
@@ -237,6 +237,7 @@ public abstract class KeyStoreHelper {
       for (Buffer certValue : iterable) {
         for (Certificate cert : loadCerts(certValue)) {
           keyStore.setCertificateEntry("cert-" + count, cert);
+          count++;
         }
       }
       return keyStore;


### PR DESCRIPTION
The count was not incrementing so each additional certificate added to the CA keystore was simply overwriting the previous one.