### PR TITLE
Fixes #1765 NullPointer in sendToSubs

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -16,17 +16,35 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
-import io.vertx.core.eventbus.impl.*;
+import io.vertx.core.eventbus.impl.CodecManager;
+import io.vertx.core.eventbus.impl.EventBusImpl;
+import io.vertx.core.eventbus.impl.HandlerHolder;
+import io.vertx.core.eventbus.impl.MessageImpl;
 import io.vertx.core.impl.HAManager;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.net.*;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.TCPSSLOptions;
+import io.vertx.core.net.TrustOptions;
 import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
@@ -312,7 +330,7 @@ public class ClusteredEventBus extends EventBusImpl {
     if (sendContext.message.isSend()) {
       // Choose one
       ServerID sid = subs.choose();
-      if (!sid.equals(serverID)) {  //We don't send to this node
+      if (sid != null && !sid.equals(serverID)) {  //We don't send to this node
         metrics.messageSent(address, false, false, true);
         sendRemote(sid, sendContext.message);
       } else {

--- a/src/test/java/io/vertx/test/core/EventBusTestBase.java
+++ b/src/test/java/io/vertx/test/core/EventBusTestBase.java
@@ -19,18 +19,23 @@ package io.vertx.test.core;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.ReplyFailure;
-import io.vertx.core.eventbus.impl.codecs.ReplyExceptionMessageCodec;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.*;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -379,6 +384,76 @@ public abstract class EventBusTestBase extends VertxTestBase {
       testComplete();
     });
     await();
+  }
+
+  @Test
+  public void testSendWhileUnsubscribing() throws Exception {
+    startNodes(2);
+    CountDownLatch registrationLatch = new CountDownLatch(1);
+    MessageConsumer<String> consumer = vertices[0].eventBus().consumer("whatever");
+    consumer.handler(new Handler<Message<String>>() {
+      int received = 0;
+
+      @Override
+      public void handle(Message<String> msg) {
+        if (++received == 1) {
+          consumer.unregister();
+        }
+      }
+    }).completionHandler(ar -> {
+      if (ar.succeeded()) {
+        registrationLatch.countDown();
+      } else {
+        fail(ar.cause());
+      }
+    });
+    awaitLatch(registrationLatch);
+    AtomicBoolean send = new AtomicBoolean(true);
+    while (send.get()) {
+      vertices[0].exceptionHandler(throwable -> {
+        send.set(false);
+        fail(throwable);
+      }).eventBus().send("whatever", "marseille", ar -> {
+        if (send.get() && ar.failed()) {
+          Throwable cause = ar.cause();
+          assertThat(cause, instanceOf(ReplyException.class));
+          ReplyException replyException = (ReplyException) cause;
+          assertEquals(ReplyFailure.NO_HANDLERS, replyException.failureType());
+          send.set(false);
+        }
+      });
+    }
+  }
+
+  @Test
+  public void testPublishWhileUnsubscribing() throws Exception {
+    startNodes(2);
+    CountDownLatch registrationLatch = new CountDownLatch(1);
+    MessageConsumer<String> consumer = vertices[0].eventBus().consumer("whatever");
+    consumer.handler(new Handler<Message<String>>() {
+      int received = 0;
+
+      @Override
+      public void handle(Message<String> msg) {
+        if (++received == 1) {
+          consumer.unregister();
+        }
+      }
+    }).completionHandler(ar -> {
+      if (ar.succeeded()) {
+        registrationLatch.countDown();
+      } else {
+        fail(ar.cause());
+      }
+    });
+    awaitLatch(registrationLatch);
+    AtomicBoolean send = new AtomicBoolean(true);
+    while (send.get()) {
+      vertices[0].exceptionHandler(throwable -> {
+        send.set(false);
+        fail(throwable);
+      }).eventBus().publish("whatever", "marseille");
+    }
   }
 
   protected <T> void testSend(T val) {


### PR DESCRIPTION
The io.vertx.core.spi.cluster.ChoosableIterable contract does not guarantee that
after calling io.vertx.core.spi.cluster.ChoosableIterable.isEmpty,
io.vertx.core.spi.cluster.ChoosableIterable.choose returns a non null entry.

This could happen if a consumer is unregistered on another in the cluster.

Publish shouldn't be affected but I still added a test. In order to reproduce
I had to annotate the test with @Repeat(times=1000)
I can't leave the annotation as this would take much too long with real cluster managers.
The issue could be reproduced with the FakeClusterManager anyway.