### PR TITLE
Fix typos

### DIFF
--- a/src/main/asciidoc/java/cli-for-java.adoc
+++ b/src/main/asciidoc/java/cli-for-java.adoc
@@ -63,7 +63,7 @@ CLI cli = CLI.create("some-name")
 
 For booleans, the boolean values are evaluated to `true`: `on`, `yes`, `1`, `true`.
 
-If one of your option as an `enum` as type, it computes the set of choices automatically.
+If one of your option has an `enum` as type, it computes the set of choices automatically.
 
 === Using annotations
 

--- a/src/main/asciidoc/java/cli.adoc
+++ b/src/main/asciidoc/java/cli.adoc
@@ -41,7 +41,7 @@ CLI cli = CLI.create("copy")
         .setDescription("The source")
         .setArgName("source"))
     .addArgument(new Argument()
-        .setIndex(0)
+        .setIndex(1)
         .setDescription("The destination")
         .setArgName("target"));
 ----

--- a/src/main/java/examples/cli/CLIExamples.java
+++ b/src/main/java/examples/cli/CLIExamples.java
@@ -43,7 +43,7 @@ public class CLIExamples {
             .setDescription("The source")
             .setArgName("source"))
         .addArgument(new Argument()
-            .setIndex(0)
+            .setIndex(1)
             .setDescription("The destination")
             .setArgName("target"));
   }

--- a/src/main/java/io/vertx/core/cli/annotations/package-info.java
+++ b/src/main/java/io/vertx/core/cli/annotations/package-info.java
@@ -55,7 +55,7 @@
  *
  * For booleans, the boolean values are evaluated to {@code true}: `on`, `yes`, `1`, `true`.
  *
- * If one of your option as an `enum` as type, it computes the set of choices automatically.
+ * If one of your option has an `enum` as type, it computes the set of choices automatically.
  *
  * === Using annotations
  *


### PR DESCRIPTION
- Fix the index for the `addArgument` example
- Fix typo as to has