### PR TITLE
Meaningful Error for Http2 in a WorkerVerticle

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -86,6 +86,9 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       if (creatingContext.isMultiThreadedWorkerContext()) {
         throw new IllegalStateException("Cannot use HttpClient in a multi-threaded worker verticle");
       }
+      if(options.getProtocolVersion() == HttpVersion.HTTP_2 && creatingContext.isWorkerContext()) {
+        throw new IllegalStateException("Cannot use HttpClient with HTTP_2 in a worker verticle");
+      }
       creatingContext.addCloseHook(closeHook);
     }
     HttpClientMetrics metrics = vertx.metricsSPI().createMetrics(this, options);

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -46,10 +46,7 @@ import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
@@ -1817,4 +1814,23 @@ public class Http2ClientTest extends Http2TestBase {
     await();
   }
 */
+
+  @Test
+  public void testHttp2ClientInWorkerVerticle() throws Exception {
+
+    Verticle workerVerticle = new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        try {
+          vertx.createHttpClient(createHttp2ClientOptions());
+          fail("HttpClient should not work with HTTP_2");
+        } catch(Exception ex) {
+          assertEquals("Cannot use HttpClient with HTTP_2 in a worker verticle", ex.getMessage());
+          complete();
+        }
+      }
+    };
+    vertx.deployVerticle(workerVerticle, new DeploymentOptions().setWorker(true));
+    await();
+  }
 }


### PR DESCRIPTION
Throw a meaningful exception when using HTTP_2 in a WorkerVerticle to properly signal that this is not supported. Currently, a NullPointerException is thrown somewhere in the netty code. Discussed in issue #1699 