### PR TITLE
Fix #1718

### DIFF
--- a/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
+++ b/src/test/java/io/vertx/core/impl/launcher/commands/StartStopListCommandsTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,260 +36,298 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class StartStopListCommandsTest extends CommandTestBase {
 
-  @Before
-  public void setUp() throws IOException {
-    File manifest = new File("target/test-classes/META-INF/MANIFEST.MF");
-    if (manifest.isFile()) {
-      manifest.delete();
+    @Before
+    public void setUp() throws IOException {
+        File manifest = new File("target/test-classes/META-INF/MANIFEST.MF");
+        if (manifest.isFile()) {
+            manifest.delete();
+        }
+
+        super.setUp();
     }
 
-    super.setUp();
-  }
+    @Test
+    public void testStartListStop() throws InterruptedException {
+        record();
 
-  @Test
-  public void testStartListStop() throws InterruptedException {
-    record();
+        cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
+            "--launcher-class", Launcher.class.getName()});
 
-    cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
-        "--launcher-class", Launcher.class.getName()});
+        waitForStartup();
+        assertThat(output.toString()).contains("Starting vert.x application");
 
-    waitForStartup();
-    assertThat(output.toString()).contains("Starting vert.x application");
+        output.reset();
+        cli.dispatch(new String[]{"list"});
+        assertThat(output.toString()).hasLineCount(2);
+        assertThat(output.toString()).contains("\t" + HttpTestVerticle.class.getName());
 
-    output.reset();
-    cli.dispatch(new String[]{"list"});
-    assertThat(output.toString()).hasLineCount(2);
-    assertThat(output.toString()).contains("\t" + HttpTestVerticle.class.getName());
-
-    // Extract id.
-    String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
-    output.reset();
-    // pass --redeploy to not call system.exit
-    cli.dispatch(new String[]{"stop", id, "--redeploy"});
-    assertThat(output.toString())
-        .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' terminated with status 0");
+        // Extract id.
+        String[] lines = output.toString().split(System.lineSeparator());
+        String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Application '" + id + "' terminated with status 0");
 
 
-    waitForShutdown();
+        waitForShutdown();
 
-    waitUntil(() -> {
-      output.reset();
-      cli.dispatch(new String[]{"list"});
-      return !output.toString().contains(id);
-    });
+        waitUntil(() -> {
+            output.reset();
+            cli.dispatch(new String[]{"list"});
+            return !output.toString().contains(id);
+        });
 
