### PR TITLE
Expose send() as part of the Message interface

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/Message.java
+++ b/src/main/java/io/vertx/core/eventbus/Message.java
@@ -67,6 +67,13 @@ public interface Message<T> {
   String replyAddress();
 
   /**
+   * Signals if this message represents a send or publish event.
+   *
+   * @return true if this is a send.
+   */
+  boolean isSend();
+
+  /**
    * Reply to this message.
    * <p>
    * If the message was sent specifying a reply handler, that handler will be

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -316,7 +316,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
 
   protected <T> void sendOrPub(SendContextImpl<T> sendContext) {
     MessageImpl message = sendContext.message;
-    metrics.messageSent(message.address(), !message.send(), true, false);
+    metrics.messageSent(message.address(), !message.isSend(), true, false);
     deliverMessageLocally(sendContext);
   }
 
@@ -362,23 +362,23 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     msg.setBus(this);
     Handlers handlers = handlerMap.get(msg.address());
     if (handlers != null) {
-      if (msg.send()) {
+      if (msg.isSend()) {
         //Choose one
         HandlerHolder holder = handlers.choose();
-        metrics.messageReceived(msg.address(), !msg.send(), isMessageLocal(msg), holder != null ? 1 : 0);
+        metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), holder != null ? 1 : 0);
         if (holder != null) {
           deliverToHandler(msg, holder);
         }
       } else {
         // Publish
-        metrics.messageReceived(msg.address(), !msg.send(), isMessageLocal(msg), handlers.list.size());
+        metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), handlers.list.size());
         for (HandlerHolder holder: handlers.list) {
           deliverToHandler(msg, holder);
         }
       }
       return true;
     } else {
-      metrics.messageReceived(msg.address(), !msg.send(), isMessageLocal(msg), 0);
+      metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), 0);
       return false;
     }
   }
@@ -453,7 +453,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
 
     @Override
     public boolean send() {
-      return message.send();
+      return message.isSend();
     }
   }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/MessageImpl.java
@@ -138,12 +138,13 @@ public class MessageImpl<U, V> implements Message<V> {
     }
   }
 
-  public void setReplyAddress(String replyAddress) {
-    this.replyAddress = replyAddress;
+  @Override
+  public boolean isSend() {
+    return send;
   }
 
-  public boolean send() {
-    return send;
+  public void setReplyAddress(String replyAddress) {
+    this.replyAddress = replyAddress;
   }
 
   public MessageCodec<U, V> codec() {

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -217,7 +217,7 @@ public class ClusteredEventBus extends EventBusImpl {
         if (serverIDs != null && !serverIDs.isEmpty()) {
           sendToSubs(serverIDs, sendContext);
         } else {
-          metrics.messageSent(address, !sendContext.message.send(), true, false);
+          metrics.messageSent(address, !sendContext.message.isSend(), true, false);
           deliverMessageLocally(sendContext);
         }
       } else {
@@ -309,7 +309,7 @@ public class ClusteredEventBus extends EventBusImpl {
 
   private <T> void sendToSubs(ChoosableIterable<ServerID> subs, SendContextImpl<T> sendContext) {
     String address = sendContext.message.address();
-    if (sendContext.message.send()) {
+    if (sendContext.message.isSend()) {
       // Choose one
       ServerID sid = subs.choose();
       if (!sid.equals(serverID)) {  //We don't send to this node

--- a/src/test/java/io/vertx/test/core/ClusteredEventBusTestBase.java
+++ b/src/test/java/io/vertx/test/core/ClusteredEventBusTestBase.java
@@ -18,19 +18,12 @@ package io.vertx.test.core;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.*;
-import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.test.fakecluster.FakeClusterManager;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -54,6 +47,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
 
     MessageConsumer<T> reg = vertices[1].eventBus().<T>consumer(ADDRESS1).handler((Message<T> msg) -> {
       if (consumer == null) {
+        assertTrue(msg.isSend());
         assertEquals(received, msg.body());
         if (options != null) {
           assertNotNull(msg.headers());
@@ -109,6 +103,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
       assertTrue(ar.succeeded());
       vertices[0].eventBus().send(ADDRESS1, str, onSuccess((Message<R> reply) -> {
         if (consumer == null) {
+          assertTrue(reply.isSend());
           assertEquals(received, reply.body());
           if (options != null && options.getHeaders() != null) {
             assertNotNull(reply.headers());
@@ -164,6 +159,7 @@ public class ClusteredEventBusTestBase extends EventBusTestBase {
       @Override
       public void handle(Message<T> msg) {
         if (consumer == null) {
+          assertFalse(msg.isSend());
           assertEquals(val, msg.body());
         } else {
           consumer.accept(msg.body());

--- a/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -947,6 +947,7 @@ public class LocalEventBusTest extends EventBusTestBase {
   protected <T, R> void testSend(T val, R received, Consumer<T> consumer, DeliveryOptions options) {
     eb.<T>consumer(ADDRESS1).handler((Message<T> msg) -> {
       if (consumer == null) {
+        assertTrue(msg.isSend());
         assertEquals(received, msg.body());
         if (options != null && options.getHeaders() != null) {
           assertNotNull(msg.headers());
@@ -992,6 +993,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     });
     eb.send(ADDRESS1, str, onSuccess((Message<R> reply) -> {
       if (consumer == null) {
+        assertTrue(reply.isSend());
         assertEquals(received, reply.body());
         if (options != null && options.getHeaders() != null) {
           assertNotNull(reply.headers());
@@ -1015,6 +1017,7 @@ public class LocalEventBusTest extends EventBusTestBase {
       @Override
       public void handle(Message<T> msg) {
         if (consumer == null) {
+          assertFalse(msg.isSend());
           assertEquals(val, msg.body());
         } else {
           consumer.accept(msg.body());


### PR DESCRIPTION
This allows the TCP EventBus bridge to signal to the client that the
serialized message should be treated as a send or publish.

See https://github.com/vert-x3/vertx-tcp-eventbus-bridge/issues/20 for
more details.

Are there any known implementations of the `Message` interface outside of Vert.x core? If so, this change would break them unless we added a default implementation to the interface. However, a default implementation would likely need to return a constant value (possibly `true`), which may not be desirable.  