### PR TITLE
Change HttpServerResponse#closeHandler to be closed when the HttpServ…

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -184,8 +184,8 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   HttpServerResponse putTrailer(CharSequence name, Iterable<CharSequence> value);
 
   /**
-   * Set a close handler for the response. This will be called if the underlying connection closes before the response
-   * is complete.
+   * Set a close handler for the response. This will be called when the response is ended or if the underlying connection
+   * closes before the response ends.
    *
    * @param handler  the handler
    * @return a reference to this, so the API can be used fluently

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -40,7 +40,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.channels.ClosedChannelException;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -128,12 +127,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
   }
 
   void handleClose() {
-    if (handleEnded(true)) {
-      handleError(new ClosedChannelException());
-    }
-    if (closeHandler != null) {
-      closeHandler.handle(null);
-    }
+    handleEnded(true);
   }
 
   private void checkHeadWritten() {
@@ -431,7 +425,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
     }
   }
 
-  private boolean handleEnded(boolean failed) {
+  private void handleEnded(boolean failed) {
     if (!ended) {
       ended = true;
       if (metric != null) {
@@ -443,9 +437,10 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
           conn.metrics().responseEnd(metric, this);
         }
       }
-      return true;
+      if (closeHandler != null) {
+        closeHandler.handle(null);
+      }
     }
-    return false;
   }
 
   void writabilityChanged() {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -65,7 +65,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   private boolean written;
   private Handler<Void> drainHandler;
   private Handler<Throwable> exceptionHandler;
-  private Handler<Void> closeHandler;
+  private Handler<Void> endHandler;
   private Handler<Void> headersEndHandler;
   private Handler<Void> bodyEndHandler;
   private boolean chunked;
@@ -262,7 +262,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse closeHandler(Handler<Void> handler) {
     synchronized (conn) {
       checkWritten();
-      this.closeHandler = handler;
+      this.endHandler = handler;
       return this;
     }
   }
@@ -428,6 +428,9 @@ public class HttpServerResponseImpl implements HttpServerResponse {
     if (bodyEndHandler != null) {
       bodyEndHandler.handle(null);
     }
+    if (endHandler != null) {
+      endHandler.handle(null);
+    }
   }
 
   private void doSendFile(String filename, long offset, long length, Handler<AsyncResult<Void>> resultHandler) {
@@ -548,8 +551,8 @@ public class HttpServerResponseImpl implements HttpServerResponse {
 
   void handleClosed() {
     synchronized (conn) {
-      if (closeHandler != null) {
-        closeHandler.handle(null);
+      if (endHandler != null) {
+        endHandler.handle(null);
       }
     }
   }


### PR DESCRIPTION
…erResponse is disposed in the same manner for HTTP/1 and HTTP/2 - fixes #1840