-    assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
-  }
-
-  @Test
-  public void testStartListStopWithJVMOptions() throws InterruptedException, IOException {
-    record();
-
-    cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
-        "--launcher-class", Launcher.class.getName(), "--java-opts=-Dfoo=bar -Dbaz=bar", "--redirect-output"});
-
-    waitForStartup();
-    assertThat(output.toString()).contains("Starting vert.x application");
-
-    JsonObject content = RunCommandTest.getContent();
-    assertThat(content.getString("foo")).isEqualToIgnoringCase("bar");
-    assertThat(content.getString("baz")).isEqualToIgnoringCase("bar");
-
-    output.reset();
-    cli.dispatch(new String[]{"list"});
-    assertThat(output.toString()).hasLineCount(2);
-
-    // Extract id.
-    String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
-    output.reset();
-    // pass --redeploy to not call system.exit
-    cli.dispatch(new String[]{"stop", id, "--redeploy"});
-    assertThat(output.toString())
-        .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' terminated with status 0");
-
-    waitForShutdown();
-
-    waitUntil(() -> {
-      output.reset();
-      cli.dispatch(new String[]{"list"});
-      return !output.toString().contains(id);
-    });
-
-    assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
-  }
-
-  private void waitForShutdown() {
-    waitUntil(() -> {
-      try {
-        getHttpCode();
-      } catch (IOException e) {
-        return true;
-      }
-      return false;
-    });
-  }
-
-  private void waitForStartup() {
-    waitUntil(() -> {
-      try {
-        return getHttpCode() == 200;
-      } catch (IOException e) {
-        // Ignore it.
-      }
-      return false;
-    });
-  }
-
-  @Test
-  public void testStartListStopWithId() throws InterruptedException, IOException {
-    record();
-
-    cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
-        "--launcher-class", Launcher.class.getName(), "--vertx-id=hello"});
-    waitForStartup();
-    assertThat(output.toString()).contains("Starting vert.x application").contains("hello");
-
-    output.reset();
-    cli.dispatch(new String[]{"list"});
-    assertThat(output.toString()).hasLineCount(2).contains("hello");
-
-    // Extract id.
-    String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
-    assertThat(id).isEqualToIgnoringCase("hello");
-    output.reset();
-    // pass --redeploy to not call system.exit
-    cli.dispatch(new String[]{"stop", id, "--redeploy"});
-    assertThat(output.toString())
-        .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' terminated with status 0");
-
-    waitForShutdown();
-
-    waitUntil(() -> {
-      output.reset();
-      cli.dispatch(new String[]{"list"});
-      return !output.toString().contains(id);
-    });
-
-    assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
-  }
-
-  @Test
-  public void testStartListStopWithIdAndAnotherArgument() throws InterruptedException, IOException {
-    record();
-
-    cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
-        "--launcher-class", Launcher.class.getName(), "--vertx-id=hello", "-cluster"});
-
-    waitForStartup();
-    assertThat(output.toString()).contains("Starting vert.x application").contains("hello");
-    assertThat(RunCommandTest.getContent().getBoolean("clustered")).isTrue();
-
-    output.reset();
-    cli.dispatch(new String[]{"list"});
-    assertThat(output.toString()).hasLineCount(2).contains("hello");
-
-    // Extract id.
-    String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
-    assertThat(id).isEqualToIgnoringCase("hello");
-    output.reset();
-    // pass --redeploy to not call system.exit
-    cli.dispatch(new String[]{"stop", id, "--redeploy"});
-    assertThat(output.toString())
-        .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' terminated with status 0");
-
-    waitForShutdown();
-
-    waitUntil(() -> {
-      output.reset();
-      cli.dispatch(new String[]{"list"});
-      return !output.toString().contains(id);
-    });
-
-    assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
-  }
-
-  @Test
-  public void testStartListStopWithIdAndAnotherArgumentBeforeId() throws InterruptedException, IOException {
-    record();
-
-    cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
-        "--launcher-class", Launcher.class.getName(), "-cluster", "--vertx-id=hello"});
-
-    waitForStartup();
-    assertThat(output.toString()).contains("Starting vert.x application").contains("hello");
-    assertThat(RunCommandTest.getContent().getBoolean("clustered")).isTrue();
-
-    output.reset();
-    cli.dispatch(new String[]{"list"});
-    assertThat(output.toString()).hasLineCount(2).contains("hello");
-
-    // Extract id.
-    String[] lines = output.toString().split(System.lineSeparator());
-    String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
-    assertThat(id).isEqualToIgnoringCase("hello");
-    output.reset();
-    // pass --redeploy to not call system.exit
-    cli.dispatch(new String[]{"stop", id, "--redeploy"});
-    assertThat(output.toString())
-        .contains("Stopping vert.x application '" + id + "'")
-        .contains("Application '" + id + "' terminated with status 0");
-
-    waitForShutdown();
-
-    waitUntil(() -> {
-      output.reset();
-      cli.dispatch(new String[]{"list"});
-      return !output.toString().contains(id);
-    });
-
-    assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
-  }
-
-  private int getHttpCode() throws IOException {
-    return ((HttpURLConnection) new URL("http://localhost:8080")
-        .openConnection()).getResponseCode();
-  }
-
-  @Test
-  public void testFatJarExtraction() {
-    String command = "java -jar fat.jar -Dvertx.id=xxx --cluster";
-    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("fat.jar");
-
-    command = "java -jar bin/fat.jar -Dvertx.id=xxx --cluster";
-    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("bin/fat.jar");
-
-    command = "java foo bar -Dvertx.id=xxx --cluster";
-    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("");
-  }
-
-  @Test
-  public void testStoppingAnUnknownProcess() {
-    if (ExecUtils.isWindows()) {
-      // Test skipped on windows, because on windows we do not check whether or not the pid exists.
-      return;
+        assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
     }
-    record();
-    String id = "this-process-does-not-exist";
-    output.reset();
-    // pass --redeploy to not call system.exit
-    cli.dispatch(new String[]{"stop", id, "--redeploy"});
-    assertThat(output.toString())
-        .contains("Stopping vert.x application '" + id + "'")
-        .contains("Cannot find process for application using the id");
-  }
 
