### PR TITLE
Fixes #1765 NullPointer in sendToSubs

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -332,7 +332,7 @@ public class ClusteredEventBus extends EventBusImpl {
     if (sendContext.message.isSend()) {
       // Choose one
       ServerID sid = subs.choose();
-      if (!sid.equals(serverID)) {  //We don't send to this node
+      if (sid != null && !sid.equals(serverID)) {  //We don't send to this node
         metrics.messageSent(address, false, false, true);
         sendRemote(sid, sendContext.message);
       } else {


### PR DESCRIPTION
The io.vertx.core.spi.cluster.ChoosableIterable contract does not guarantee that
after calling io.vertx.core.spi.cluster.ChoosableIterable.isEmpty,
io.vertx.core.spi.cluster.ChoosableIterable.choose returns a non null entry.

This could happen if a consumer is unregistered on another in the cluster.

Publish shouldn't be affected but I still added a test. In order to reproduce
I had to annotate the test with @Repeat(times=1000)
I can't leave the annotation as this would take much too long with real cluster managers.
The issue could be reproduced with the FakeClusterManager anyway.