### PR TITLE
Fixed command line parameter name to be "hagroup" instead of "ha-group"

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1475,7 +1475,7 @@ To specify an HA group you use the `-hagroup` switch when running the verticle, 
 
 [source]
 ----
-vertx run my-verticle.js -ha -ha-group my-group
+vertx run my-verticle.js -ha -hagroup my-group
 ----
 
 Let's look at an example:


### PR DESCRIPTION
Signed-off-by: Richard Perez <riperez@gmail.com>