### PR TITLE
Meaningful Error for Http2 in a WorkerVerticle

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -23,6 +23,7 @@ import io.vertx.core.VertxException;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.Closeable;
+import io.vertx.core.Context;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
@@ -86,8 +87,8 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       if (creatingContext.isMultiThreadedWorkerContext()) {
         throw new IllegalStateException("Cannot use HttpClient in a multi-threaded worker verticle");
       }
-      if(options.getProtocolVersion() == HttpVersion.HTTP_2 && creatingContext.isWorkerContext()) {
-        throw new IllegalStateException("Cannot use HttpClient with HTTP_2 in a worker verticle");
+      if(options.getProtocolVersion() == HttpVersion.HTTP_2 && Context.isOnWorkerThread()) {
+        throw new IllegalStateException("Cannot use HttpClient with HTTP_2 in a worker");
       }
       creatingContext.addCloseHook(closeHook);
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -86,6 +86,9 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       if (creatingContext.isMultiThreadedWorkerContext()) {
         throw new IllegalStateException("Cannot use HttpClient in a multi-threaded worker verticle");
       }
+      if(options.getProtocolVersion() == HttpVersion.HTTP_2 && creatingContext.isWorkerContext()) {
+        throw new IllegalStateException("Cannot use HttpClient with HTTP_2 in a worker verticle");
+      }
       creatingContext.addCloseHook(closeHook);
     }
     HttpClientMetrics metrics = vertx.metricsSPI().createMetrics(this, options);

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -46,10 +46,7 @@ import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
@@ -1817,4 +1814,21 @@ public class Http2ClientTest extends Http2TestBase {
     await();
   }
 */
+  @Test
+  public void testHttp2ClientInWorkerVerticle() throws Exception {
+    Verticle workerVerticle = new AbstractVerticle() {
+      @Override
+      public void start() throws Exception {
+        try {
+          vertx.createHttpClient(createHttp2ClientOptions());
+          fail("HttpClient should not work with HTTP_2");
+        } catch(Exception ex) {
+          assertEquals("Cannot use HttpClient with HTTP_2 in a worker verticle", ex.getMessage());
+          complete();
+        }
+      }
+    };
+    vertx.deployVerticle(workerVerticle, new DeploymentOptions().setWorker(true));
+    await();
+  }
 }

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -1823,7 +1823,7 @@ public class Http2ClientTest extends Http2TestBase {
           vertx.createHttpClient(createHttp2ClientOptions());
           fail("HttpClient should not work with HTTP_2");
         } catch(Exception ex) {
-          assertEquals("Cannot use HttpClient with HTTP_2 in a worker verticle", ex.getMessage());
+          assertEquals("Cannot use HttpClient with HTTP_2 in a worker", ex.getMessage());
           complete();
         }
       }
@@ -1833,22 +1833,17 @@ public class Http2ClientTest extends Http2TestBase {
   }
 
   @Test
-  public void testExecuteBlocking() throws Exception {
-
-    String expected = TestUtils.randomAlphaString(27);
-    server.requestHandler(req -> req.response().end(expected));
-    startServer();
+  public void testExecuteBlockingException() throws Exception {
 
     vertx.executeBlocking(fut -> {
-      client = vertx.createHttpClient(createHttp2ClientOptions());
-      client.getNow(DEFAULT_HTTPS_PORT, DEFAULT_HTTPS_HOST, "/", resp -> {
-        resp.bodyHandler(body -> fut.complete(body.toString()));
-      });
-    }, res -> {
-      assertTrue(res.succeeded());
-      assertEquals(expected, res.result());
-      complete();
-    });
+      try {
+        vertx.createHttpClient(createHttp2ClientOptions());
+        fail("HttpClient should not work with HTTP_2 inside executeBlocking");
+      } catch(Exception ex) {
+        assertEquals("Cannot use HttpClient with HTTP_2 in a worker", ex.getMessage());
+        complete();
+      }
+    }, null);
 
     await();
   }


### PR DESCRIPTION
Throw a meaningful exception when using HTTP_2 in a WorkerVerticle to properly signal that this is not supported. Currently, a NullPointerException is thrown somewhere in the netty code. Discussed in issue #1699