### PR TITLE
Patch/thread max execution time setting

### DIFF
--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -502,7 +502,7 @@ public interface Vertx extends Measured {
    *
    * @param name the name of the worker executor
    * @param poolSize the size of the pool
-   * @param maxExecuteTime the value of max worker execute time, in ns
+   * @param maxExecuteTime the value of max worker execute time, in ms
    * @return the named worker executor
    */
   WorkerExecutor createSharedWorkerExecutor(String name, int poolSize, long maxExecuteTime);

--- a/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
+++ b/src/main/java/io/vertx/core/impl/BlockedThreadChecker.java
@@ -45,10 +45,10 @@ public class BlockedThreadChecker {
           long now = System.nanoTime();
           for (VertxThread thread : threads.keySet()) {
             long execStart = thread.startTime();
-            long dur = now - execStart;
+            long dur = (now - execStart) / 1000000;
             final long timeLimit = thread.getMaxExecTime();
             if (execStart != 0 && dur > timeLimit) {
-              final String message = "Thread " + thread + " has been blocked for " + (dur / 1000000) + " ms, time limit is " + (timeLimit / 1000000);
+              final String message = "Thread " + thread + " has been blocked for " + dur + " ms, time limit is " + timeLimit + " ms";
               if (dur <= warningExceptionTime) {
                 log.warn(message);
               } else {


### PR DESCRIPTION
Fix #1812 by having src/main/java/io/vertx/core/impl/BlockedThreadChecker.java be more consistent in what timing values mean.