### PR TITLE
Future<T> extends Handler<AsyncResult<T>> - fixes #1826

### DIFF
--- a/src/main/java/io/vertx/core/Future.java
+++ b/src/main/java/io/vertx/core/Future.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
-public interface Future<T> extends AsyncResult<T> {
+public interface Future<T> extends AsyncResult<T>, Handler<AsyncResult<T>> {
 
   /**
    * Create a future that hasn't completed yet
@@ -292,17 +292,20 @@ public interface Future<T> extends AsyncResult<T> {
   }
 
   /**
+   * Succeed or fail this future with the {@link AsyncResult} event.
+   *
+   * @param asyncResult the async result to handle
+   */
+  @GenIgnore
+  @Override
+  void handle(AsyncResult<T> asyncResult);
+
+  /**
    * @return an handler completing this future
    */
   @CacheReturn
   default Handler<AsyncResult<T>> completer() {
-    return ar -> {
-      if (ar.succeeded()) {
-        complete(ar.result());
-      } else {
-        fail(ar.cause());
-      }
-    };
+    return this;
   }
 
   /**

--- a/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
@@ -272,11 +272,11 @@ public class CompositeFutureImpl implements CompositeFuture, Handler<AsyncResult
   }
 
   @Override
-  public void handle(AsyncResult<CompositeFuture> ar) {
-    if (ar.succeeded()) {
+  public void handle(AsyncResult<CompositeFuture> asyncResult) {
+    if (asyncResult.succeeded()) {
       complete(this);
     } else {
-      fail(ar.cause());
+      fail(asyncResult.cause());
     }
   }
 }

--- a/src/main/java/io/vertx/core/impl/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/FutureImpl.java
@@ -130,11 +130,11 @@ class FutureImpl<T> implements Future<T>, Handler<AsyncResult<T>> {
   }
 
   @Override
-  public void handle(AsyncResult<T> ar) {
-    if (ar.succeeded()) {
-      complete(ar.result());
+  public void handle(AsyncResult<T> asyncResult) {
+    if (asyncResult.succeeded()) {
+      complete(asyncResult.result());
     } else {
-      fail(ar.cause());
+      fail(asyncResult.cause());
     }
   }
 

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -653,6 +653,13 @@ public class FutureTest extends VertxTestBase {
       public Throwable cause() { throw new UnsupportedOperationException(); }
       public boolean succeeded() { throw new UnsupportedOperationException(); }
       public boolean failed() { throw new UnsupportedOperationException(); }
+      public void handle(AsyncResult<T> asyncResult) {
+        if (asyncResult.succeeded()) {
+          complete(asyncResult.result());
+        } else {
+          fail(asyncResult.cause());
+        }
+      }
     }
 
     DefaultCompleterTestFuture<Object> successFuture = new DefaultCompleterTestFuture<>();


### PR DESCRIPTION
Motivation:

It is actually possible to turn a `Future<T>` into an `Handler<AsyncResult<T>>` using `Future#completer()` method. This is actually the polyglot method to achieve it as `AsyncResult<T>` might not be mapped correctly sometimes (like in JS or Ruby).

The implementations of `Future` actually implements `Handler<AsyncResult<T>>` and return `this` in the `completer()` method.

When using java-ish languages like Java, Kotlin or Groovy, it should be possible to use directly the represented `Future` type directly as an `Handler<AsyncResult>`.

Resolution:

This patch makes `Future<T>` extend `Handler<AsyncResult<T>>` (in addition of `AsyncResult<T>`) and the `handle(AsyncResult<T>)` is annotated with `@GenIgnore`.