### PR TITLE
Add the map operation to AsyncResult to easily transform an async res…

### DIFF
--- a/src/main/java/io/vertx/core/AsyncResult.java
+++ b/src/main/java/io/vertx/core/AsyncResult.java
@@ -16,6 +16,8 @@
 
 package io.vertx.core;
 
+import java.util.function.Function;
+
 /**
  * Encapsulates the result of an asynchronous operation.
  * <p>
@@ -58,5 +60,32 @@ public interface AsyncResult<T> {
    * @return true if it failed or false otherwise
    */
   boolean failed();
+
+  /**
+   * Apply a {@code mapper} function on this async result.<p>
+   *
+   * The {@code mapper} is called with the completed value and this mapper returns a value. This value will complete the result returned by this method call.<p>
+   *
+   * If the {@code mapper} throws an exception, the returned future will be failed with this exception.<p>
+   *
+   * When this async result is failed, the failure will be propagated to the returned future and the {@code mapper}
+   * will not be called.
+   *
+   * @param mapper the mapper function
+   * @return the mapped async result
+   */
+  <U> AsyncResult<U> map(Function<T, U> mapper);
+
+  /**
+   * Map the result of this async result to a specific {@code value}.<p>
+   *
+   * When this async result succeeds, this {@code value} will succeeeds the async result returned by this method call.<p>
+   *
+   * When this future fails, the failure will be propagated to the returned async result.
+   *
+   * @param value the value that eventually completes the mapped async result
+   * @return the mapped async result
+   */
+  <V> AsyncResult<V> map(V value);
 
 }

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -619,6 +620,8 @@ public class FutureTest extends VertxTestBase {
       public Throwable cause() { throw new UnsupportedOperationException(); }
       public boolean succeeded() { return true; }
       public boolean failed() { throw new UnsupportedOperationException(); }
+      public <U> AsyncResult<U> map(Function<Object, U> mapper) { throw new UnsupportedOperationException(); }
+      public <V> AsyncResult<V> map(V value) { throw new UnsupportedOperationException(); }
     };
 
     AsyncResult<Object> failedAsyncResult = new AsyncResult<Object>() {
@@ -627,6 +630,8 @@ public class FutureTest extends VertxTestBase {
       public Throwable cause() { return cause; }
       public boolean succeeded() { return false; }
       public boolean failed() { throw new UnsupportedOperationException(); }
+      public <U> AsyncResult<U> map(Function<Object, U> mapper) { throw new UnsupportedOperationException(); }
+      public <V> AsyncResult<V> map(V value) { throw new UnsupportedOperationException(); }
     };
 
     class DefaultCompleterTestFuture<T> implements Future<T> {


### PR DESCRIPTION
…ult into another one

This aims to replace boiler plate code like:

```
public void start(Handler<AsyncResult<MyType>> handler) {
   ...
   startSomeServer(ar -> {
     if (ar.succeeded()) {
        handler.handle(Future.succeededFuture(this));
     } else {
        handler.handle(Future.failedFuture(ar.cause()));
     }
   });
   ...
}
```

by

```
public void start(Handler<AsyncResult<MyType>> handler) {
   ...
   startSomeServer(ar -> {
      handler.handle(ar.map(this));
   });
   ...
}
```