### PR TITLE
Websocket cleanup

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -20,6 +20,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.http.WebSocketBase;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -157,30 +158,8 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
   }
 
   @Override
-  public ServerWebSocket frameHandler(Handler<WebSocketFrame> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.frameHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket textMessageHandler(Handler<String> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.textMessageHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket binaryMessageHandler(Handler<Buffer> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.binaryMessageHandler = handler;
-      return this;
-    }
+  public ServerWebSocketImpl frameHandler(Handler<WebSocketFrame> handler) {
+    return (ServerWebSocketImpl) super.frameHandler(handler);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -16,11 +16,8 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
-import io.vertx.core.http.WebSocketBase;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.impl.ConnectionBase;
@@ -37,14 +34,13 @@ import javax.security.cert.X509Certificate;
  * @author <a href="http://tfox.org">Tim Fox</a>
  *
  */
-public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebSocket {
+public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> implements ServerWebSocket {
 
   private final String uri;
   private final String path;
   private final String query;
   private final Runnable connectRunnable;
   private final MultiMap headers;
-  private Object metric;
 
   private boolean connected;
   private boolean rejected;
@@ -100,11 +96,6 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
   }
 
   @Override
-  public void end() {
-    close();
-  }
-
-  @Override
   public void close() {
     synchronized (conn) {
       checkClosed();
@@ -122,100 +113,6 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
   }
 
   @Override
-  public ServerWebSocket handler(Handler<Buffer> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.dataHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket endHandler(Handler<Void> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.endHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket exceptionHandler(Handler<Throwable> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.exceptionHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket closeHandler(Handler<Void> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.closeHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocketImpl frameHandler(Handler<WebSocketFrame> handler) {
-    return (ServerWebSocketImpl) super.frameHandler(handler);
-  }
-
-  @Override
-  public ServerWebSocket pause() {
-    synchronized (conn) {
-      checkClosed();
-      conn.doPause();
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket resume() {
-    synchronized (conn) {
-      checkClosed();
-      conn.doResume();
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket setWriteQueueMaxSize(int maxSize) {
-    synchronized (conn) {
-      checkClosed();
-      conn.doSetWriteQueueMaxSize(maxSize);
-      return this;
-    }
-  }
-
-  @Override
-  public boolean writeQueueFull() {
-    synchronized (conn) {
-      checkClosed();
-      return conn.isNotWritable();
-    }
-  }
-
-  @Override
-  public ServerWebSocket write(Buffer data) {
-    synchronized (conn) {
-      checkClosed();
-      writeFrame(WebSocketFrame.binaryFrame(data, true));
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket drainHandler(Handler<Void> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.drainHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
   public ServerWebSocket writeFrame(WebSocketFrame frame) {
     synchronized (conn) {
       if (connectRunnable != null) {
@@ -226,36 +123,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
           connect();
         }
       }
-      super.writeFrameInternal(frame);
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket writeFinalTextFrame(String text) {
-    return writeFrame(WebSocketFrame.textFrame(text, true));
-  }
-
-  @Override
-  public ServerWebSocket writeFinalBinaryFrame(Buffer data) {
-    return writeFrame(WebSocketFrame.binaryFrame(data, true));
-  }
-
-  @Override
-  public ServerWebSocket writeBinaryMessage(Buffer data) {
-    synchronized (conn) {
-      checkClosed();
-      writeMessageInternal(data);
-      return this;
-    }
-  }
-
-  @Override
-  public ServerWebSocket writeTextMessage(String text) {
-    synchronized (conn) {
-      checkClosed();
-      writeTextMessageInternal(text);
-      return this;
+      return super.writeFrame(frame);
     }
   }
 
@@ -277,13 +145,5 @@ public class ServerWebSocketImpl extends WebSocketImplBase implements ServerWebS
     synchronized (conn) {
       return rejected;
     }
-  }
-
-  void setMetric(Object metric) {
-    this.metric = metric;
-  }
-
-  Object getMetric() {
-    return metric;
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -42,6 +42,11 @@ public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
   }
 
   @Override
+  public WebSocketImpl frameHandler(Handler<WebSocketFrame> handler) {
+    return (WebSocketImpl) super.frameHandler(handler);
+  }
+
+  @Override
   public WebSocket handler(Handler<Buffer> handler) {
     synchronized (conn) {
       if (handler != null) {
@@ -108,33 +113,6 @@ public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
     synchronized (conn) {
       checkClosed();
       this.closeHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket frameHandler(Handler<WebSocketFrame> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.frameHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket textMessageHandler(Handler<String> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.textMessageHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket binaryMessageHandler(Handler<Buffer> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.binaryMessageHandler = handler;
       return this;
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -16,8 +16,6 @@
 
 package io.vertx.core.http.impl;
 
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.VertxInternal;
@@ -31,9 +29,7 @@ import io.vertx.core.impl.VertxInternal;
  * @author <a href="http://tfox.org">Tim Fox</a>
  *
  */
-public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
-
-  private Object metric;
+public class WebSocketImpl extends WebSocketImplBase<WebSocket> implements WebSocket {
 
   public WebSocketImpl(VertxInternal vertx,
                        ClientConnection conn, boolean supportsContinuation,
@@ -42,140 +38,10 @@ public class WebSocketImpl extends WebSocketImplBase implements WebSocket {
   }
 
   @Override
-  public WebSocketImpl frameHandler(Handler<WebSocketFrame> handler) {
-    return (WebSocketImpl) super.frameHandler(handler);
-  }
-
-  @Override
-  public WebSocket handler(Handler<Buffer> handler) {
-    synchronized (conn) {
-      if (handler != null) {
-        checkClosed();
-      }
-      this.dataHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket endHandler(Handler<Void> handler) {
-    synchronized (conn) {
-      if (handler != null) {
-        checkClosed();
-      }
-      this.endHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket exceptionHandler(Handler<Throwable> handler) {
-    synchronized (conn) {
-      if (handler != null) {
-        checkClosed();
-      }
-      this.exceptionHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket writeFrame(WebSocketFrame frame) {
-    writeFrameInternal(frame);
-    return this;
-  }
-
-  @Override
-  public WebSocket writeFinalTextFrame(String text) {
-    return writeFrame(WebSocketFrame.textFrame(text, true));
-  }
-
-  @Override
-  public WebSocket writeFinalBinaryFrame(Buffer data) {
-    return writeFrame(WebSocketFrame.binaryFrame(data, true));
-  }
-
-  @Override
-  public WebSocket writeBinaryMessage(Buffer data) {
-    writeMessageInternal(data);
-    return this;
-  }
-
-  @Override
-  public WebSocket writeTextMessage(String text) {
-    writeTextMessageInternal(text);
-    return this;
-  }
-
-
-  @Override
-  public WebSocket closeHandler(Handler<Void> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.closeHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket pause() {
-    synchronized (conn) {
-      checkClosed();
-      conn.doPause();
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket resume() {
-    synchronized (conn) {
-      checkClosed();
-      conn.doResume();
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket setWriteQueueMaxSize(int maxSize) {
-    synchronized (conn) {
-      checkClosed();
-      conn.doSetWriteQueueMaxSize(maxSize);
-      return this;
-    }
-  }
-
-  @Override
-  public WebSocket write(Buffer data) {
-    writeFrame(WebSocketFrame.binaryFrame(data, true));
-    return this;
-  }
-
-  @Override
-  public WebSocket drainHandler(Handler<Void> handler) {
-    synchronized (conn) {
-      checkClosed();
-      this.drainHandler = handler;
-      return this;
-    }
-  }
-
-  @Override
   void handleClosed() {
     synchronized (conn) {
-      ((ClientConnection) conn).metrics().disconnected(metric);
+      ((ClientConnection) conn).metrics().disconnected(getMetric());
       super.handleClosed();
     }
   }
-
-  void setMetric(Object metric) {
-    synchronized (conn) {
-      this.metric = metric;
-    }
-  }
-
-  @Override
-  public void end() {
-    close();
-  }
-
 }


### PR DESCRIPTION
Motivation:

generate cleanup in websocket impl hierarchy, a recent PR added support for message aggregation and the introduced code could be factored out as an internal frame handler of the `WebSocketServerBase` in order to increase readability. Lot of duplicated code was found in `WebSocketServerBase` sub-interfaces and could be factored out in the `WebSocketServerBase ` interface as well.

Result:
- message aggregation is now handled in an internal frame handler of `WebSocketServerBase `
- common code has been factored in `WebSocketServerBase ` instead of being duplicated in `WebSocketImpl` and `ServerWebSocketImpl`
