### PR TITLE
When simulating kill, wait for result uninterruptedly

### DIFF
--- a/src/test/java/io/vertx/test/core/HATest.java
+++ b/src/test/java/io/vertx/test/core/HATest.java
@@ -418,8 +418,12 @@ public class HATest extends VertxTestBase {
   protected void kill(int pos) {
     VertxInternal v = (VertxInternal)vertices[pos];
     v.executeBlocking(fut -> {
-      v.simulateKill();
-      fut.complete();
+      try {
+        v.simulateKill();
+        fut.complete();
+      } catch (Exception e) {
+        fut.fail(e);
+      }
     }, ar -> {
       assertTrue(ar.succeeded());
     });

--- a/src/test/java/io/vertx/test/core/HATest.java
+++ b/src/test/java/io/vertx/test/core/HATest.java
@@ -425,7 +425,9 @@ public class HATest extends VertxTestBase {
         fut.fail(e);
       }
     }, ar -> {
-      assertTrue(ar.succeeded());
+      if (!ar.succeeded()) {
+        fail(ar.cause());
+      }
     });
   }
 


### PR DESCRIPTION
The calling thread might be interrupted and then the test fails like this:

```
java.lang.IllegalStateException: Assert or failure from non main thread but no await() on main thread
	at io.vertx.test.core.AsyncTestBase.afterAsyncTestBase(AsyncTestBase.java:161)
	at io.vertx.test.core.AsyncTestBase.tearDown(AsyncTestBase.java:71)
	at io.vertx.test.core.VertxTestBase.tearDown(VertxTestBase.java:99)
	at io.vertx.test.core.HATest.tearDown(HATest.java:47)
	at io.vertx.test.core.AsyncTestBase.after(AsyncTestBase.java:81)
	at sun.reflect.GeneratedMethodAccessor167.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:33)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
Caused by: java.lang.AssertionError: null
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at io.vertx.test.core.AsyncTestBase.assertTrue(AsyncTestBase.java:372)
	at io.vertx.test.core.HATest.lambda$kill$47(HATest.java:424)
	at io.vertx.core.impl.FutureImpl.checkCallHandler(FutureImpl.java:158)
	at io.vertx.core.impl.FutureImpl.setHandler(FutureImpl.java:100)
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:279)
	at io.vertx.core.impl.ContextImpl.lambda$wrapTask$2(ContextImpl.java:324)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:418)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:440)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:873)
	at java.lang.Thread.run(Thread.java:745)
```