### PR TITLE
Expose the HttpClientRequest in HttpClientResponse

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClientResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpClientResponse.java
@@ -149,4 +149,9 @@ public interface HttpClientResponse extends ReadStream<Buffer> {
   @CacheReturn
   NetSocket netSocket();
 
+  /**
+   * @return the corresponding request
+   */
+  @CacheReturn
+  HttpClientRequest request();
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -490,6 +490,11 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
           private boolean resumed;
 
           @Override
+          public HttpClientRequest request() {
+            return resp.request();
+          }
+
+          @Override
           public int statusCode() {
             return resp.statusCode();
           }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -75,7 +75,8 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
     this.headers = headers;
   }
 
-  HttpClientRequestBase request() {
+  @Override
+  public HttpClientRequestBase request() {
     return request;
   }
 


### PR DESCRIPTION
The method is already there, just not exposed in the interface. I suggest to expose it.