### PR TITLE
Changes the subs map handling for better consistency

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.eventbus.impl.clustered;
+
+import java.io.Serializable;
+
+/**
+ * @author Rikard Björklind
+ */
+public class ClusterNodeInfo implements Serializable {
+  public String nodeId;
+  public String host;
+  public int port;
+
+  public ClusterNodeInfo() {
+  }
+
+  public ClusterNodeInfo(String nodeId, String host, int port) {
+    this.nodeId = nodeId;
+    this.host = host;
+    this.port = port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ClusterNodeInfo that = (ClusterNodeInfo) o;
+
+    if (port != that.port) return false;
+    if (nodeId != null ? !nodeId.equals(that.nodeId) : that.nodeId != null) return false;
+    return host != null ? host.equals(that.host) : that.host == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = nodeId != null ? nodeId.hashCode() : 0;
+    result = 31 * result + (host != null ? host.hashCode() : 0);
+    result = 31 * result + port;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return nodeId + ":" + host + ":" + port;
+  }
+}

--- a/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
+++ b/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
@@ -19,6 +19,8 @@ package io.vertx.core.spi.cluster;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
+import java.util.function.Predicate;
+
 /**
  *
  * An asynchronous multi-map.
@@ -63,4 +65,6 @@ public interface AsyncMultiMap<K, V> {
    * @param completionHandler This will be called when the remove is complete
    */
   void removeAllForValue(V v, Handler<AsyncResult<Void>> completionHandler);
+
+  void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler);
 }

--- a/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 public class FakeClusterManager implements ClusterManager {
 
@@ -366,6 +367,11 @@ public class FakeClusterManager implements ClusterManager {
 
     @Override
     public void removeAllForValue(final V v, Handler<AsyncResult<Void>> completionHandler) {
+      removeAll(v::equals, completionHandler);
+    }
+
+    @Override
+    public void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler) {
       vertx.executeBlocking(fut -> {
         Iterator<Map.Entry<K, ChoosableSet<V>>> mapIter = map.entrySet().iterator();
         while (mapIter.hasNext()) {
@@ -374,7 +380,7 @@ public class FakeClusterManager implements ClusterManager {
           Iterator<V> iter = vals.iterator();
           while (iter.hasNext()) {
             V val = iter.next();
-            if (val.equals(v)) {
+            if (p.test(val)) {
               iter.remove();
             }
           }


### PR DESCRIPTION
This pull request tries to fix the problem with the subs map getting out of sync with the set of actual cluster members. The following issue has a rather long discussion about it: https://github.com/vert-x3/vertx-hazelcast/issues/13. It is an alternate solution to https://github.com/eclipse/vert.x/pull/1594.

The solution uses the ClusterManager view of members rather than HAManager's distributed clusterMap, which itself may be out of sync. It cleans up and updates the subs map every time a node is added to or removed from the cluster, instead of just when a node crash is detected.
The AsyncMultiMap interface has a new method in order to support removal in a more flexible way, which means that it breaks the API for cluster plugins. A corresponding pull request for vertx-hazelcast will be created shortly to address this; see https://github.com/vert-x3/vertx-hazelcast/pull/53.

To reproduce this issue, set up clustering with at least two nodes on different hosts, with TCP clustering for Hazelcast (not multicast). The nodes should send some messages periodically, see above mentioned issue #13 for an example producer/consumer. Then simulate a network failure by blocking traffic with iptables (or kill the machines). Hazelcast will partition the cluster. Restart the verticles that are consuming messages. Remove the iptables rule (or bring the machines back up) - if hz fails to merge the cluster properly, the subs map will still contain the old entries, and so Vertx will try to send messages to these, now dead, verticles.
