### PR TITLE
Fixes vert-x3/vertx-hazelcast#49 io.vertx.test.core.HazelcastHATest.testSimpleFailover

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/test/java/io/vertx/test/core/HATest.java
+++ b/src/test/java/io/vertx/test/core/HATest.java
@@ -424,7 +424,7 @@ public class HATest extends VertxTestBase {
       } catch (Exception e) {
         fut.fail(e);
       }
-    }, ar -> {
+    }, false, ar -> {
       if (!ar.succeeded()) {
         fail(ar.cause());
       }


### PR DESCRIPTION
Simulate kill should not use ordered executeBlocking otherwise the CM
leave operation may not execute before the minute delay expires.