### PR TITLE
NetServer rework

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -2,6 +2,7 @@
 
 The described `link:../../apidocs/io/vertx/core/cli/Option.html[Option]` and `link:../../apidocs/io/vertx/core/cli/Argument.html[Argument]` classes are _untyped_,
 meaning that the only get String values.
+
 `link:../../apidocs/io/vertx/core/cli/TypedOption.html[TypedOption]` and `link:../../apidocs/io/vertx/core/cli/TypedArgument.html[TypedArgument]` let you specify a _type_, so the
 (String) raw value is converted to the specified type.
 

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -33,7 +33,6 @@ import io.vertx.core.datagram.PacketWritestream;
 import io.vertx.core.impl.Arguments;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.net.NetworkOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.PartialPooledByteBufAllocator;
@@ -41,7 +40,6 @@ import io.vertx.core.net.impl.SocketAddressImpl;
 import io.vertx.core.spi.metrics.DatagramSocketMetrics;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
-import io.vertx.core.spi.metrics.NetworkMetrics;
 
 import java.net.*;
 import java.util.Objects;
@@ -52,10 +50,11 @@ import java.util.Objects;
 public class DatagramSocketImpl extends ConnectionBase implements DatagramSocket, MetricsProvider {
 
   private Handler<io.vertx.core.datagram.DatagramPacket> packetHandler;
+  private DatagramSocketMetrics metrics;
 
   public DatagramSocketImpl(VertxInternal vertx, DatagramSocketOptions options) {
     super(vertx, createChannel(options.isIpV6() ? io.vertx.core.datagram.impl.InternetProtocolFamily.IPv6 : io.vertx.core.datagram.impl.InternetProtocolFamily.IPv4,
-          new DatagramSocketOptions(options)), vertx.getOrCreateContext(), options);
+          new DatagramSocketOptions(options)), vertx.getOrCreateContext());
     ContextImpl creatingContext = vertx.getContext();
     if (creatingContext != null && creatingContext.isMultiThreadedWorkerContext()) {
       throw new IllegalStateException("Cannot use DatagramSocket in a multi-threaded worker verticle");
@@ -68,11 +67,12 @@ public class DatagramSocketImpl extends ConnectionBase implements DatagramSocket
     channel.pipeline().addLast("handler", new DatagramServerHandler(this));
     channel().config().setMaxMessagesPerRead(1);
     channel().config().setAllocator(PartialPooledByteBufAllocator.INSTANCE);
+    metrics = vertx.metricsSPI().createMetrics(this, (DatagramSocketOptions) options);
   }
 
   @Override
