### PR TITLE
Fixes vert-x3/vertx-infinispan#3 InfinispanHATest>HATest.testFailureInFailover fails intermittently

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -659,7 +659,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   @Override
   public synchronized void failoverCompleteHandler(FailoverCompleteHandler failoverCompleteHandler) {
     if (haManager() != null) {
-      haManager.setFailoverCompleteHandler(failoverCompleteHandler);
+      haManager().setFailoverCompleteHandler(failoverCompleteHandler);
     }
   }
 


### PR DESCRIPTION
Actually it does not fail in Infinispan CM only, it fails in Hazelcast CM as well.

The reason is that simulateKill returns just after calling "leave" on the CM. So calling tests assumes rebalance and stuff happened already but actually the information may even have not been handed over to the cluster manager.