### PR TITLE
Added unmasked frame supporting for websocket, client and server both…

### DIFF
--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -92,6 +92,10 @@ public class HttpClientOptionsConverter {
     if (json.getValue("verifyHost") instanceof Boolean) {
       obj.setVerifyHost((Boolean)json.getValue("verifyHost"));
     }
+    if(json.getValue("unmaskedFrame") instanceof  Boolean)
+    {
+      obj.setUnmaskedFrame((Boolean)json.getValue("unmaskedFrame"));
+    }
   }
 
   public static void toJson(HttpClientOptions obj, JsonObject json) {

--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -68,6 +68,10 @@ public class HttpServerOptionsConverter {
     if (json.getValue("websocketSubProtocols") instanceof String) {
       obj.setWebsocketSubProtocols((String)json.getValue("websocketSubProtocols"));
     }
+    if(json.getValue("unmaskedFrame") instanceof  Boolean)
+    {
+      obj.setUnmaskedFrame((Boolean)json.getValue("unmaskedFrame"));
+    }
   }
 
   public static void toJson(HttpServerOptions obj, JsonObject json) {

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -159,6 +159,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private Http2Settings initialSettings;
   private List<HttpVersion> alpnVersions;
   private boolean http2ClearTextUpgrade;
+  private boolean unmaskedFrame;
 
   /**
    * Default constructor
@@ -195,6 +196,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.initialSettings = other.initialSettings != null ? new Http2Settings(other.initialSettings) : null;
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
     this.http2ClearTextUpgrade = other.http2ClearTextUpgrade;
+    this.unmaskedFrame = other.isUnmaskedFrame();
   }
 
   /**
@@ -562,6 +564,25 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public HttpClientOptions setTryUseCompression(boolean tryUseCompression) {
     this.tryUseCompression = tryUseCompression;
+    return this;
+  }
+
+  /**
+   * Is Unmasking frame enabled. It's false as default
+   * @return
+   */
+  public boolean isUnmaskedFrame() {
+    return unmaskedFrame;
+  }
+
+  /**
+   * Set whether unmasking frame is enabled
+   *
+   * @param unmaskedFrame  true if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setUnmaskedFrame(boolean unmaskedFrame) {
+    this.unmaskedFrame = unmaskedFrame;
     return this;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -106,6 +106,7 @@ public class HttpServerOptions extends NetServerOptions {
   private List<HttpVersion> alpnVersions;
   private int http2ConnectionWindowSize;
   private boolean decompressionSupported;
+  private boolean unmaskedFrame;
 
   /**
    * Default constructor
@@ -135,6 +136,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.alpnVersions = other.alpnVersions != null ? new ArrayList<>(other.alpnVersions) : null;
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.decompressionSupported = other.isDecompressionSupported();
+    this.unmaskedFrame = other.isUnmaskedFrame();
   }
 
   /**
@@ -405,6 +407,25 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public int getMaxWebsocketFrameSize() {
     return maxWebsocketFrameSize;
+  }
+
+  /**
+   * Is Unmasking frame enabled. It's false as default
+   * @return
+   */
+  public boolean isUnmaskedFrame() {
+    return unmaskedFrame;
+  }
+
+  /**
+   * Set whether unmasking frame is enabled
+   *
+   * @param unmaskedFrame  true if enabled
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setUnmaskedFrame(boolean unmaskedFrame) {
+    this.unmaskedFrame = unmaskedFrame;
+    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -136,7 +136,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
         nettyHeaders = null;
       }
       handshaker = WebSocketClientHandshakerFactory.newHandshaker(wsuri, version, subProtocols, false,
-                                                                  nettyHeaders, maxWebSocketFrameSize);
+                                                                  nettyHeaders, maxWebSocketFrameSize,!client.getOptions().isUnmaskedFrame(),false);
       ChannelPipeline p = channel.pipeline();
       p.addBefore("handler", "handshakeCompleter", new HandshakeInboundHandler(wsConnect, version != WebSocketVersion.V00));
       handshaker.handshake(channel).addListener(future -> {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -843,7 +843,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
       WebSocketServerHandshakerFactory factory =
         new WebSocketServerHandshakerFactory(getWebSocketLocation(ch.pipeline(), request), subProtocols, false,
-          options.getMaxWebsocketFrameSize());
+          options.getMaxWebsocketFrameSize(),options.isUnmaskedFrame());
       WebSocketServerHandshaker shake = factory.newHandshaker(request);
 
       if (shake == null) {


### PR DESCRIPTION
…. See https://tools.ietf.org/html/rfc6455#section-5.2

Signed-off-by: stecolet@gmail.com <stefano.coletta@hubparking.com>

Added unmasked frame supporting for websocket, client and server both
As you can see from https://tools.ietf.org/html/rfc6455#section-5.2 websocket protocol suggests to mask frame (it's not mandatory). In my project I need to manage unmasked frame. In this PR you can find a new Httpclient/Server option in order to enable unmasking frame to websocket protocol.
