### PR TITLE
fix#1634: Log4j2 impl does not support logging method name and line number properly 

### DIFF
--- a/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
@@ -142,7 +142,7 @@ public class Log4j2LogDelegate implements LogDelegate {
 
   @Override
   public void trace(Object message, Throwable t, Object... params) {
-    log(Level.INFO, message.toString(), t, params);
+    log(Level.TRACE, message.toString(), t, params);
   }
 
   private void log(Level level, Object message) {

--- a/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/Log4j2LogDelegate.java
@@ -19,6 +19,7 @@ package io.vertx.core.logging;
 import io.vertx.core.spi.logging.LogDelegate;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.FormattedMessage;
+import org.apache.logging.log4j.spi.ExtendedLogger;
 
 /**
  * A {@link LogDelegate} which delegates to Apache Log4j 2
@@ -27,10 +28,11 @@ import org.apache.logging.log4j.message.FormattedMessage;
  */
 public class Log4j2LogDelegate implements LogDelegate {
 
-  final org.apache.logging.log4j.Logger logger;
+  final ExtendedLogger logger;
+  final static String FQCN = Logger.class.getCanonicalName();
 
   Log4j2LogDelegate(final String name) {
-    logger = org.apache.logging.log4j.LogManager.getLogger(name);
+    logger = (ExtendedLogger) org.apache.logging.log4j.LogManager.getLogger(name);
   }
 
   public boolean isInfoEnabled() {
@@ -148,15 +150,15 @@ public class Log4j2LogDelegate implements LogDelegate {
   }
 
   private void log(Level level, Object message, Throwable t) {
-    logger.log(level, message, t);
+    logger.logIfEnabled(FQCN, level, null, message, t);
   }
 
   private void log(Level level, String message, Object... params) {
-    logger.log(level, message, params);
+    logger.logIfEnabled(FQCN, level, null, message, params);
   }
 
   private void log(Level level, String message, Throwable t, Object... params) {
-    logger.log(level, new FormattedMessage(message, params), t);
+    logger.logIfEnabled(FQCN, level, null, new FormattedMessage(message, params), t);
   }
 
   @Override

--- a/src/test/java/io/vertx/test/it/Log4J2LogDelegateTest.java
+++ b/src/test/java/io/vertx/test/it/Log4J2LogDelegateTest.java
@@ -202,4 +202,18 @@ public class Log4J2LogDelegateTest {
     assertTrue(result.contains("java.lang.IllegalStateException"));
   }
 
+  // test that line numbers and method name are logged correctly
+  // we use anonymous class instead of a lambda since we have to know the calling method name
+  @Test
+  public void testMethodName() {
+    Logger logger = LoggerFactory.getLogger("my-log4j2-logger");
+    String result = recording.execute(new Runnable() {
+      @Override
+      public void run() {
+        logger.warn("hello");
+      }
+    });
+    assertTrue(result.contains(".run:"));
+  }
+  
 }

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -28,7 +28,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.follow = true
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%t] %p %c - %m%n
+appender.console.layout.pattern = [%t] %p %c %C{1}.%M:%L - %m%n
 appender.console.target = SYSTEM_ERR
 
 rootLogger.level = trace


### PR DESCRIPTION
pass Logger class name to ExtendedLogger.logIfEnabled to enable logging of the correct methodname / line number in Log4j2

