### PR TITLE
Issue #1807 - Add support for websocket text framing.

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -761,6 +761,10 @@ Set the maximum requests allowed in the wait queue, any requests beyond the max 
 +++
 Set the max websocket frame size
 +++
+|[[maxWebsocketMessageSize]]`maxWebsocketMessageSize`|`Number (int)`|
++++
+Set the max websocket message size
++++
 |[[metricsName]]`metricsName`|`String`|
 +++
 Set the metrics name identifying the reported metrics, useful for grouping metrics
@@ -995,6 +999,10 @@ Set the maximum length of the initial line for HTTP/1.x (e.g. <code>"GET / HTTP/
 |[[maxWebsocketFrameSize]]`maxWebsocketFrameSize`|`Number (int)`|
 +++
 Set the maximum websocket frames size
++++
+|[[maxWebsocketMessageSize]]`maxWebsocketMessageSize`|`Number (int)`|
++++
+Set the maximum websocket message size
 +++
 |[[openSslEngineOptions]]`openSslEngineOptions`|`link:dataobjects.html#OpenSSLEngineOptions[OpenSSLEngineOptions]`|-
 |[[pemKeyCertOptions]]`pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|

--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -2074,14 +2074,18 @@ client.websocket("/some-uri", websocket -> {
 
 ==== Writing messages to WebSockets
 
-If you wish to write a single binary WebSocket message to the WebSocket you can do this with
-`link:../../apidocs/io/vertx/core/http/WebSocket.html#writeBinaryMessage-io.vertx.core.buffer.Buffer-[writeBinaryMessage]`:
+If you wish to write a single WebSocket message to the WebSocket you can do this with
+`link:../../apidocs/io/vertx/core/http/WebSocket.html#writeBinaryMessage-io.vertx.core.buffer.Buffer-[writeBinaryMessage]` or
+`link:../../apidocs/io/vertx/core/http/WebSocket.html#writeTextMessage-java.lang.String-[writeTextMessage]` :
 
 [source,java]
 ----
 Buffer buffer = Buffer.buffer().appendInt(123).appendFloat(1.23f);
-
 websocket.writeBinaryMessage(buffer);
+
+// Write a simple text message
+String message = "hello";
+websocket.writeTextMessage(message);
 ----
 
 If the WebSocket message is larger than the maximum websocket frame size as configured with

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -80,6 +80,9 @@ public class HttpClientOptionsConverter {
     if (json.getValue("maxWebsocketFrameSize") instanceof Number) {
       obj.setMaxWebsocketFrameSize(((Number)json.getValue("maxWebsocketFrameSize")).intValue());
     }
+    if (json.getValue("maxWebsocketMessageSize") instanceof Number) {
+      obj.setMaxWebsocketMessageSize(((Number)json.getValue("maxWebsocketMessageSize")).intValue());
+    }
     if (json.getValue("pipelining") instanceof Boolean) {
       obj.setPipelining((Boolean)json.getValue("pipelining"));
     }
@@ -125,6 +128,7 @@ public class HttpClientOptionsConverter {
     json.put("maxRedirects", obj.getMaxRedirects());
     json.put("maxWaitQueueSize", obj.getMaxWaitQueueSize());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
+    json.put("maxWebsocketMessageSize", obj.getMaxWebsocketMessageSize());
     json.put("pipelining", obj.isPipelining());
     json.put("pipeliningLimit", obj.getPipeliningLimit());
     if (obj.getProtocolVersion() != null) {

--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -68,6 +68,9 @@ public class HttpServerOptionsConverter {
     if (json.getValue("maxWebsocketFrameSize") instanceof Number) {
       obj.setMaxWebsocketFrameSize(((Number)json.getValue("maxWebsocketFrameSize")).intValue());
     }
+    if (json.getValue("maxWebsocketMessageSize") instanceof Number) {
+      obj.setMaxWebsocketMessageSize(((Number)json.getValue("maxWebsocketMessageSize")).intValue());
+    }
     if (json.getValue("websocketSubProtocols") instanceof String) {
       obj.setWebsocketSubProtocols((String)json.getValue("websocketSubProtocols"));
     }
@@ -92,6 +95,7 @@ public class HttpServerOptionsConverter {
     json.put("maxHeaderSize", obj.getMaxHeaderSize());
     json.put("maxInitialLineLength", obj.getMaxInitialLineLength());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
+    json.put("maxWebsocketMessageSize", obj.getMaxWebsocketMessageSize());
     if (obj.getWebsocketSubProtocols() != null) {
       json.put("websocketSubProtocols", obj.getWebsocketSubProtocols());
     }

--- a/src/main/java/examples/HTTPExamples.java
+++ b/src/main/java/examples/HTTPExamples.java
@@ -699,10 +699,13 @@ public class HTTPExamples {
   }
 
   public void example55(WebSocket websocket) {
-    // Write a simple message
+    // Write a simple binary message
     Buffer buffer = Buffer.buffer().appendInt(123).appendFloat(1.23f);
-
     websocket.writeBinaryMessage(buffer);
+
+    // Write a simple text message
+    String message = "hello";
+    websocket.writeTextMessage(message);
   }
 
   public void example56(WebSocket websocket, Buffer buffer1, Buffer buffer2, Buffer buffer3) {

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -84,6 +84,12 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_MAX_WEBSOCKET_FRAME_SIZE = 65536;
 
   /**
+   * The default value for maximum websocket messages (could be assembled from multiple frames) is 4 full frames
+   * worth of data
+   */
+  public static final int DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE = 65536 * 4;
+
+  /**
    * The default value for host name = "localhost"
    */
   public static final String DEFAULT_DEFAULT_HOST = "localhost";
@@ -149,6 +155,7 @@ public class HttpClientOptions extends ClientOptionsBase {
 
   private boolean tryUseCompression;
   private int maxWebsocketFrameSize;
+  private int maxWebsocketMessageSize;
   private String defaultHost;
   private int defaultPort;
   private HttpVersion protocolVersion;
@@ -187,6 +194,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.tryUseCompression = other.isTryUseCompression();
     this.maxWebsocketFrameSize = other.maxWebsocketFrameSize;
+    this.maxWebsocketMessageSize = other.maxWebsocketMessageSize;
     this.defaultHost = other.defaultHost;
     this.defaultPort = other.defaultPort;
     this.protocolVersion = other.protocolVersion;
@@ -234,6 +242,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     tryUseCompression = DEFAULT_TRY_USE_COMPRESSION;
     maxWebsocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
+    maxWebsocketMessageSize = DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE;
     defaultHost = DEFAULT_DEFAULT_HOST;
     defaultPort = DEFAULT_DEFAULT_PORT;
     protocolVersion = DEFAULT_PROTOCOL_VERSION;
@@ -626,6 +635,26 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
+   * Get the maximum websocket message size to use
+   *
+   * @return  the max websocket message size
+   */
+  public int getMaxWebsocketMessageSize() {
+    return maxWebsocketMessageSize;
+  }
+
+  /**
+   * Set the max websocket message size
+   *
+   * @param maxWebsocketMessageSize  the max message size, in bytes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setMaxWebsocketMessageSize(int maxWebsocketMessageSize) {
+    this.maxWebsocketMessageSize = maxWebsocketMessageSize;
+    return this;
+  }
+
+  /**
    * Get the default host name to be used by this client in requests if none is provided when making the request.
    *
    * @return  the default host name
@@ -890,6 +919,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (maxPoolSize != that.maxPoolSize) return false;
     if (http2MultiplexingLimit != that.http2MultiplexingLimit) return false;
     if (maxWebsocketFrameSize != that.maxWebsocketFrameSize) return false;
+    if (maxWebsocketMessageSize != that.maxWebsocketMessageSize) return false;
     if (pipelining != that.pipelining) return false;
     if (pipeliningLimit != that.pipeliningLimit) return false;
     if (tryUseCompression != that.tryUseCompression) return false;
@@ -919,6 +949,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     result = 31 * result + pipeliningLimit;
     result = 31 * result + (tryUseCompression ? 1 : 0);
     result = 31 * result + maxWebsocketFrameSize;
+    result = 31 * result + maxWebsocketMessageSize;
     result = 31 * result + defaultHost.hashCode();
     result = 31 * result + defaultPort;
     result = 31 * result + protocolVersion.hashCode();

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -55,6 +55,12 @@ public class HttpServerOptions extends NetServerOptions {
   public static final int DEFAULT_MAX_WEBSOCKET_FRAME_SIZE = 65536;
 
   /**
+   * Default max websocket message size (could be assembled from multiple frames) is 4 full frames
+   * worth of data
+   */
+  public static final int DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE = 65536 * 4;
+
+  /**
    * Default max HTTP chunk size = 8192
    */
   public static final int DEFAULT_MAX_CHUNK_SIZE = 8192;
@@ -102,6 +108,7 @@ public class HttpServerOptions extends NetServerOptions {
   private boolean compressionSupported;
   private int compressionLevel;
   private int maxWebsocketFrameSize;
+  private int maxWebsocketMessageSize;
   private String websocketSubProtocols;
   private boolean handle100ContinueAutomatically;
   private int maxChunkSize;
@@ -132,6 +139,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.compressionSupported = other.isCompressionSupported();
     this.compressionLevel = other.getCompressionLevel();
     this.maxWebsocketFrameSize = other.getMaxWebsocketFrameSize();
+    this.maxWebsocketMessageSize = other.getMaxWebsocketMessageSize();
     this.websocketSubProtocols = other.getWebsocketSubProtocols();
     this.handle100ContinueAutomatically = other.handle100ContinueAutomatically;
     this.maxChunkSize = other.getMaxChunkSize();
@@ -171,6 +179,7 @@ public class HttpServerOptions extends NetServerOptions {
     compressionSupported = DEFAULT_COMPRESSION_SUPPORTED;
     compressionLevel = DEFAULT_COMPRESSION_LEVEL;
     maxWebsocketFrameSize = DEFAULT_MAX_WEBSOCKET_FRAME_SIZE;
+    maxWebsocketMessageSize = DEFAULT_MAX_WEBSOCKET_MESSAGE_SIZE;
     handle100ContinueAutomatically = DEFAULT_HANDLE_100_CONTINE_AUTOMATICALLY;
     maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
     maxInitialLineLength = DEFAULT_MAX_INITIAL_LINE_LENGTH;
@@ -455,6 +464,24 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   /**
+   * @return  the maximum websocket message size
+   */
+  public int getMaxWebsocketMessageSize() {
+    return maxWebsocketMessageSize;
+  }
+
+  /**
+   * Set the maximum websocket message size
+   *
+   * @param maxWebsocketMessageSize  the maximum message size in bytes.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setMaxWebsocketMessageSize(int maxWebsocketMessageSize) {
+    this.maxWebsocketMessageSize = maxWebsocketMessageSize;
+    return this;
+  }
+
+  /**
    * Set the websocket subprotocols supported by the server.
    *
    * @param subProtocols  comma separated list of subprotocols
@@ -635,6 +662,7 @@ public class HttpServerOptions extends NetServerOptions {
 
     if (compressionSupported != that.compressionSupported) return false;
     if (maxWebsocketFrameSize != that.maxWebsocketFrameSize) return false;
+    if (maxWebsocketMessageSize != that.maxWebsocketMessageSize) return false;
     if (handle100ContinueAutomatically != that.handle100ContinueAutomatically) return false;
     if (maxChunkSize != that.maxChunkSize) return false;
     if (maxInitialLineLength != that.maxInitialLineLength) return false;
@@ -654,6 +682,7 @@ public class HttpServerOptions extends NetServerOptions {
     int result = super.hashCode();
     result = 31 * result + (compressionSupported ? 1 : 0);
     result = 31 * result + maxWebsocketFrameSize;
+    result = 31 * result + maxWebsocketMessageSize;
     result = 31 * result + (websocketSubProtocols != null ? websocketSubProtocols.hashCode() : 0);
     result = 31 * result + (initialSettings != null ? initialSettings.hashCode() : 0);
     result = 31 * result + (handle100ContinueAutomatically ? 1 : 0);

--- a/src/main/java/io/vertx/core/http/WebSocket.java
+++ b/src/main/java/io/vertx/core/http/WebSocket.java
@@ -65,6 +65,9 @@ public interface WebSocket extends WebSocketBase {
   WebSocket writeBinaryMessage(Buffer data);
 
   @Override
+  WebSocket writeTextMessage(String text);
+
+  @Override
   WebSocket closeHandler(Handler<Void> handler);
 
   @Override

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -121,6 +121,16 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   WebSocketBase writeBinaryMessage(Buffer data);
 
   /**
+   * Writes a (potentially large) piece of text data to the connection. This data might be written as multiple frames
+   * if it exceeds the maximum WebSocket frame size.
+   *
+   * @param text  the data to write
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  WebSocketBase writeTextMessage(String text);
+
+  /**
    * Set a close handler. This will be called when the WebSocket is closed.
    *
    * @param handler  the handler
@@ -137,6 +147,27 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
    */
   @Fluent
   WebSocketBase frameHandler(@Nullable Handler<WebSocketFrame> handler);
+
+  /**
+   * Set a text message handler on the connection. This handler will be called similar to the
+   * {@link #binaryMessageHandler(Handler)}, but the buffer will be converted to a String first
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  WebSocketBase textMessageHandler(@Nullable Handler<String> handler);
+
+  /**
+   * Set a binary message handler on the connection. This handler serves a similar purpose to {@link #handler(Handler)}
+   * except that if a message comes into the socket in multiple frames, the data from the frames will be aggregated
+   * into a single buffer before calling the handler (using {@link WebSocketFrame#isFinal()} to find the boundaries).
+   *
+   * @param handler the handler
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  WebSocketBase binaryMessageHandler(@Nullable Handler<Buffer> handler);
 
   /**
    * Calls {@link #close()}

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -240,7 +240,8 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
       // Need to set context before constructor is called as writehandler registration needs this
       ContextImpl.setContext(context);
       WebSocketImpl webSocket = new WebSocketImpl(vertx, ClientConnection.this, supportsContinuation,
-                                                  client.getOptions().getMaxWebsocketFrameSize());
+                                                  client.getOptions().getMaxWebsocketFrameSize(),
+                                                  client.getOptions().getMaxWebsocketMessageSize());
       ws = webSocket;
       handshaker.finishHandshake(channel, response);
       context.executeFromIO(() -> {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -805,7 +805,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
           ServerWebSocketImpl ws = new ServerWebSocketImpl(vertx, theURI.toString(), theURI.getPath(),
             theURI.getQuery(), new HeadersAdaptor(request.headers()), wsConn, shake.version() != WebSocketVersion.V00,
-            connectRunnable, options.getMaxWebsocketFrameSize());
+            connectRunnable, options.getMaxWebsocketFrameSize(), options().getMaxWebsocketMessageSize());
           ws.setMetric(metrics.connected(wsConn.metric(), ws));
           wsConn.handleWebsocketConnect(ws);
           if (!ws.isRejected()) {

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -191,7 +191,7 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
     
     ws = new ServerWebSocketImpl(vertx, request.uri(), request.path(),
       request.query(), request.headers(), this, handshaker.version() != WebSocketVersion.V00,
-      null, server.options().getMaxWebsocketFrameSize());
+      null, server.options().getMaxWebsocketFrameSize(), server.options().getMaxWebsocketMessageSize());
     ws.setMetric(metrics.upgrade(requestMetric, ws));
     try {
       handshaker.handshake(channel, nettyReq);

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -50,8 +50,8 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
 
   public ServerWebSocketImpl(VertxInternal vertx, String uri, String path, String query, MultiMap headers,
                              ConnectionBase conn, boolean supportsContinuation, Runnable connectRunnable,
-                             int maxWebSocketFrameSize) {
-    super(vertx, conn, supportsContinuation, maxWebSocketFrameSize);
+                             int maxWebSocketFrameSize, int maxWebSocketMessageSize) {
+    super(vertx, conn, supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize);
     this.uri = uri;
     this.path = path;
     this.query = query;
@@ -166,6 +166,24 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
   }
 
   @Override
+  public ServerWebSocket textMessageHandler(Handler<String> handler) {
+    synchronized (conn) {
+      checkClosed();
+      this.textMessageHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
+  public ServerWebSocket binaryMessageHandler(Handler<Buffer> handler) {
+    synchronized (conn) {
+      checkClosed();
+      this.binaryMessageHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
   public ServerWebSocket pause() {
     synchronized (conn) {
       checkClosed();
@@ -249,6 +267,15 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
     synchronized (conn) {
       checkClosed();
       writeMessageInternal(data);
+      return this;
+    }
+  }
+
+  @Override
+  public ServerWebSocket writeTextMessage(String text) {
+    synchronized (conn) {
+      checkClosed();
+      writeTextMessageInternal(text);
       return this;
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -37,8 +37,8 @@ public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
 
   public WebSocketImpl(VertxInternal vertx,
                        ClientConnection conn, boolean supportsContinuation,
-                       int maxWebSocketFrameSize) {
-    super(vertx, conn, supportsContinuation, maxWebSocketFrameSize);
+                       int maxWebSocketFrameSize, int maxWebSocketMessageSize) {
+    super(vertx, conn, supportsContinuation, maxWebSocketFrameSize, maxWebSocketMessageSize);
   }
 
   @Override
@@ -97,6 +97,13 @@ public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
   }
 
   @Override
+  public WebSocket writeTextMessage(String text) {
+    writeTextMessageInternal(text);
+    return this;
+  }
+
+
+  @Override
   public WebSocket closeHandler(Handler<Void> handler) {
     synchronized (conn) {
       checkClosed();
@@ -110,6 +117,24 @@ public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
     synchronized (conn) {
       checkClosed();
       this.frameHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
+  public WebSocket textMessageHandler(Handler<String> handler) {
+    synchronized (conn) {
+      checkClosed();
+      this.textMessageHandler = handler;
+      return this;
+    }
+  }
+
+  @Override
+  public WebSocket binaryMessageHandler(Handler<Buffer> handler) {
+    synchronized (conn) {
+      checkClosed();
+      this.binaryMessageHandler = handler;
       return this;
     }
   }

--- a/src/main/java/io/vertx/core/http/package-info.java
+++ b/src/main/java/io/vertx/core/http/package-info.java
@@ -1621,8 +1621,9 @@
  *
  * ==== Writing messages to WebSockets
  *
- * If you wish to write a single binary WebSocket message to the WebSocket you can do this with
- * {@link io.vertx.core.http.WebSocket#writeBinaryMessage(io.vertx.core.buffer.Buffer)}:
+ * If you wish to write a single WebSocket message to the WebSocket you can do this with
+ * {@link io.vertx.core.http.WebSocket#writeBinaryMessage(io.vertx.core.buffer.Buffer)} or
+ * {@link io.vertx.core.http.WebSocket#writeTextMessage(java.lang.String)} :
  *
  * [source,$lang]
  * ----


### PR DESCRIPTION
Following the guidance from my pull request against vertx-web (https://github.com/vert-x3/vertx-web/pull/520), I have created this pull request against vertx-core.

I also filed issue #1807 detailing the desired behavior: vertx-core can break large text messages up into websocket frames when sending, and re-assemble multiple frames into a single frame when receiving.

There are a few open questions:

1. In WebSocketImplBase, I am creating buffers to store the frames as I re-assemble them.  These should probably have a maximum size which is configurable.  I am looking for suggestions about the best way to do that.
2. In WebsocketTest, some of the tests I added fail.  Everything that uses Unicode for the text message fails, and also the protocol version 00 fails with plain ascii.  It would be great if someone with more websocket experience could look at the errors.  The unicode tests fail with `io.netty.handler.codec.TooLongFrameException`.  To me, it looks like the frames that are given to the client have an invalid size header, which means that netty cannot figure out how to decode them.

Signed-off-by: rmelick <rmelick@cs.hmc.edu>