-  protected NetworkMetrics createMetrics(NetworkOptions options) {
-    return vertx.metricsSPI().createMetrics(this, (DatagramSocketOptions) options);
+  public DatagramSocketMetrics metrics() {
+    return metrics;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -76,11 +76,6 @@ public class DatagramSocketImpl extends ConnectionBase implements DatagramSocket
   }
 
   @Override
-  protected Object metric() {
-    return null;
-  }
-
-  @Override
   public DatagramSocket listenMulticastGroup(String multicastAddress, Handler<AsyncResult<DatagramSocket>> handler) {
     try {
       addListener(channel().joinGroup(InetAddress.getByName(multicastAddress)), handler);

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -18,7 +18,6 @@ package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
-import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.websocketx.*;
@@ -93,7 +92,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
 
   ClientConnection(HttpVersion version, HttpClientImpl client, Object endpointMetric, Channel channel, boolean ssl, String host,
                    int port, ContextImpl context, Http1xPool pool, HttpClientMetrics metrics) {
-    super(client.getVertx(), channel, context, metrics);
+    super(client.getVertx(), channel, context);
     this.client = client;
     this.ssl = ssl;
     this.host = host;
@@ -104,7 +103,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
     this.endpointMetric = endpointMetric;
   }
 
-  protected HttpClientMetrics metrics() {
+  public HttpClientMetrics metrics() {
     return metrics;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -587,7 +587,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
       pipeline.remove(inflater);
     }
     pipeline.remove("codec");
-    pipeline.replace("handler", "handler",  new VertxNetHandler(channel, socket, connectionMap) {
+    pipeline.replace("handler", "handler",  new VertxNetHandler<NetSocketImpl>(channel, socket, connectionMap) {
       @Override
       public void exceptionCaught(ChannelHandlerContext chctx, Throwable t) throws Exception {
         // remove from the real mapping
@@ -612,6 +612,12 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
           return;
         }
         super.channelRead(chctx, msg);
+      }
+
+      @Override
+      protected void handleMsgReceived(Object msg) {
+        ByteBuf buf = (ByteBuf) msg;
+        conn.handleDataReceived(Buffer.buffer(buf));
       }
     });
     return socket;

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -120,7 +120,9 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
   void createConn(HttpVersion version, ContextImpl context, int port, String host, Channel ch, Waiter waiter) {
     ClientConnection conn = new ClientConnection(version, client, queue.metric, ch,
         ssl, host, port, context, this, metrics);
-    metrics.endpointConnected(queue.metric, conn.metric());
+    Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
+    conn.metric(metric);
+    metrics.endpointConnected(queue.metric, metric);
     ClientHandler handler = ch.pipeline().get(ClientHandler.class);
     handler.conn = conn;
     synchronized (queue) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -41,6 +41,7 @@ import io.vertx.core.http.StreamResetException;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.vertx.core.spi.metrics.NetworkMetrics;
 
 import java.util.Map;
 
@@ -62,10 +63,15 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
                                Channel channel,
                                VertxHttp2ConnectionHandler connHandler,
                                HttpClientMetrics metrics) {
-    super(channel, context, connHandler, metrics);
+    super(channel, context, connHandler);
     this.http2Pool = http2Pool;
     this.metrics = metrics;
     this.queueMetric = queueMetric;
+  }
+
+  @Override
+  public HttpClientMetrics metrics() {
+    return metrics;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -54,7 +54,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   final Http2Pool http2Pool;
   final HttpClientMetrics metrics;
   final Object queueMetric;
-  final Object metric;
   int streamCount;
 
   public Http2ClientConnection(Http2Pool http2Pool,
@@ -66,7 +65,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     super(channel, context, connHandler, metrics);
     this.http2Pool = http2Pool;
     this.metrics = metrics;
-    this.metric = metrics.connected(remoteAddress(), remoteName());
     this.queueMetric = queueMetric;
   }
 
@@ -94,11 +92,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     Http2ClientStream clientStream = new Http2ClientStream(this, stream, writable);
     streams.put(clientStream.stream.id(), clientStream);
     return clientStream;
-  }
-
-  @Override
-  protected Object metric() {
-    return metric;
   }
 
   @Override
@@ -132,7 +125,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           Http2Stream promisedStream = handler.connection().stream(promisedStreamId);
           HttpClientRequestPushPromise pushReq = new HttpClientRequestPushPromise(this, promisedStream, http2Pool.client, method, rawMethod, uri, host, headersMap);
           if (metrics.isEnabled()) {
-            pushReq.metric(metrics.responsePushed(queueMetric, metric, localAddress(), remoteAddress(), pushReq));
+            pushReq.metric(metrics.responsePushed(queueMetric, metric(), localAddress(), remoteAddress(), pushReq));
           }
           streams.put(promisedStreamId, pushReq.getStream());
           pushHandler.handle(pushReq);
@@ -314,7 +307,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         h.set(HttpHeaderNames.ACCEPT_ENCODING, DEFLATE_GZIP);
       }
       if (conn.metrics.isEnabled()) {
-        request.metric(conn.metrics.requestBegin(conn.queueMetric, conn.metric, conn.localAddress(), conn.remoteAddress(), request));
+        request.metric(conn.metrics.requestBegin(conn.queueMetric, conn.metric(), conn.localAddress(), conn.remoteAddress(), request));
       }
       writeHeaders(h, end && content == null);
       if (content != null) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -94,8 +94,8 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   private boolean closed;
   private int windowSize;
 
-  public Http2ConnectionBase(Channel channel, ContextImpl context, VertxHttp2ConnectionHandler handler, TCPMetrics metrics) {
-    super((VertxInternal) context.owner(), channel, context, metrics);
+  public Http2ConnectionBase(Channel channel, ContextImpl context, VertxHttp2ConnectionHandler handler) {
+    super((VertxInternal) context.owner(), channel, context);
     this.channel = channel;
     this.handlerContext = channel.pipeline().context(handler);
     this.handler = handler;

--- a/src/main/java/io/vertx/core/http/impl/Http2Pool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2Pool.java
@@ -92,7 +92,12 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
           .server(false)
           .useCompression(client.getOptions().isTryUseCompression())
           .initialSettings(client.getOptions().getInitialSettings())
-          .connectionFactory(connHandler -> new Http2ClientConnection(Http2Pool.this, queue.metric, context, ch, connHandler, metrics))
+          .connectionFactory(connHandler -> {
+            Http2ClientConnection conn = new Http2ClientConnection(Http2Pool.this, queue.metric, context, ch, connHandler, metrics);
+            Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
+            conn.metric(metric);
+            return conn;
+          })
           .logEnabled(logEnabled)
           .build();
       if (upgrade) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -52,7 +52,6 @@ public class Http2ServerConnection extends Http2ConnectionBase {
   private final String serverOrigin;
   private final Handler<HttpServerRequest> requestHandler;
   private final HttpServerMetrics metrics;
-  private final Object metric;
 
   private Long maxConcurrentStreams;
   private int concurrentStreams;
@@ -71,7 +70,6 @@ public class Http2ServerConnection extends Http2ConnectionBase {
     this.options = options;
     this.serverOrigin = serverOrigin;
     this.requestHandler = requestHandler;
-    this.metric = metrics.connected(remoteAddress(), remoteName());
     this.metrics = metrics;
   }
 
@@ -199,11 +197,6 @@ public class Http2ServerConnection extends Http2ConnectionBase {
   protected void updateSettings(Http2Settings settingsUpdate, Handler<AsyncResult<Void>> completionHandler) {
     settingsUpdate.remove(Http2CodecUtil.SETTINGS_ENABLE_PUSH);
     super.updateSettings(settingsUpdate, completionHandler);
-  }
-
-  @Override
-  protected Object metric() {
-    return metric;
   }
 
   private class Push extends VertxHttp2Stream<Http2ServerConnection> {

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -65,7 +65,7 @@ public class Http2ServerConnection extends Http2ConnectionBase {
       HttpServerOptions options,
       Handler<HttpServerRequest> requestHandler,
       HttpServerMetrics metrics) {
-    super(channel, context, connHandler, metrics);
+    super(channel, context, connHandler);
 
     this.options = options;
     this.serverOrigin = serverOrigin;
@@ -73,7 +73,7 @@ public class Http2ServerConnection extends Http2ConnectionBase {
     this.metrics = metrics;
   }
 
-  HttpServerMetrics metrics() {
+  public HttpServerMetrics metrics() {
     return metrics;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -61,7 +61,6 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.AsyncResultHandler;
 import io.vertx.core.Closeable;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -359,7 +358,11 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
         .useDecompression(options.isDecompressionSupported())
         .compressionLevel(options.getCompressionLevel())
         .initialSettings(options.getInitialSettings())
-        .connectionFactory(connHandler -> new Http2ServerConnection(ch, holder.context, serverOrigin, connHandler, options, holder.handler.requesthHandler, metrics))
+        .connectionFactory(connHandler -> {
+          Http2ServerConnection conn = new Http2ServerConnection(ch, holder.context, serverOrigin, connHandler, options, holder.handler.requesthHandler, metrics);
+          conn.metric(metrics.connected(conn.remoteAddress(), conn.remoteName()));
+          return conn;
+        })
         .logEnabled(logEnabled)
         .build();
   }

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -48,6 +48,7 @@ import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.NetSocketImpl;
 import io.vertx.core.net.impl.VertxNetHandler;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.NetworkMetrics;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -95,11 +96,16 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
 
   ServerConnection(VertxInternal vertx, HttpServerImpl server, Channel channel, ContextImpl context, String serverOrigin,
                    WebSocketServerHandshaker handshaker, HttpServerMetrics metrics) {
-    super(vertx, channel, context, metrics);
+    super(vertx, channel, context);
     this.serverOrigin = serverOrigin;
     this.server = server;
     this.handshaker = handshaker;
     this.metrics = metrics;
+  }
+
+  @Override
+  public HttpServerMetrics metrics() {
+    return metrics;
   }
 
   public synchronized void pause() {

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -234,7 +234,7 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
       pipeline.remove("chunkedWriter");
     }
 
-    channel.pipeline().replace("handler", "handler", new VertxNetHandler(channel, socket, connectionMap) {
+    channel.pipeline().replace("handler", "handler", new VertxNetHandler<NetSocketImpl>(channel, socket, connectionMap) {
       @Override
       public void exceptionCaught(ChannelHandlerContext chctx, Throwable t) throws Exception {
         // remove from the real mapping
@@ -256,6 +256,12 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
           return;
         }
         super.channelRead(chctx, msg);
+      }
+
+      @Override
+      protected void handleMsgReceived(Object msg) {
+        ByteBuf buf = (ByteBuf) msg;
+        conn.handleDataReceived(Buffer.buffer(buf));
       }
     });
 

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -51,6 +51,7 @@ import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.impl.NetClientImpl;
 import io.vertx.core.net.impl.NetServerImpl;
+import io.vertx.core.net.impl.NetServerBase;
 import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.shareddata.SharedData;
 import io.vertx.core.shareddata.impl.SharedDataImpl;
@@ -96,7 +97,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final DeploymentManager deploymentManager;
   private final FileResolver fileResolver;
   private final Map<ServerID, HttpServerImpl> sharedHttpServers = new HashMap<>();
-  private final Map<ServerID, NetServerImpl> sharedNetServers = new HashMap<>();
+  private final Map<ServerID, NetServerBase> sharedNetServers = new HashMap<>();
   private final WorkerPool workerPool;
   private final WorkerPool internalBlockingPool;
   private final ThreadFactory eventLoopThreadFactory;
@@ -320,7 +321,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     return sharedHttpServers;
   }
 
-  public Map<ServerID, NetServerImpl> sharedNetServers() {
+  public Map<ServerID, NetServerBase> sharedNetServers() {
     return sharedNetServers;
   }
 
@@ -488,7 +489,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
             closeClusterManager(ar4 -> {
               // Copy set to prevent ConcurrentModificationException
               Set<HttpServer> httpServers = new HashSet<>(sharedHttpServers.values());
-              Set<NetServer> netServers = new HashSet<>(sharedNetServers.values());
+              Set<NetServerBase> netServers = new HashSet<>(sharedNetServers.values());
               sharedHttpServers.clear();
               sharedNetServers.clear();
 
@@ -508,7 +509,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
               for (HttpServer server : httpServers) {
                 server.close(serverCloseHandler);
               }
-              for (NetServer server : netServers) {
+              for (NetServerBase server : netServers) {
                 server.close(serverCloseHandler);
               }
               if (serverCount == 0) {

--- a/src/main/java/io/vertx/core/impl/VertxInternal.java
+++ b/src/main/java/io/vertx/core/impl/VertxInternal.java
@@ -26,7 +26,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.impl.HttpServerImpl;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.impl.NetServerImpl;
+import io.vertx.core.net.impl.NetServerBase;
 import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.metrics.VertxMetrics;
@@ -57,7 +57,7 @@ public interface VertxInternal extends Vertx {
 
   Map<ServerID, HttpServerImpl> sharedHttpServers();
 
-  Map<ServerID, NetServerImpl> sharedNetServers();
+  Map<ServerID, NetServerBase> sharedNetServers();
 
   VertxMetrics metricsSPI();
 

--- a/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
+++ b/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
@@ -35,7 +35,6 @@ import io.vertx.core.http.WebSocket;
 import io.vertx.core.spi.metrics.*;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
 
@@ -78,7 +77,7 @@ public class DummyVertxMetrics implements VertxMetrics {
   }
 
   @Override
-  public TCPMetrics createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options) {
+  public TCPMetrics createMetrics(SocketAddress localAddress, NetServerOptions options) {
     return DummyTCPMetrics.INSTANCE;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -59,6 +59,7 @@ public abstract class ConnectionBase {
   private boolean needsFlush;
   private Thread ctxThread;
   private boolean needsAsyncFlush;
+  private Object metric;
 
   protected ConnectionBase(VertxInternal vertx, Channel channel, ContextImpl context, NetworkMetrics metrics) {
     this.vertx = vertx;
@@ -182,7 +183,13 @@ public abstract class ConnectionBase {
     return context;
   }
 
-  protected abstract Object metric();
+  public synchronized void metric(Object metric) {
+    this.metric = metric;
+  }
+
+  public synchronized Object metric() {
+    return metric;
+  }
 
   protected synchronized void handleException(Throwable t) {
     metrics.exceptionOccurred(metric(), remoteAddress(), t);

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -24,6 +24,7 @@ import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.NetworkOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.NetworkMetrics;
 import io.vertx.core.spi.metrics.TCPMetrics;

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -233,12 +233,12 @@ public class NetClientImpl implements NetClient, MetricsProvider {
   private void connected(ContextImpl context, Channel ch, Handler<AsyncResult<NetSocket>> connectHandler, String host, int port) {
     // Need to set context before constructor is called as writehandler registration needs this
     ContextImpl.setContext(context);
-    NetSocketImpl sock = new NetSocketImpl(vertx, ch, host, port, context, sslHelper, metrics, null);
+    NetSocketImpl sock = new NetSocketImpl(vertx, ch, host, port, context, sslHelper, metrics);
     VertxNetHandler handler = ch.pipeline().get(VertxNetHandler.class);
     handler.conn = sock;
     socketMap.put(ch, sock);
     context.executeFromIO(() -> {
-      sock.setMetric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
+      sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
       connectHandler.handle(Future.succeededFuture(sock));
     });
   }

--- a/src/main/java/io/vertx/core/net/impl/NetServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerBase.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.net.impl;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.spi.metrics.Metrics;
+import io.vertx.core.spi.metrics.MetricsProvider;
+import io.vertx.core.spi.metrics.TCPMetrics;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *
+ * This class is thread-safe
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public abstract class NetServerBase<C extends ConnectionBase> implements Closeable, MetricsProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(NetServerBase.class);
+
+  protected final VertxInternal vertx;
+  protected final NetServerOptions options;
+  protected final ContextImpl creatingContext;
+  protected final SSLHelper sslHelper;
+  protected final boolean logEnabled;
+  private final Map<Channel, C> socketMap = new ConcurrentHashMap<>();
+  private final VertxEventLoopGroup availableWorkers = new VertxEventLoopGroup();
+  private final HandlerManager<Handler<? super C>> handlerManager = new HandlerManager<>(availableWorkers);
+  private ChannelGroup serverChannelGroup;
+  private boolean paused;
+  private volatile boolean listening;
+  private Handler<? super C> registeredHandler;
+  private volatile ServerID id;
+  private NetServerBase actualServer;
+  private AsyncResolveConnectHelper bindFuture;
+  private volatile int actualPort;
+  private ContextImpl listenContext;
+  private TCPMetrics metrics;
+
+  public NetServerBase(VertxInternal vertx, NetServerOptions options) {
+    this.vertx = vertx;
+    this.options = new NetServerOptions(options);
+    this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
+    this.creatingContext = vertx.getContext();
+    this.logEnabled = options.getLogActivity();
+    if (creatingContext != null) {
+      if (creatingContext.isMultiThreadedWorkerContext()) {
+        throw new IllegalStateException("Cannot use NetServer in a multi-threaded worker verticle");
+      }
+      creatingContext.addCloseHook(this);
+    }
+  }
+
+  protected synchronized void pauseAccepting() {
+    paused = true;
+  }
+
+  protected synchronized void resumeAccepting() {
+    paused = false;
+  }
+
+  protected synchronized boolean isPaused() {
+    return paused;
+  }
+
+  protected boolean isListening() {
+    return listening;
+  }
+
+  protected abstract void initChannel(ChannelPipeline pipeline);
+
+  public synchronized void listen(Handler<? super C> handler, int port, String host, Handler<AsyncResult<Void>> listenHandler) {
+    if (handler == null) {
+      throw new IllegalStateException("Set connect handler first");
+    }
+    if (listening) {
+      throw new IllegalStateException("Listen already called");
+    }
+    listening = true;
+
+    listenContext = vertx.getOrCreateContext();
+    registeredHandler = handler;
+
+    synchronized (vertx.sharedNetServers()) {
+      this.actualPort = port; // Will be updated on bind for a wildcard port
+      id = new ServerID(port, host);
+      NetServerBase shared = vertx.sharedNetServers().get(id);
+      if (shared == null || port == 0) { // Wildcard port will imply a new actual server each time
+        serverChannelGroup = new DefaultChannelGroup("vertx-acceptor-channels", GlobalEventExecutor.INSTANCE);
+
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(availableWorkers);
+        bootstrap.channel(NioServerSocketChannel.class);
+        sslHelper.validate(vertx);
+
+        bootstrap.childHandler(new ChannelInitializer<Channel>() {
+          @Override
+          protected void initChannel(Channel ch) throws Exception {
+            if (isPaused()) {
+              ch.close();
+              return;
+            }
+            ChannelPipeline pipeline = ch.pipeline();
+            NetServerBase.this.initChannel(ch.pipeline());
+            pipeline.addLast("handler", new ServerHandler(ch));
+          }
+        });
+
+        applyConnectionOptions(bootstrap);
+
+        handlerManager.addHandler(handler, listenContext);
+
+        try {
+          bindFuture = AsyncResolveConnectHelper.doBind(vertx, port, host, bootstrap);
+          bindFuture.addListener(res -> {
+            if (res.succeeded()) {
+              Channel ch = res.result();
+              log.trace("Net server listening on " + host + ":" + ch.localAddress());
+              // Update port to actual port - wildcard port 0 might have been used
+              NetServerBase.this.actualPort = ((InetSocketAddress)ch.localAddress()).getPort();
+              NetServerBase.this.id = new ServerID(NetServerBase.this.actualPort, id.host);
+              serverChannelGroup.add(ch);
+              vertx.sharedNetServers().put(id, NetServerBase.this);
+              metrics = vertx.metricsSPI().createMetrics(new SocketAddressImpl(id.port, id.host), options);
+            } else {
+              vertx.sharedNetServers().remove(id);
+            }
+          });
+
+        } catch (Throwable t) {
+          // Make sure we send the exception back through the handler (if any)
+          if (listenHandler != null) {
+            vertx.runOnContext(v ->  listenHandler.handle(Future.failedFuture(t)));
+          } else {
+            // No handler - log so user can see failure
+            log.error(t);
+          }
+          listening = false;
+          return;
+        }
+        if (port != 0) {
+          vertx.sharedNetServers().put(id, this);
+        }
+        actualServer = this;
+      } else {
+        // Server already exists with that host/port - we will use that
+        actualServer = shared;
+        this.actualPort = shared.actualPort();
+        metrics = vertx.metricsSPI().createMetrics(new SocketAddressImpl(id.port, id.host), options);
+        actualServer.handlerManager.addHandler(handler, listenContext);
+      }
+
+      // just add it to the future so it gets notified once the bind is complete
+      actualServer.bindFuture.addListener(res -> {
+        if (listenHandler != null) {
+          AsyncResult<Void> ares;
+          if (res.succeeded()) {
+            ares = Future.succeededFuture();
+          } else {
+            listening = false;
+            ares = Future.failedFuture(res.cause());
+          }
+          // Call with expectRightThread = false as if server is already listening
+          // Netty will call future handler immediately with calling thread
+          // which might be a non Vert.x thread (if running embedded)
+          listenContext.runOnContext(v -> listenHandler.handle(ares));
+        } else if (res.failed()) {
+          // No handler - log so user can see failure
+          log.error("Failed to listen", res.cause());
+          listening = false;
+        }
+      });
+    }
+    return;
+  }
+
+  public synchronized void close() {
+    close(null);
+  }
+
+  @Override
+  public synchronized void close(Handler<AsyncResult<Void>> done) {
+    ContextImpl context = vertx.getOrCreateContext();
+    if (!listening) {
+      if (done != null) {
+        executeCloseDone(context, done, null);
+      }
+      return;
+    }
+    listening = false;
+    synchronized (vertx.sharedNetServers()) {
+
+      if (actualServer != null) {
+        actualServer.handlerManager.removeHandler(registeredHandler, listenContext);
+
+        if (actualServer.handlerManager.hasHandlers()) {
+          // The actual server still has handlers so we don't actually close it
+          if (done != null) {
+            executeCloseDone(context, done, null);
+          }
+        } else {
+          // No Handlers left so close the actual server
+          // The done handler needs to be executed on the context that calls close, NOT the context
+          // of the actual server
+          actualServer.actualClose(context, done);
+        }
+      }
+    }
+    if (creatingContext != null) {
+      creatingContext.removeCloseHook(this);
+    }
+  }
+
+  public synchronized int actualPort() {
+    return actualPort;
+  }
+
+  @Override
+  public boolean isMetricsEnabled() {
+    return metrics != null && metrics.isEnabled();
+  }
+
+  @Override
+  public Metrics getMetrics() {
+    return metrics;
+  }
+
+  private void actualClose(ContextImpl closeContext, Handler<AsyncResult<Void>> done) {
+    if (id != null) {
+      vertx.sharedNetServers().remove(id);
+    }
+
+    ContextImpl currCon = vertx.getContext();
+
+    for (C sock : socketMap.values()) {
+      sock.close();
+    }
+
+    // Sanity check
+    if (vertx.getContext() != currCon) {
+      throw new IllegalStateException("Context was changed");
+    }
+
+    ChannelGroupFuture fut = serverChannelGroup.close();
+    fut.addListener(cg -> {
+      if (metrics != null) {
+        metrics.close();
+      }
+      executeCloseDone(closeContext, done, fut.cause());
+    });
+
+  }
+
+  private void executeCloseDone(ContextImpl closeContext, Handler<AsyncResult<Void>> done, Exception e) {
+    if (done != null) {
+      Future<Void> fut = e == null ? Future.succeededFuture() : Future.failedFuture(e);
+      closeContext.runOnContext(v -> done.handle(fut));
+    }
+  }
+
+  private class ServerHandler extends VertxNetHandler<C> {
+    public ServerHandler(Channel ch) {
+      super(ch, socketMap);
+    }
+
+    @Override
+    protected void handleMsgReceived(Object msg) {
+      NetServerBase.this.handleMsgReceived(conn, msg);
+    }
+
+    @Override
+    protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+      return NetServerBase.this.safeObject(msg, allocator);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+      Channel ch = ctx.channel();
+      EventLoop worker = ch.eventLoop();
+
+      //Choose a handler
+      HandlerHolder<Handler<? super C>> handler = handlerManager.chooseHandler(worker);
+      if (handler == null) {
+        //Ignore
+        return;
+      }
+
+      if (sslHelper.isSSL()) {
+        SslHandler sslHandler = ch.pipeline().get(SslHandler.class);
+
+        io.netty.util.concurrent.Future<Channel> fut = sslHandler.handshakeFuture();
+        fut.addListener(future -> {
+          if (future.isSuccess()) {
+            connected(ch, handler);
+          } else {
+            log.error("Client from origin " + ch.remoteAddress() + " failed to connect over ssl: " + future.cause());
+          }
+        });
+      } else {
+        connected(ch, handler);
+      }
+    }
+
+    private void connected(Channel ch, HandlerHolder<Handler<? super C>> handler) {
+      // Need to set context before constructor is called as writehandler registration needs this
+      ContextImpl.setContext(handler.context);
+      C sock = createConnection(vertx, ch, handler.context, sslHelper, metrics);
+      socketMap.put(ch, sock);
+      VertxNetHandler netHandler = ch.pipeline().get(VertxNetHandler.class);
+      netHandler.conn = sock;
+      handler.context.executeFromIO(() -> {
+        sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
+        handler.handler.handle(sock);
+      });
+    }
+  }
+
+  protected abstract void handleMsgReceived(C conn, Object msg);
+
+  protected abstract Object safeObject(Object msg, ByteBufAllocator allocator);
+
+  /**
+   * Create a connection for a channel.
+   *
+   * @return the created connection
+   */
+  protected abstract C createConnection(VertxInternal vertx, Channel channel, ContextImpl context,
+                                        SSLHelper helper, TCPMetrics metrics);
+
+  /**
+   * Apply the connection option to the server.
+   *
+   * @param bootstrap the Netty server bootstrap
+   */
+  protected void applyConnectionOptions(ServerBootstrap bootstrap) {
+    bootstrap.childOption(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
+    if (options.getSendBufferSize() != -1) {
+      bootstrap.childOption(ChannelOption.SO_SNDBUF, options.getSendBufferSize());
+    }
+    if (options.getReceiveBufferSize() != -1) {
+      bootstrap.childOption(ChannelOption.SO_RCVBUF, options.getReceiveBufferSize());
+      bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(options.getReceiveBufferSize()));
+    }
+    if (options.getSoLinger() != -1) {
+      bootstrap.option(ChannelOption.SO_LINGER, options.getSoLinger());
+    }
+    if (options.getTrafficClass() != -1) {
+      bootstrap.childOption(ChannelOption.IP_TOS, options.getTrafficClass());
+    }
+    bootstrap.childOption(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
+
+    bootstrap.childOption(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
+    bootstrap.option(ChannelOption.SO_REUSEADDR, options.isReuseAddress());
+    if (options.getAcceptBacklog() != -1) {
+      bootstrap.option(ChannelOption.SO_BACKLOG, options.getAcceptBacklog());
+    }
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    // Make sure this gets cleaned up if there are no more references to it
+    // so as not to leave connections and resources dangling until the system is shutdown
+    // which could make the JVM run out of file handles.
+    close();
+    super.finalize();
+  }
+}

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -412,12 +412,12 @@ public class NetServerImpl implements NetServer, Closeable, MetricsProvider {
     private void connected(Channel ch, HandlerHolder<Handler<NetSocket>> handler) {
       // Need to set context before constructor is called as writehandler registration needs this
       ContextImpl.setContext(handler.context);
-      NetSocketImpl sock = new NetSocketImpl(vertx, ch, handler.context, sslHelper, metrics, null);
+      NetSocketImpl sock = new NetSocketImpl(vertx, ch, handler.context, sslHelper, metrics);
       socketMap.put(ch, sock);
       VertxNetHandler netHandler = ch.pipeline().get(VertxNetHandler.class);
       netHandler.conn = sock;
       handler.context.executeFromIO(() -> {
-        sock.setMetric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
+        sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
         handler.handler.handle(sock);
       });
     }

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -16,36 +16,25 @@
 
 package io.vertx.core.net.impl;
 
-import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.*;
-import io.netty.channel.group.ChannelGroup;
-import io.netty.channel.group.ChannelGroupFuture;
-import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.util.concurrent.GlobalEventExecutor;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Closeable;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.NetSocketStream;
-import io.vertx.core.spi.metrics.Metrics;
-import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.TCPMetrics;
 
-import java.net.InetSocketAddress;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import static io.vertx.core.net.impl.VertxHandler.safeBuffer;
 
 /**
  *
@@ -53,56 +42,60 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class NetServerImpl implements NetServer, Closeable, MetricsProvider {
+public class NetServerImpl extends NetServerBase<NetSocketImpl> implements NetServer {
 
-  private static final Logger log = LoggerFactory.getLogger(NetServerImpl.class);
-
-  private final VertxInternal vertx;
-  private final NetServerOptions options;
-  private final ContextImpl creatingContext;
-  private final SSLHelper sslHelper;
-  private final Map<Channel, NetSocketImpl> socketMap = new ConcurrentHashMap<>();
-  private final VertxEventLoopGroup availableWorkers = new VertxEventLoopGroup();
-  private final HandlerManager<Handler<NetSocket>> handlerManager = new HandlerManager<>(availableWorkers);
   private final NetSocketStreamImpl connectStream = new NetSocketStreamImpl();
-  private final boolean logEnabled;
-  private ChannelGroup serverChannelGroup;
-  private volatile boolean listening;
-  private volatile ServerID id;
-  private NetServerImpl actualServer;
-  private AsyncResolveConnectHelper bindFuture;
-  private volatile int actualPort;
-  private ContextImpl listenContext;
-  private TCPMetrics metrics;
+  private Handler<NetSocket> handler;
+  private Handler<Void> endHandler;
 
   public NetServerImpl(VertxInternal vertx, NetServerOptions options) {
-    this.vertx = vertx;
-    this.options = new NetServerOptions(options);
-    this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
-    this.creatingContext = vertx.getContext();
-    this.logEnabled = options.getLogActivity();
-    if (creatingContext != null) {
-      if (creatingContext.isMultiThreadedWorkerContext()) {
-        throw new IllegalStateException("Cannot use NetServer in a multi-threaded worker verticle");
-      }
-      creatingContext.addCloseHook(this);
-    }
+    super(vertx, options);
   }
 
   @Override
-  public NetServer connectHandler(Handler<NetSocket> handler) {
-    connectStream.handler(handler);
+  public synchronized Handler<NetSocket> connectHandler() {
+    return handler;
+  }
+
+  @Override
+  public synchronized NetServer connectHandler(Handler<NetSocket> handler) {
+    if (isListening()) {
+      throw new IllegalStateException("Cannot set connectHandler when server is listening");
+    }
+    this.handler = handler;
     return this;
   }
 
   @Override
-  public Handler<NetSocket> connectHandler() {
-    return connectStream.handler();
+  protected void initChannel(ChannelPipeline pipeline) {
+    if (sslHelper.isSSL()) {
+      SslHandler sslHandler = sslHelper.createSslHandler(vertx);
+      pipeline.addLast("ssl", sslHandler);
+    }
+    if (logEnabled) {
+      pipeline.addLast("logging", new LoggingHandler());
+    }
+    if (sslHelper.isSSL()) {
+      // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.
+      pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());       // For large file / sendfile support
+    }
+    if (options.getIdleTimeout() > 0) {
+      pipeline.addLast("idle", new IdleStateHandler(0, 0, options.getIdleTimeout()));
+    }
   }
 
   @Override
-  public NetSocketStream connectStream() {
-    return connectStream;
+  protected void handleMsgReceived(NetSocketImpl conn, Object msg) {
+    ByteBuf buf = (ByteBuf) msg;
+    conn.handleDataReceived(Buffer.buffer(buf));
+  }
+
+  @Override
+  protected Object safeObject(Object msg, ByteBufAllocator allocator) {
+    if (msg instanceof ByteBuf) {
+      return safeBuffer((ByteBuf) msg, allocator);
+    }
+    return msg;
   }
 
   @Override
@@ -132,370 +125,68 @@ public class NetServerImpl implements NetServer, Closeable, MetricsProvider {
   }
 
   @Override
-  public synchronized NetServer listen(int port, String host, Handler<AsyncResult<NetServer>> listenHandler) {
-    if (connectStream.handler() == null) {
-      throw new IllegalStateException("Set connect handler first");
-    }
-    if (listening) {
-      throw new IllegalStateException("Listen already called");
-    }
-    listening = true;
-
-    listenContext = vertx.getOrCreateContext();
-
-    synchronized (vertx.sharedNetServers()) {
-      this.actualPort = port; // Will be updated on bind for a wildcard port
-      id = new ServerID(port, host);
-      NetServerImpl shared = vertx.sharedNetServers().get(id);
-      if (shared == null || port == 0) { // Wildcard port will imply a new actual server each time
-        serverChannelGroup = new DefaultChannelGroup("vertx-acceptor-channels", GlobalEventExecutor.INSTANCE);
-
-        ServerBootstrap bootstrap = new ServerBootstrap();
-        bootstrap.group(availableWorkers);
-        bootstrap.channel(NioServerSocketChannel.class);
-        sslHelper.validate(vertx);
-
-        bootstrap.childHandler(new ChannelInitializer<Channel>() {
-          @Override
-          protected void initChannel(Channel ch) throws Exception {
-            if (connectStream.isPaused()) {
-              ch.close();
-              return;
-            }
-            ChannelPipeline pipeline = ch.pipeline();
-            if (sslHelper.isSSL()) {
-              SslHandler sslHandler = sslHelper.createSslHandler(vertx);
-              pipeline.addLast("ssl", sslHandler);
-            }
-            if (logEnabled) {
-              pipeline.addLast("logging", new LoggingHandler());
-            }
-            if (sslHelper.isSSL()) {
-              // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.
-              pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());       // For large file / sendfile support
-            }
-            if (options.getIdleTimeout() > 0) {
-              pipeline.addLast("idle", new IdleStateHandler(0, 0, options.getIdleTimeout()));
-            }
-            pipeline.addLast("handler", new ServerHandler(ch));
-          }
-        });
-
-        applyConnectionOptions(bootstrap);
-
-        if (connectStream.handler() != null) {
-          handlerManager.addHandler(connectStream.handler(), listenContext);
-        }
-
-        try {
-          bindFuture = AsyncResolveConnectHelper.doBind(vertx, port, host, bootstrap);
-          bindFuture.addListener(res -> {
-            if (res.succeeded()) {
-              Channel ch = res.result();
-              log.trace("Net server listening on " + host + ":" + ch.localAddress());
-              // Update port to actual port - wildcard port 0 might have been used
-              NetServerImpl.this.actualPort = ((InetSocketAddress)ch.localAddress()).getPort();
-              NetServerImpl.this.id = new ServerID(NetServerImpl.this.actualPort, id.host);
-              serverChannelGroup.add(ch);
-              vertx.sharedNetServers().put(id, NetServerImpl.this);
-              metrics = vertx.metricsSPI().createMetrics(this, new SocketAddressImpl(id.port, id.host), options);
-            } else {
-              vertx.sharedNetServers().remove(id);
-            }
-          });
-
-        } catch (Throwable t) {
-          // Make sure we send the exception back through the handler (if any)
-          if (listenHandler != null) {
-            vertx.runOnContext(v ->  listenHandler.handle(Future.failedFuture(t)));
-          } else {
-            // No handler - log so user can see failure
-            log.error(t);
-          }
-          listening = false;
-          return this;
-        }
-        if (port != 0) {
-          vertx.sharedNetServers().put(id, this);
-        }
-        actualServer = this;
-      } else {
-        // Server already exists with that host/port - we will use that
-        actualServer = shared;
-        this.actualPort = shared.actualPort();
-        metrics = vertx.metricsSPI().createMetrics(this, new SocketAddressImpl(id.port, id.host), options);
-        if (connectStream.handler() != null) {
-          actualServer.handlerManager.addHandler(connectStream.handler(), listenContext);
-        }
-      }
-
-      // just add it to the future so it gets notified once the bind is complete
-      actualServer.bindFuture.addListener(res -> {
-        if (listenHandler != null) {
-          AsyncResult<NetServer> ares;
-          if (res.succeeded()) {
-            ares = Future.succeededFuture(NetServerImpl.this);
-          } else {
-            listening = false;
-            ares = Future.failedFuture(res.cause());
-          }
-          // Call with expectRightThread = false as if server is already listening
-          // Netty will call future handler immediately with calling thread
-          // which might be a non Vert.x thread (if running embedded)
-          listenContext.runOnContext(v -> listenHandler.handle(ares));
-        } else if (res.failed()) {
-          // No handler - log so user can see failure
-          log.error("Failed to listen", res.cause());
-          listening = false;
-        }
-      });
-    }
+  public synchronized NetServerImpl listen(int port, String host, Handler<AsyncResult<NetServer>> listenHandler) {
+    listen(handler, port, host, ar -> listenHandler.handle(ar.map(this)));
     return this;
   }
 
-  public synchronized void close() {
-    close(null);
+  @Override
+  public NetSocketStream connectStream() {
+    return connectStream;
   }
 
   @Override
   public synchronized void close(Handler<AsyncResult<Void>> done) {
-    if (connectStream.endHandler() != null) {
-      Handler<Void> endHandler = connectStream.endHandler;
-      connectStream.endHandler = null;
+    if (endHandler != null) {
+      Handler<Void> handler = endHandler;
+      endHandler = null;
       Handler<AsyncResult<Void>> next = done;
       done = event -> {
         if (event.succeeded()) {
-          endHandler.handle(event.result());
+          handler.handle(event.result());
         }
         if (next != null) {
           next.handle(event);
         }
       };
     }
-
-    ContextImpl context = vertx.getOrCreateContext();
-    if (!listening) {
-      if (done != null) {
-        executeCloseDone(context, done, null);
-      }
-      return;
-    }
-    listening = false;
-    synchronized (vertx.sharedNetServers()) {
-
-      if (actualServer != null) {
-        actualServer.handlerManager.removeHandler(connectStream.handler(), listenContext);
-
-        if (actualServer.handlerManager.hasHandlers()) {
-          // The actual server still has handlers so we don't actually close it
-          if (done != null) {
-            executeCloseDone(context, done, null);
-          }
-        } else {
-          // No Handlers left so close the actual server
-          // The done handler needs to be executed on the context that calls close, NOT the context
-          // of the actual server
-          actualServer.actualClose(context, done);
-        }
-      }
-    }
-    if (creatingContext != null) {
-      creatingContext.removeCloseHook(this);
-    }
+    super.close(done);
   }
 
   @Override
-  public synchronized int actualPort() {
-    return actualPort;
-  }
-
-  @Override
-  public boolean isMetricsEnabled() {
-    return metrics != null && metrics.isEnabled();
-  }
-
-  @Override
-  public Metrics getMetrics() {
-    return metrics;
-  }
-
-  private void applyConnectionOptions(ServerBootstrap bootstrap) {
-    bootstrap.childOption(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
-    if (options.getSendBufferSize() != -1) {
-      bootstrap.childOption(ChannelOption.SO_SNDBUF, options.getSendBufferSize());
-    }
-    if (options.getReceiveBufferSize() != -1) {
-      bootstrap.childOption(ChannelOption.SO_RCVBUF, options.getReceiveBufferSize());
-      bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(options.getReceiveBufferSize()));
-    }
-    if (options.getSoLinger() != -1) {
-      bootstrap.option(ChannelOption.SO_LINGER, options.getSoLinger());
-    }
-    if (options.getTrafficClass() != -1) {
-      bootstrap.childOption(ChannelOption.IP_TOS, options.getTrafficClass());
-    }
-    bootstrap.childOption(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
-
-    bootstrap.childOption(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
-    bootstrap.option(ChannelOption.SO_REUSEADDR, options.isReuseAddress());
-    if (options.getAcceptBacklog() != -1) {
-      bootstrap.option(ChannelOption.SO_BACKLOG, options.getAcceptBacklog());
-    }
-  }
-
-  private void actualClose(ContextImpl closeContext, Handler<AsyncResult<Void>> done) {
-    if (id != null) {
-      vertx.sharedNetServers().remove(id);
-    }
-
-    ContextImpl currCon = vertx.getContext();
-
-    for (NetSocketImpl sock : socketMap.values()) {
-      sock.close();
-    }
-
-    // Sanity check
-    if (vertx.getContext() != currCon) {
-      throw new IllegalStateException("Context was changed");
-    }
-
-    ChannelGroupFuture fut = serverChannelGroup.close();
-    fut.addListener(cg -> {
-      if (metrics != null) {
-        metrics.close();
-      }
-      executeCloseDone(closeContext, done, fut.cause());
-    });
-
-  }
-
-  private void executeCloseDone(ContextImpl closeContext, Handler<AsyncResult<Void>> done, Exception e) {
-    if (done != null) {
-      Future<Void> fut = e == null ? Future.succeededFuture() : Future.failedFuture(e);
-      closeContext.runOnContext(v -> done.handle(fut));
-    }
-  }
-
-  private class ServerHandler extends VertxNetHandler {
-    public ServerHandler(Channel ch) {
-      super(ch, socketMap);
-    }
-
-    @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
-      Channel ch = ctx.channel();
-      EventLoop worker = ch.eventLoop();
-
-      //Choose a handler
-      HandlerHolder<Handler<NetSocket>> handler = handlerManager.chooseHandler(worker);
-      if (handler == null) {
-        //Ignore
-        return;
-      }
-
-      if (sslHelper.isSSL()) {
-        SslHandler sslHandler = ch.pipeline().get(SslHandler.class);
-
-        io.netty.util.concurrent.Future<Channel> fut = sslHandler.handshakeFuture();
-        fut.addListener(future -> {
-          if (future.isSuccess()) {
-            connected(ch, handler);
-          } else {
-            log.error("Client from origin " + ch.remoteAddress() + " failed to connect over ssl: " + future.cause());
-          }
-        });
-      } else {
-        connected(ch, handler);
-      }
-    }
-
-    private void connected(Channel ch, HandlerHolder<Handler<NetSocket>> handler) {
-      // Need to set context before constructor is called as writehandler registration needs this
-      ContextImpl.setContext(handler.context);
-      NetSocketImpl sock = new NetSocketImpl(vertx, ch, handler.context, sslHelper, metrics);
-      socketMap.put(ch, sock);
-      VertxNetHandler netHandler = ch.pipeline().get(VertxNetHandler.class);
-      netHandler.conn = sock;
-      handler.context.executeFromIO(() -> {
-        sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
-        handler.handler.handle(sock);
-      });
-    }
-  }
-
-  @Override
-  protected void finalize() throws Throwable {
-    // Make sure this gets cleaned up if there are no more references to it
-    // so as not to leave connections and resources dangling until the system is shutdown
-    // which could make the JVM run out of file handles.
-    close();
-    super.finalize();
+  protected NetSocketImpl createConnection(VertxInternal vertx, Channel channel, ContextImpl context, SSLHelper helper, TCPMetrics metrics) {
+    return new NetSocketImpl(vertx, channel, context, helper, metrics);
   }
 
   /*
-    Needs to be protected using the NetServerImpl monitor as that protects the listening variable
-    In practice synchronized overhead should be close to zero assuming most access is from the same thread due
-    to biased locks
-  */
+        Needs to be protected using the NetServerImpl monitor as that protects the listening variable
+        In practice synchronized overhead should be close to zero assuming most access is from the same thread due
+        to biased locks
+      */
   private class NetSocketStreamImpl implements NetSocketStream {
-
-    private Handler<NetSocket> handler;
-    private boolean paused;
-    private Handler<Void> endHandler;
-
-    Handler<NetSocket> handler() {
-      synchronized (NetServerImpl.this) {
-        return handler;
-      }
-    }
-
-    boolean isPaused() {
-      synchronized (NetServerImpl.this) {
-        return paused;
-      }
-    }
-
-     Handler<Void> endHandler() {
-       synchronized (NetServerImpl.this) {
-         return endHandler;
-       }
-    }
 
     @Override
     public NetSocketStreamImpl handler(Handler<NetSocket> handler) {
-      synchronized (NetServerImpl.this) {
-        if (listening) {
-          throw new IllegalStateException("Cannot set connectHandler when server is listening");
-        }
-        this.handler = handler;
-        return this;
-      }
+      connectHandler(handler);
+      return this;
     }
 
     @Override
     public NetSocketStreamImpl pause() {
-      synchronized (NetServerImpl.this) {
-        if (!paused) {
-          paused = true;
-        }
-        return this;
-      }
+      pauseAccepting();
+      return this;
     }
 
     @Override
     public NetSocketStreamImpl resume() {
-      synchronized (NetServerImpl.this) {
-        if (paused) {
-          paused = false;
-        }
-        return this;
-      }
+      resumeAccepting();
+      return this;
     }
 
     @Override
-    public NetSocketStreamImpl endHandler(Handler<Void> endHandler) {
+    public NetSocketStreamImpl endHandler(Handler<Void> handler) {
       synchronized (NetServerImpl.this) {
-        this.endHandler = endHandler;
+        endHandler = handler;
         return this;
       }
     }

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -302,7 +302,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
     }
   }
 
-  synchronized void handleDataReceived(Buffer data) {
+  public synchronized void handleDataReceived(Buffer data) {
     checkContext();
     if (paused) {
       if (pendingData == null) {

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -64,7 +64,6 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   private final SSLHelper helper;
   private final String host;
   private final int port;
-  private Object metric;
   private Handler<Buffer> dataHandler;
   private Handler<Void> endHandler;
   private Handler<Void> drainHandler;
@@ -73,29 +72,19 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   private ChannelFuture writeFuture;
 
   public NetSocketImpl(VertxInternal vertx, Channel channel, ContextImpl context,
-                       SSLHelper helper, TCPMetrics metrics, Object metric) {
-    this(vertx, channel, null, 0, context, helper, metrics, metric);
+                       SSLHelper helper, TCPMetrics metrics) {
+    this(vertx, channel, null, 0, context, helper, metrics);
   }
 
   public NetSocketImpl(VertxInternal vertx, Channel channel, String host, int port, ContextImpl context,
-                       SSLHelper helper, TCPMetrics metrics, Object metric) {
+                       SSLHelper helper, TCPMetrics metrics) {
     super(vertx, channel, context, metrics);
     this.helper = helper;
     this.writeHandlerID = UUID.randomUUID().toString();
-    this.metric = metric;
     this.host = host;
     this.port = port;
     Handler<Message<Buffer>> writeHandler = msg -> write(msg.body());
     registration = vertx.eventBus().<Buffer>localConsumer(writeHandlerID).handler(writeHandler);
-  }
-
-  protected synchronized void setMetric(Object metric) {
-    this.metric = metric;
-  }
-
-  @Override
-  protected synchronized Object metric() {
-    return metric;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -35,6 +35,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.spi.metrics.NetworkMetrics;
 import io.vertx.core.spi.metrics.TCPMetrics;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -64,6 +65,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   private final SSLHelper helper;
   private final String host;
   private final int port;
+  private final TCPMetrics metrics;
   private Handler<Buffer> dataHandler;
   private Handler<Void> endHandler;
   private Handler<Void> drainHandler;
@@ -78,13 +80,19 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
 
   public NetSocketImpl(VertxInternal vertx, Channel channel, String host, int port, ContextImpl context,
                        SSLHelper helper, TCPMetrics metrics) {
-    super(vertx, channel, context, metrics);
+    super(vertx, channel, context);
     this.helper = helper;
     this.writeHandlerID = UUID.randomUUID().toString();
     this.host = host;
     this.port = port;
+    this.metrics = metrics;
     Handler<Message<Buffer>> writeHandler = msg -> write(msg.body());
     registration = vertx.eventBus().<Buffer>localConsumer(writeHandlerID).handler(writeHandler);
+  }
+
+  @Override
+  public TCPMetrics metrics() {
+    return metrics;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -39,7 +39,7 @@ public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDupl
     return connection.getContext();
   }
 
-  protected static ByteBuf safeBuffer(ByteBuf buf, ByteBufAllocator allocator) {
+  public static ByteBuf safeBuffer(ByteBuf buf, ByteBufAllocator allocator) {
     if (buf == Unpooled.EMPTY_BUFFER) {
       return buf;
     }

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -126,12 +126,11 @@ public interface VertxMetrics extends Metrics, Measured {
    * the provided {@code server} argument can be used to distinguish the different {@code TCPMetrics}
    * instances.
    *
-   * @param server       the Vert.x net server
    * @param localAddress localAddress the local address the net socket is listening on
-   * @param options      the options used to create the {@link io.vertx.core.net.NetServer}
+   * @param options      the options used to create the {@link NetServer}
    * @return the net server metrics SPI
    */
-  TCPMetrics<?> createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options);
+  TCPMetrics<?> createMetrics(SocketAddress localAddress, NetServerOptions options);
 
   /**
    * Provides the net client metrics SPI when a net client is created.<p/>

--- a/src/test/java/io/vertx/test/core/MetricsContextTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsContextTest.java
@@ -520,7 +520,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (vertx, options) -> new DummyVertxMetrics() {
       @Override
-      public TCPMetrics createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options) {
+      public TCPMetrics createMetrics(SocketAddress localAddress, NetServerOptions options) {
         return new DummyTCPMetrics() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {

--- a/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -27,7 +27,6 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.*;
@@ -74,7 +73,7 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     return new FakeHttpClientMetrics(client, options.getMetricsName());
   }
 
-  public TCPMetrics<?> createMetrics(NetServer server, SocketAddress localAddress, NetServerOptions options) {
+  public TCPMetrics<?> createMetrics(SocketAddress localAddress, NetServerOptions options) {
     return new TCPMetrics<Object>() {
 
       public Object connected(SocketAddress remoteAddress, String remoteName) {


### PR DESCRIPTION
Provide the `NetServerBase` that manages the state of a TCP server that is extracted from `NetServerImpl` in order to reuse it in _vertx-mqtt-server_ that will benefit of its feature. The _vertx-mqtt-server_ is based on Netty's MQTT codec.