-  @Test
-  public void testVerticleExtraction() {
-    String command = "vertx run verticle test1 -Dvertx.id=xxx --cluster";
-    assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("verticle");
-  }
+    @Test
+    public void testStartListStopWithoutCommand() throws InterruptedException {
+        record();
+
+        cli.dispatch(new String[]{"start", HttpTestVerticle.class.getName(),
+            "--launcher-class", Launcher.class.getName()});
+
+        waitForStartup();
+        assertThat(output.toString()).contains("Starting vert.x application");
+
+        output.reset();
+        cli.dispatch(new String[]{"list"});
+        assertThat(output.toString()).hasLineCount(2);
+        assertThat(output.toString()).contains("\t" + HttpTestVerticle.class.getName());
+
+        // Extract id.
+        String[] lines = output.toString().split(System.lineSeparator());
+        String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Application '" + id + "' terminated with status 0");
+
+
+        waitForShutdown();
+
+        waitUntil(() -> {
+            output.reset();
+            cli.dispatch(new String[]{"list"});
+            return !output.toString().contains(id);
+        });
+
+        assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
+    }
+
+    @Test
+    public void testStartListStopWithJVMOptions() throws InterruptedException, IOException {
+        record();
+
+        cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
+            "--launcher-class", Launcher.class.getName(), "--java-opts=-Dfoo=bar -Dbaz=bar", "--redirect-output"});
+
+        waitForStartup();
+        assertThat(output.toString()).contains("Starting vert.x application");
+
+        JsonObject content = RunCommandTest.getContent();
+        assertThat(content.getString("foo")).isEqualToIgnoringCase("bar");
+        assertThat(content.getString("baz")).isEqualToIgnoringCase("bar");
+
+        output.reset();
+        cli.dispatch(new String[]{"list"});
+        assertThat(output.toString()).hasLineCount(2);
+
+        // Extract id.
+        String[] lines = output.toString().split(System.lineSeparator());
+        String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Application '" + id + "' terminated with status 0");
+
+        waitForShutdown();
+
+        waitUntil(() -> {
+            output.reset();
+            cli.dispatch(new String[]{"list"});
+            return !output.toString().contains(id);
+        });
+
+        assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
+    }
+
+    private void waitForShutdown() {
+        waitUntil(() -> {
+            try {
+                getHttpCode();
+            } catch (IOException e) {
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private void waitForStartup() {
+        waitUntil(() -> {
+            try {
+                return getHttpCode() == 200;
+            } catch (IOException e) {
+                // Ignore it.
+            }
+            return false;
+        });
+    }
+
+    @Test
+    public void testStartListStopWithId() throws InterruptedException, IOException {
+        record();
+
+        cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
+            "--launcher-class", Launcher.class.getName(), "--vertx-id=hello"});
+        waitForStartup();
+        assertThat(output.toString()).contains("Starting vert.x application").contains("hello");
+
+        output.reset();
+        cli.dispatch(new String[]{"list"});
+        assertThat(output.toString()).hasLineCount(2).contains("hello");
+
+        // Extract id.
+        String[] lines = output.toString().split(System.lineSeparator());
+        String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
+
+        assertThat(id).isEqualToIgnoringCase("hello");
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Application '" + id + "' terminated with status 0");
+
+        waitForShutdown();
+
+        waitUntil(() -> {
+            output.reset();
+            cli.dispatch(new String[]{"list"});
+            return !output.toString().contains(id);
+        });
+
+        assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
+    }
+
+    @Test
+    public void testStartListStopWithIdAndAnotherArgument() throws InterruptedException, IOException {
+        record();
+
+        cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
+            "--launcher-class", Launcher.class.getName(), "--vertx-id=hello", "-cluster"});
+
+        waitForStartup();
+        assertThat(output.toString()).contains("Starting vert.x application").contains("hello");
+        assertThat(RunCommandTest.getContent().getBoolean("clustered")).isTrue();
+
+        output.reset();
+        cli.dispatch(new String[]{"list"});
+        assertThat(output.toString()).hasLineCount(2).contains("hello");
+
+        // Extract id.
+        String[] lines = output.toString().split(System.lineSeparator());
+        String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
+        assertThat(id).isEqualToIgnoringCase("hello");
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Application '" + id + "' terminated with status 0");
+
+        waitForShutdown();
+
+        waitUntil(() -> {
+            output.reset();
+            cli.dispatch(new String[]{"list"});
+            return !output.toString().contains(id);
+        });
+
+        assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
+    }
+
+    @Test
+    public void testStartListStopWithIdAndAnotherArgumentBeforeId() throws InterruptedException, IOException {
+        record();
+
+        cli.dispatch(new String[]{"start", "run", HttpTestVerticle.class.getName(),
+            "--launcher-class", Launcher.class.getName(), "-cluster", "--vertx-id=hello"});
+
+        waitForStartup();
+        assertThat(output.toString()).contains("Starting vert.x application").contains("hello");
+        assertThat(RunCommandTest.getContent().getBoolean("clustered")).isTrue();
+
+        output.reset();
+        cli.dispatch(new String[]{"list"});
+        assertThat(output.toString()).hasLineCount(2).contains("hello");
+
+        // Extract id.
+        String[] lines = output.toString().split(System.lineSeparator());
+        String id = lines[1].trim().substring(0, lines[1].trim().indexOf("\t"));
+        assertThat(id).isEqualToIgnoringCase("hello");
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Application '" + id + "' terminated with status 0");
+
+        waitForShutdown();
+
+        waitUntil(() -> {
+            output.reset();
+            cli.dispatch(new String[]{"list"});
+            return !output.toString().contains(id);
+        });
+
+        assertThat(output.toString()).hasLineCount(2).contains("No vert.x application found");
+    }
+
+    private int getHttpCode() throws IOException {
+        return ((HttpURLConnection) new URL("http://localhost:8080")
+            .openConnection()).getResponseCode();
+    }
+
+    @Test
+    public void testFatJarExtraction() {
+        String command = "java -jar fat.jar -Dvertx.id=xxx --cluster";
+        assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("fat.jar");
+
+        command = "java -jar bin/fat.jar -Dvertx.id=xxx --cluster";
+        assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("bin/fat.jar");
+
+        command = "java foo bar -Dvertx.id=xxx --cluster";
+        assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("");
+    }
+
+    @Test
+    public void testStoppingAnUnknownProcess() {
+        if (ExecUtils.isWindows()) {
+            // Test skipped on windows, because on windows we do not check whether or not the pid exists.
+            return;
+        }
+        record();
+        String id = "this-process-does-not-exist";
+        output.reset();
+        // pass --redeploy to not call system.exit
+        cli.dispatch(new String[]{"stop", id, "--redeploy"});
+        assertThat(output.toString())
+            .contains("Stopping vert.x application '" + id + "'")
+            .contains("Cannot find process for application using the id");
+    }
+
+    @Test
+    public void testVerticleExtraction() {
+        String command = "vertx run verticle test1 -Dvertx.id=xxx --cluster";
+        assertThat(ListCommand.extractApplicationDetails(command)).isEqualTo("verticle");
+    }
 
 }


### PR DESCRIPTION
When using the `start` command without an explicit command, use the `run` command.
