### PR TITLE
TrustManagerFactorySpi not initiated before call - Tests Added

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -18,7 +18,6 @@ package io.vertx.core.net.impl;
 
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.*;
-import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ClientAuth;
@@ -28,18 +27,10 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.net.JdkSSLEngineOptions;
-import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.OpenSSLEngineOptions;
-import io.vertx.core.net.SSLEngineOptions;
-import io.vertx.core.net.TCPSSLOptions;
-import io.vertx.core.net.TrustOptions;
+import io.vertx.core.net.*;
 
 import javax.net.ssl.*;
 import java.io.ByteArrayInputStream;
-import java.security.KeyStore;
 import java.security.cert.CRL;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -266,6 +257,7 @@ public class SSLHelper {
         }
       }
       if (trustMgrFactory != null) {
+        // FIXME Should init before here.
         builder.trustManager(trustMgrFactory);
       }
       if (cipherSuites != null && cipherSuites.size() > 0) {

--- a/src/test/java/io/vertx/test/core/SSLHelperTest.java
+++ b/src/test/java/io/vertx/test/core/SSLHelperTest.java
@@ -173,6 +173,6 @@ public class SSLHelperTest extends VertxTestBase {
 
     helper.getContext((VertxInternal) vertx);
 
-    Assert.assertTrue("Trust Manager was initialised at some point.", completableFuture.isDone());
+    Assert.assertTrue("Assert Trust Manager was initialised at some point.", completableFuture.isDone());
   }
 }

--- a/src/test/java/io/vertx/test/core/SSLHelperTest.java
+++ b/src/test/java/io/vertx/test/core/SSLHelperTest.java
@@ -173,6 +173,6 @@ public class SSLHelperTest extends VertxTestBase {
 
     helper.getContext((VertxInternal) vertx);
 
-    Assert.assertTrue("Assert Trust Manager was initialised at some point.", completableFuture.isDone());
+    Assert.assertTrue("Assert Trust Manager initialised at some point.", completableFuture.isDone());
   }
 }

--- a/src/test/java/io/vertx/test/core/SSLHelperTest.java
+++ b/src/test/java/io/vertx/test/core/SSLHelperTest.java
@@ -20,28 +20,26 @@ import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.OpenSslServerContext;
 import io.netty.handler.ssl.OpenSslServerSessionContext;
 import io.netty.handler.ssl.SslContext;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerOptionsConverter;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.NetServerOptionsConverter;
-import io.vertx.core.net.NetworkOptionsConverter;
-import io.vertx.core.net.OpenSSLEngineOptions;
-import io.vertx.core.net.TCPSSLOptionsConverter;
+import io.vertx.core.net.*;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.test.core.tls.Cert;
 import io.vertx.test.core.tls.Trust;
+import org.junit.Assert;
 import org.junit.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSessionContext;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import javax.net.ssl.TrustManagerFactory;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -145,5 +143,36 @@ public class SSLHelperTest extends VertxTestBase {
     List<String> expectedProtocols = new ArrayList<>(Arrays.asList(protocols));
     expectedProtocols.retainAll(engineProtocols);
     assertEquals(engineProtocols, expectedProtocols);
+  }
+
+  @Test
+  public void testCustomTrustManagerFactoryInit() throws Exception {
+    // Ensure any TrustManagerFactory is initialised before a call is made.
+
+    CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+
+    TrustOptions trustOptions = new TrustOptions() {
+
+      @Override
+      public TrustManagerFactory getTrustManagerFactory(Vertx vertx) throws Exception {
+        return new TestTrustManagerFactory(() -> completableFuture.complete(null));
+      }
+
+      @Override
+      public TrustOptions clone() {
+        return this;
+      }
+    };
+
+    NetServerOptions netServerOptions = new NetServerOptions()
+            .setTrustOptions(trustOptions)
+            .setClientAuth(ClientAuth.REQUIRED);
+
+
+    SSLHelper helper = new SSLHelper(netServerOptions, Cert.SERVER_PEM.get(), trustOptions);
+
+    helper.getContext((VertxInternal) vertx);
+
+    Assert.assertTrue("Trust Manager was initialised at some point.", completableFuture.isDone());
   }
 }

--- a/src/test/java/io/vertx/test/core/TestTrustManagerFactory.java
+++ b/src/test/java/io/vertx/test/core/TestTrustManagerFactory.java
@@ -1,0 +1,18 @@
+package io.vertx.test.core;
+
+import javax.net.ssl.TrustManagerFactory;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Created by dominic on 14/02/17.
+ *
+ * Test Trust Manager Factory for SSLHelperTest. Required due to protected constructor.
+ */
+class TestTrustManagerFactory extends TrustManagerFactory {
+    TestTrustManagerFactory(Runnable callback) throws NoSuchAlgorithmException {
+        super(new TestTrustManagerFactorySpi(callback),
+                KeyPairGenerator.getInstance("RSA").getProvider(),
+                KeyPairGenerator.getInstance("RSA").getAlgorithm());
+    }
+}

--- a/src/test/java/io/vertx/test/core/TestTrustManagerFactorySpi.java
+++ b/src/test/java/io/vertx/test/core/TestTrustManagerFactorySpi.java
@@ -1,0 +1,45 @@
+package io.vertx.test.core;
+
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactorySpi;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+
+/**
+ * Created by dominic on 14/02/17.
+ *
+ * Test Trust Manager Factory SPI for SSLHelperTest. Required due to protected constructor.
+ */
+public class TestTrustManagerFactorySpi extends TrustManagerFactorySpi {
+
+    private final Runnable callback;
+    private volatile boolean initiated;
+
+    TestTrustManagerFactorySpi(Runnable callback) {
+        this.callback = callback;
+        initiated = false;
+    }
+
+    @Override
+    protected void engineInit(KeyStore keyStore) throws KeyStoreException {
+        callback.run();
+        initiated = true;
+    }
+
+    @Override
+    protected void engineInit(ManagerFactoryParameters managerFactoryParameters) throws InvalidAlgorithmParameterException {
+        callback.run();
+        initiated = true;
+    }
+
+    @Override
+    protected TrustManager[] engineGetTrustManagers() {
+        if(initiated) {
+            return new TrustManager[0];
+        } else {
+            throw new Error("Trust Manager was not initiated");
+        }
+    }
+}


### PR DESCRIPTION
Creating tests to ensure engineInit called before engineGetTrustManagers