### PR TITLE
Test locking on same Vert.x instance

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/test/java/io/vertx/test/core/AsynchronousLockTest.java
+++ b/src/test/java/io/vertx/test/core/AsynchronousLockTest.java
@@ -16,12 +16,17 @@
 
 package io.vertx.test.core;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.Lock;
+import io.vertx.core.shareddata.SharedData;
 import org.junit.Test;
 
-import static io.vertx.test.core.TestUtils.assertIllegalArgumentException;
-import static io.vertx.test.core.TestUtils.assertNullPointerException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.vertx.test.core.TestUtils.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -56,6 +61,96 @@ public class AsynchronousLockTest extends VertxTestBase {
         assertTrue(System.currentTimeMillis() - start >= 1000);
         testComplete();
       });
+    });
+    await();
+  }
+
+  @Test
+  public void testAcquireOnSameEventLoop() {
+    Vertx vertx = getVertx();
+    Context context = vertx.getOrCreateContext();
+    SharedData sharedData = vertx.sharedData();
+    AtomicReference<Long> start = new AtomicReference<>();
+    context.runOnContext(v -> {
+      sharedData.getLock("foo", ar -> {
+        assertTrue(ar.succeeded());
+        start.set(System.currentTimeMillis());
+        Lock lock = ar.result();
+        vertx.setTimer(1000, tid -> {
+          lock.release();
+        });
+        context.runOnContext(v2 -> {
+          sharedData.getLock("foo", ar2 -> {
+            assertTrue(ar2.succeeded());
+            // Should be delayed
+            assertTrue(System.currentTimeMillis() - start.get() >= 1000);
+            testComplete();
+          });
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void testAcquireOnExecuteBlocking() {
+    Vertx vertx = getVertx();
+    SharedData sharedData = vertx.sharedData();
+    AtomicReference<Long> start = new AtomicReference<>();
+    vertx.<Lock>executeBlocking(future -> {
+      CountDownLatch acquireLatch = new CountDownLatch(1);
+      AtomicReference<AsyncResult<Lock>> lockReference = new AtomicReference<>();
+      sharedData.getLock("foo", ar -> {
+        lockReference.set(ar);
+        acquireLatch.countDown();
+      });
+      try {
+        awaitLatch(acquireLatch);
+        AsyncResult<Lock> ar = lockReference.get();
+        if (ar.succeeded()) {
+          future.complete(ar.result());
+        } else {
+          future.fail(ar.cause());
+        }
+      } catch (InterruptedException e) {
+        future.fail(e);
+      }
+    }, ar -> {
+      if (ar.succeeded()) {
+        start.set(System.currentTimeMillis());
+        vertx.setTimer(1000, tid -> {
+          ar.result().release();
+        });
+        vertx.executeBlocking(future -> {
+          CountDownLatch acquireLatch = new CountDownLatch(1);
+          AtomicReference<AsyncResult<Lock>> lockReference = new AtomicReference<>();
+          sharedData.getLock("foo", ar2 -> {
+            lockReference.set(ar2);
+            acquireLatch.countDown();
+          });
+          try {
+            awaitLatch(acquireLatch);
+            AsyncResult<Lock> ar3 = lockReference.get();
+            if (ar3.succeeded()) {
+              future.complete(ar3.result());
+            } else {
+              future.fail(ar3.cause());
+            }
+          } catch (InterruptedException e) {
+            future.fail(e);
+          }
+        }, ar4 -> {
+          if (ar4.succeeded()) {
+            // Should be delayed
+            assertTrue(System.currentTimeMillis() - start.get() >= 1000);
+            testComplete();
+          } else {
+            fail(ar4.cause());
+          }
+        });
+      } else {
+        fail(ar.cause());
+      }
     });
     await();
   }


### PR DESCRIPTION
The existing clustered lock tests always involve two different Vert.x instances.
In vert-x3/vertx-hazelcast#41, it has been reported that concurrent requests to a clustered lock on the same instance can lead to deadlocking.
It happens because locks are acquired with ordered execute blocking, the same for releasing.

The fix consists in applying the technique used in jdbc client connections: a dedicated worker executor is created for a lock instance, then the lock is acquired in order, but released freely. Consequently, we never find ourselves in a situation where a lock release task is waiting for a lock acquire task to complete.

Pull requests for the cluster managers are ready and will be pushed soon.