### PR TITLE
Fixed command line parameter name to be "hagroup" instead of "ha-group"

### DIFF
--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1363,7 +1363,7 @@
  *
  * [source]
  * ----
- * vertx run my-verticle.js -ha -ha-group my-group
+ * vertx run my-verticle.js -ha -hagroup my-group
  * ----
  *
  * Let's look at an example:


### PR DESCRIPTION
Signed-off-by: Richard Perez <riperez@gmail.com>