### PR TITLE
Recursive mergeIn for JsonObject

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -691,22 +691,22 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    */
   @SuppressWarnings("unchecked")
   public JsonObject mergeIn(JsonObject other, int depth) {
-    if(depth < 1) {
+    if (depth < 1) {
       return this;
     }
-    if(depth == 1) {
+    if (depth == 1) {
       map.putAll(other.map);
       return this;
     }
-    for(Map.Entry<String, Object> e : other.map.entrySet()) {
+    for (Map.Entry<String, Object> e: other.map.entrySet()) {
       map.merge(e.getKey(), e.getValue(), (oldVal, newVal) -> {
-        if(oldVal instanceof Map) {
+        if (oldVal instanceof Map) {
           oldVal = new JsonObject((Map)oldVal);
         }
-        if(newVal instanceof Map) {
+        if (newVal instanceof Map) {
           newVal = new JsonObject((Map)newVal);
         }
-        if(oldVal instanceof JsonObject && newVal instanceof JsonObject) {
+        if (oldVal instanceof JsonObject && newVal instanceof JsonObject) {
           return ((JsonObject) oldVal).mergeIn((JsonObject)newVal, depth - 1);
         }
         return newVal;

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -678,7 +678,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    * @return a reference to this, so the API can be used fluently
    */
   public JsonObject mergeIn(JsonObject other, boolean deep) {
-    return mergeIn(other, Integer.MAX_VALUE);
+    return mergeIn(other, deep ? Integer.MAX_VALUE : 1);
   }
 
   /**

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -1157,6 +1157,16 @@ public class JsonObjectTest {
   }
 
   @Test
+  public void testMergeInFlat() {
+    JsonObject obj1 = new JsonObject("{ \"foo\": { \"bar\": \"flurb\", \"eek\": 32 }}");
+    JsonObject obj2 = new JsonObject("{ \"foo\": { \"bar\": \"eek\" }}");
+    obj1.mergeIn(obj2, false);
+    assertEquals(1, obj1.size());
+    assertEquals(1, obj1.getJsonObject("foo").size());
+    assertEquals("eek", obj1.getJsonObject("foo").getString("bar"));
+  }
+
+  @Test
   public void testMergeInDepth1() {
     JsonObject obj1 = new JsonObject("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}");
     JsonObject obj2 = new JsonObject("{ \"flurb\": { \"bar\": \"flurb1\" }}");

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -1147,6 +1147,37 @@ public class JsonObjectTest {
   }
 
   @Test
+  public void testMergeInDepth0() {
+    JsonObject obj1 = new JsonObject("{ \"foo\": { \"bar\": \"flurb\" }}");
+    JsonObject obj2 = new JsonObject("{ \"foo\": { \"bar\": \"eek\" }}");
+    obj1.mergeIn(obj2, 0);
+    assertEquals(1, obj1.size());
+    assertEquals(1, obj1.getJsonObject("foo").size());
+    assertEquals("flurb", obj1.getJsonObject("foo").getString("bar"));
+  }
+
+  @Test
+  public void testMergeInDepth1() {
+    JsonObject obj1 = new JsonObject("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}");
+    JsonObject obj2 = new JsonObject("{ \"flurb\": { \"bar\": \"flurb1\" }}");
+    obj1.mergeIn(obj2, 1);
+    assertEquals(2, obj1.size());
+    assertEquals(1, obj1.getJsonObject("flurb").size());
+    assertEquals("flurb1", obj1.getJsonObject("flurb").getString("bar"));
+  }
+
+  @Test
+  public void testMergeInDepth2() {
+    JsonObject obj1 = new JsonObject("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}");
+    JsonObject obj2 = new JsonObject("{ \"flurb\": { \"bar\": \"flurb1\" }}");
+    obj1.mergeIn(obj2, 2);
+    assertEquals(2, obj1.size());
+    assertEquals(2, obj1.getJsonObject("flurb").size());
+    assertEquals("foo", obj1.getJsonObject("flurb").getString("eek"));
+    assertEquals("flurb1", obj1.getJsonObject("flurb").getString("bar"));
+  }
+
+  @Test
   public void testEncode() throws Exception {
     jsonObject.put("mystr", "foo");
     jsonObject.put("mycharsequence", new StringBuilder("oob"));


### PR DESCRIPTION
Implementation of a recursive mergeIn method for JsonObject. The existing mergeIn method keeps its semantic of a flat merge. But the new overloads allow deep merges. e.g.:

```
JsonObject defaultConfig = new JsonObject()
   .put("mongo", new JsonObject()
      .put("db_name", "mydb")
      .put("host", "localhost")
      .put("port", 27017));

// configFile: { "mongo": { "host": "prod.mongo.dbhost" } }
JsonObject config = defaultConfig.mergeIn(configFile, true);
// config now contains all defaults and the host that was overriden in the configFile
```