### PR TITLE
Addition of Future.discardingCompleter()

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -293,13 +293,29 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   /**
-   * @return an handler completing this future
+   * @return a handler completing this future
+   * @see #complete(Object)
    */
   @CacheReturn
   default Handler<AsyncResult<T>> completer() {
     return ar -> {
       if (ar.succeeded()) {
         complete(ar.result());
+      } else {
+        fail(ar.cause());
+      }
+    };
+  }
+
+  @CacheReturn
+  /**
+   * @return a handler completing this future with {@code null} on success
+   * @see #complete()
+   */
+  default <U> Handler<AsyncResult<U>> discardingCompleter() {
+    return ar -> {
+      if (ar.succeeded()) {
+        complete();
       } else {
         fail(ar.cause());
       }

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -646,7 +646,7 @@ public class FutureTest extends VertxTestBase {
       public boolean isComplete() { throw new UnsupportedOperationException(); }
       public Future<T> setHandler(Handler<AsyncResult<T>> handler) { throw new UnsupportedOperationException(); }
       public void complete(T result) { succeeded = true; this.result = result; }
-      public void complete() { throw new UnsupportedOperationException(); }
+      public void complete() { succeeded = true; }
       public void fail(Throwable throwable) { failed = true; cause = throwable; }
       public void fail(String failureMessage) { throw new UnsupportedOperationException(); }
       public T result() { throw new UnsupportedOperationException(); }
@@ -664,6 +664,15 @@ public class FutureTest extends VertxTestBase {
     failureFuture.completer().handle(failedAsyncResult);
     assertTrue(failureFuture.failed);
     assertEquals(failedAsyncResult.cause(), failureFuture.cause);
+
+    DefaultCompleterTestFuture<Void> voidSuccessFuture = new DefaultCompleterTestFuture<>();
+    voidSuccessFuture.discardingCompleter().handle(succeededAsyncResult);
+    assertTrue(voidSuccessFuture.succeeded);
+
+    DefaultCompleterTestFuture<Void> voidFailureFuture = new DefaultCompleterTestFuture<>();
+    voidFailureFuture.discardingCompleter().handle(failedAsyncResult);
+    assertFalse(voidFailureFuture.succeeded);
+    assertEquals(failedAsyncResult.cause(), voidFailureFuture.cause);
   }
 
   class Checker<T> {


### PR DESCRIPTION
This method is similar to `Future.completer()` except that it works for any type of `AsyncResult` and discards the result value to set null on success, and the throwable in case of error.

The motivation for this addition is to simplify code such as:

``` java
@Override
public void start(Future<Void> startFuture) {
  // (...)
  .listen(8080, ar -> {
    if (ar.succeeded()) {
      startFuture.complete();
    } else {
      startFuture.fail(ar.cause());
    }
  });
}
```

to:

``` java
@Override
public void start(Future<Void> startFuture) {
  // (...)
  .listen(8080, startFuture.discardingCompleter());
}
```
