### PR TITLE
Fixes vert-x3/issues#75 Send messages instantly

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,7 +2,6 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
-
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -16,17 +16,35 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
-import io.vertx.core.eventbus.impl.*;
+import io.vertx.core.eventbus.impl.CodecManager;
+import io.vertx.core.eventbus.impl.EventBusImpl;
+import io.vertx.core.eventbus.impl.HandlerHolder;
+import io.vertx.core.eventbus.impl.MessageImpl;
 import io.vertx.core.impl.HAManager;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.net.*;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.TCPSSLOptions;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
@@ -224,7 +242,8 @@ public class ClusteredEventBus extends EventBusImpl {
         log.error("Failed to send message", asyncResult.cause());
       }
     };
-    if (Vertx.currentContext() == null) {
+    Context context = Vertx.currentContext();
+    if (context == null || !context.isEventLoopContext()) {
       // Guarantees the order when there is no current context
       sendNoContext.runOnContext(v -> {
         subs.get(address, resultHandler);

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -245,6 +245,7 @@ public class ClusteredEventBus extends EventBusImpl {
     Context context = Vertx.currentContext();
     if (context == null || !context.isEventLoopContext()) {
       // Guarantees the order when there is no current context
+      // Or, when there is a worker context, makes sure message can be sent instantly
       sendNoContext.runOnContext(v -> {
         subs.get(address, resultHandler);
       });

--- a/src/test/java/io/vertx/test/core/EventBusTestBase.java
+++ b/src/test/java/io/vertx/test/core/EventBusTestBase.java
@@ -393,25 +393,20 @@ public abstract class EventBusTestBase extends VertxTestBase {
       receivedLatch.countDown();
     }).completionHandler(ar -> {
       assertTrue(ar.succeeded());
-      vertices[0].deployVerticle(new AbstractVerticle() {
-        @Override
-        public void start() throws Exception {
-          vertx().executeBlocking(fut -> {
-            vertices[0].eventBus().send(ADDRESS1, expectedBody);
-            try {
-              awaitLatch(receivedLatch); // Make sure message is sent even if we're busy
-            } catch (InterruptedException e) {
-              Thread.interrupted();
-              fut.fail(e);
-            }
-            fut.complete();
-          }, ar -> {
-            if (ar.succeeded()) {
-              testComplete();
-            } else {
-              fail(ar.cause());
-            }
-          });
+      vertices[0].executeBlocking(fut -> {
+        vertices[0].eventBus().send(ADDRESS1, expectedBody);
+        try {
+          awaitLatch(receivedLatch); // Make sure message is sent even if we're busy
+        } catch (InterruptedException e) {
+          Thread.interrupted();
+          fut.fail(e);
+        }
+        fut.complete();
+      }, ar2 -> {
+        if (ar2.succeeded()) {
+          testComplete();
+        } else {
+          fail(ar2.cause());
         }
       });
     });


### PR DESCRIPTION
We must make sure messages are sent instantly, whether sent from worker verticle or executeBlocking