### PR TITLE
Fault tolerance for event bus subscription

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
@@ -16,6 +16,8 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
+import io.vertx.core.net.impl.ServerID;
+
 import java.io.Serializable;
 
 /**
@@ -26,16 +28,14 @@ public class ClusterNodeInfo implements Serializable {
   private static final long serialVersionUID = 1L;
 
   public String nodeId;
-  public String host;
-  public int port;
+  public ServerID serverID;
 
   public ClusterNodeInfo() {
   }
 
-  public ClusterNodeInfo(String nodeId, String host, int port) {
+  public ClusterNodeInfo(String nodeId, ServerID serverID) {
     this.nodeId = nodeId;
-    this.host = host;
-    this.port = port;
+    this.serverID = serverID;
   }
 
   @Override
@@ -45,21 +45,19 @@ public class ClusterNodeInfo implements Serializable {
 
     ClusterNodeInfo that = (ClusterNodeInfo) o;
 
-    if (port != that.port) return false;
     if (nodeId != null ? !nodeId.equals(that.nodeId) : that.nodeId != null) return false;
-    return host != null ? host.equals(that.host) : that.host == null;
+    return serverID != null ? serverID.equals(that.serverID) : that.serverID == null;
   }
 
   @Override
   public int hashCode() {
     int result = nodeId != null ? nodeId.hashCode() : 0;
-    result = 31 * result + (host != null ? host.hashCode() : 0);
-    result = 31 * result + port;
+    result = 31 * result + (serverID != null ? serverID.hashCode() : 0);
     return result;
   }
 
   @Override
   public String toString() {
-    return nodeId + ":" + host + ":" + port;
+    return nodeId + ":" + serverID.toString();
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusterNodeInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.eventbus.impl.clustered;
+
+import java.io.Serializable;
+
+/**
+ * @author Rikard Björklind
+ */
+public class ClusterNodeInfo implements Serializable {
+  // Make sure we can add new fields in future versions
+  private static final long serialVersionUID = 1L;
+
+  public String nodeId;
+  public String host;
+  public int port;
+
+  public ClusterNodeInfo() {
+  }
+
+  public ClusterNodeInfo(String nodeId, String host, int port) {
+    this.nodeId = nodeId;
+    this.host = host;
+    this.port = port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ClusterNodeInfo that = (ClusterNodeInfo) o;
+
+    if (port != that.port) return false;
+    if (nodeId != null ? !nodeId.equals(that.nodeId) : that.nodeId != null) return false;
+    return host != null ? host.equals(that.host) : that.host == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = nodeId != null ? nodeId.hashCode() : 0;
+    result = 31 * result + (host != null ? host.hashCode() : 0);
+    result = 31 * result + port;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return nodeId + ":" + host + ":" + port;
+  }
+}

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -52,11 +52,13 @@ import io.vertx.core.spi.cluster.AsyncMultiMap;
 import io.vertx.core.spi.cluster.ChoosableIterable;
 import io.vertx.core.spi.cluster.ClusterManager;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Predicate;
 
 /**
  * An event bus implementation that clusters with other Vert.x nodes
@@ -283,7 +285,7 @@ public class ClusteredEventBus extends EventBusImpl {
         });
       });
 
-      subs.removeAllMatching(ci -> !members.contains(ci.nodeId), removeResult -> {
+      subs.removeAllMatching((Serializable & Predicate<ClusterNodeInfo>) ci -> !members.contains(ci.nodeId), removeResult -> {
         if (removeResult.failed()) {
           log.warn("Error removing subs", removeResult.cause());
         }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -146,7 +146,7 @@ public class ClusteredEventBus extends EventBusImpl {
             int serverPort = getClusterPublicPort(options, server.actualPort());
             String serverHost = getClusterPublicHost(options);
             serverID = new ServerID(serverPort, serverHost);
-            nodeInfo = new ClusterNodeInfo(clusterManager.getNodeID(), serverHost, serverPort);
+            nodeInfo = new ClusterNodeInfo(clusterManager.getNodeID(), serverID);
             haManager.addDataToAHAInfo(SERVER_ID_HA_KEY, new JsonObject().put("host", serverID.host).put("port", serverID.port));
             if (resultHandler != null) {
               started = true;
@@ -345,7 +345,7 @@ public class ClusteredEventBus extends EventBusImpl {
     if (sendContext.message.isSend()) {
       // Choose one
       ClusterNodeInfo ci = subs.choose();
-      ServerID sid = ci == null ? null : new ServerID(ci.port, ci.host);
+      ServerID sid = ci == null ? null : ci.serverID;
       if (sid != null && !sid.equals(serverID)) {  //We don't send to this node
         metrics.messageSent(address, false, false, true);
         sendRemote(sid, sendContext.message);
@@ -358,10 +358,9 @@ public class ClusteredEventBus extends EventBusImpl {
       boolean local = false;
       boolean remote = false;
       for (ClusterNodeInfo ci : subs) {
-        ServerID sid = new ServerID(ci.port, ci.host);
-        if (!sid.equals(serverID)) {  //We don't send to this node
+        if (!ci.serverID.equals(serverID)) {  //We don't send to this node
           remote = true;
-          sendRemote(sid, sendContext.message);
+          sendRemote(ci.serverID, sendContext.message);
         } else {
           local = true;
         }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -30,6 +30,7 @@ import io.vertx.core.eventbus.impl.CodecManager;
 import io.vertx.core.eventbus.impl.EventBusImpl;
 import io.vertx.core.eventbus.impl.HandlerHolder;
 import io.vertx.core.eventbus.impl.MessageImpl;
+import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.impl.HAManager;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
@@ -52,6 +53,7 @@ import io.vertx.core.spi.cluster.ChoosableIterable;
 import io.vertx.core.spi.cluster.ClusterManager;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -68,7 +70,7 @@ public class ClusteredEventBus extends EventBusImpl {
   public static final String CLUSTER_PUBLIC_HOST_PROP_NAME = "vertx.cluster.public.host";
   public static final String CLUSTER_PUBLIC_PORT_PROP_NAME = "vertx.cluster.public.port";
 
-  private static final Buffer PONG = Buffer.buffer(new byte[] { (byte)1 });
+  private static final Buffer PONG = Buffer.buffer(new byte[]{(byte) 1});
   private static final String SERVER_ID_HA_KEY = "server_id";
   private static final String SUBS_MAP_NAME = "__vertx.subs";
 
@@ -78,8 +80,10 @@ public class ClusteredEventBus extends EventBusImpl {
   private final Context sendNoContext;
 
   private EventBusOptions options;
-  private AsyncMultiMap<String, ServerID> subs;
+  private AsyncMultiMap<String, ClusterNodeInfo> subs;
+  private Set<String> ownSubs = new ConcurrentHashSet<>();
   private ServerID serverID;
+  private ClusterNodeInfo nodeInfo;
   private NetServer server;
 
   public ClusteredEventBus(VertxInternal vertx,
@@ -91,7 +95,7 @@ public class ClusteredEventBus extends EventBusImpl {
     this.clusterManager = clusterManager;
     this.haManager = haManager;
     this.sendNoContext = vertx.getOrCreateContext();
-    setNodeCrashedHandler(haManager);
+    setClusterViewChangedHandler(haManager);
   }
 
   private NetServerOptions getServerOptions() {
@@ -131,7 +135,7 @@ public class ClusteredEventBus extends EventBusImpl {
 
   @Override
   public void start(Handler<AsyncResult<Void>> resultHandler) {
-    clusterManager.<String, ServerID>getAsyncMultiMap(SUBS_MAP_NAME, ar2 -> {
+    clusterManager.<String, ClusterNodeInfo>getAsyncMultiMap(SUBS_MAP_NAME, ar2 -> {
       if (ar2.succeeded()) {
         subs = ar2.result();
         server = vertx.createNetServer(getServerOptions());
@@ -142,6 +146,7 @@ public class ClusteredEventBus extends EventBusImpl {
             int serverPort = getClusterPublicPort(options, server.actualPort());
             String serverHost = getClusterPublicHost(options);
             serverID = new ServerID(serverPort, serverHost);
+            nodeInfo = new ClusterNodeInfo(clusterManager.getNodeID(), serverHost, serverPort);
             haManager.addDataToAHAInfo(SERVER_ID_HA_KEY, new JsonObject().put("host", serverID.host).put("port", serverID.port));
             if (resultHandler != null) {
               started = true;
@@ -174,7 +179,7 @@ public class ClusteredEventBus extends EventBusImpl {
             log.error("Failed to close server", ar.cause());
           }
           // Close all outbound connections explicitly - don't rely on context hooks
-          for (ConnectionHolder holder: connections.values()) {
+          for (ConnectionHolder holder : connections.values()) {
             holder.close();
           }
           if (completionHandler != null) {
@@ -205,7 +210,8 @@ public class ClusteredEventBus extends EventBusImpl {
                                      Handler<AsyncResult<Void>> completionHandler) {
     if (newAddress && subs != null && !replyHandler && !localOnly) {
       // Propagate the information
-      subs.add(address, serverID, completionHandler);
+      subs.add(address, nodeInfo, completionHandler);
+      ownSubs.add(address);
     } else {
       completionHandler.handle(Future.succeededFuture());
     }
@@ -215,7 +221,8 @@ public class ClusteredEventBus extends EventBusImpl {
   protected <T> void removeRegistration(HandlerHolder lastHolder, String address,
                                         Handler<AsyncResult<Void>> completionHandler) {
     if (lastHolder != null && subs != null && !lastHolder.isLocalOnly()) {
-      removeSub(address, serverID, completionHandler);
+      ownSubs.remove(address);
+      removeSub(address, nodeInfo, completionHandler);
     } else {
       callCompletionHandlerAsync(completionHandler);
     }
@@ -229,9 +236,9 @@ public class ClusteredEventBus extends EventBusImpl {
   @Override
   protected <T> void sendOrPub(SendContextImpl<T> sendContext) {
     String address = sendContext.message.address();
-    Handler<AsyncResult<ChoosableIterable<ServerID>>> resultHandler = asyncResult -> {
+    Handler<AsyncResult<ChoosableIterable<ClusterNodeInfo>>> resultHandler = asyncResult -> {
       if (asyncResult.succeeded()) {
-        ChoosableIterable<ServerID> serverIDs = asyncResult.result();
+        ChoosableIterable<ClusterNodeInfo> serverIDs = asyncResult.result();
         if (serverIDs != null && !serverIDs.isEmpty()) {
           sendToSubs(serverIDs, sendContext);
         } else {
@@ -262,20 +269,25 @@ public class ClusteredEventBus extends EventBusImpl {
 
   @Override
   protected boolean isMessageLocal(MessageImpl msg) {
-    ClusteredMessage clusteredMessage = (ClusteredMessage)msg;
+    ClusteredMessage clusteredMessage = (ClusteredMessage) msg;
     return !clusteredMessage.isFromWire();
   }
 
-  private void setNodeCrashedHandler(HAManager haManager) {
-    haManager.setNodeCrashedHandler((failedNodeID, haInfo, failed) -> {
-      JsonObject jsid = haInfo.getJsonObject(SERVER_ID_HA_KEY);
-      if (jsid != null) {
-        ServerID sid = new ServerID(jsid.getInteger("port"), jsid.getString("host"));
-        if (subs != null) {
-          subs.removeAllForValue(sid, res -> {
-          });
+  private void setClusterViewChangedHandler(HAManager haManager) {
+    haManager.setClusterViewChangedHandler(members -> {
+      ownSubs.forEach(address -> {
+        subs.add(address, nodeInfo, addResult -> {
+          if (addResult.failed()) {
+            log.warn("Failed to update subs map with self", addResult.cause());
+          }
+        });
+      });
+
+      subs.removeAll(ci -> !members.contains(ci.nodeId), removeResult -> {
+        if (removeResult.failed()) {
+          log.warn("Error removing subs", removeResult.cause());
         }
-      }
+      });
     });
   }
 
@@ -303,6 +315,7 @@ public class ClusteredEventBus extends EventBusImpl {
       RecordParser parser = RecordParser.newFixed(4, null);
       Handler<Buffer> handler = new Handler<Buffer>() {
         int size = -1;
+
         public void handle(Buffer buff) {
           if (size == -1) {
             size = buff.getInt(0);
@@ -327,11 +340,12 @@ public class ClusteredEventBus extends EventBusImpl {
     };
   }
 
-  private <T> void sendToSubs(ChoosableIterable<ServerID> subs, SendContextImpl<T> sendContext) {
+  private <T> void sendToSubs(ChoosableIterable<ClusterNodeInfo> subs, SendContextImpl<T> sendContext) {
     String address = sendContext.message.address();
     if (sendContext.message.isSend()) {
       // Choose one
-      ServerID sid = subs.choose();
+      ClusterNodeInfo ci = subs.choose();
+      ServerID sid = ci == null ? null : new ServerID(ci.port, ci.host);
       if (sid != null && !sid.equals(serverID)) {  //We don't send to this node
         metrics.messageSent(address, false, false, true);
         sendRemote(sid, sendContext.message);
@@ -343,7 +357,8 @@ public class ClusteredEventBus extends EventBusImpl {
       // Publish
       boolean local = false;
       boolean remote = false;
-      for (ServerID sid : subs) {
+      for (ClusterNodeInfo ci : subs) {
+        ServerID sid = new ServerID(ci.port, ci.host);
         if (!sid.equals(serverID)) {  //We don't send to this node
           remote = true;
           sendRemote(sid, sendContext.message);
@@ -389,11 +404,11 @@ public class ClusteredEventBus extends EventBusImpl {
         holder.connect();
       }
     }
-    holder.writeMessage((ClusteredMessage)message);
+    holder.writeMessage((ClusteredMessage) message);
   }
 
-  private void removeSub(String subName, ServerID theServerID, Handler<AsyncResult<Void>> completionHandler) {
-    subs.remove(subName, theServerID, ar -> {
+  private void removeSub(String subName, ClusterNodeInfo node, Handler<AsyncResult<Void>> completionHandler) {
+    subs.remove(subName, node, ar -> {
       if (!ar.succeeded()) {
         log.error("Failed to remove sub", ar.cause());
       } else {
@@ -422,6 +437,5 @@ public class ClusteredEventBus extends EventBusImpl {
   EventBusOptions options() {
     return options;
   }
-
 }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -283,7 +283,7 @@ public class ClusteredEventBus extends EventBusImpl {
         });
       });
 
-      subs.removeAll(ci -> !members.contains(ci.nodeId), removeResult -> {
+      subs.removeAllMatching(ci -> !members.contains(ci.nodeId), removeResult -> {
         if (removeResult.failed()) {
           log.warn("Error removing subs", removeResult.cause());
         }

--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -143,6 +143,9 @@ public class HAManager {
     haInfo.put("group", this.group);
     this.clusterMap = clusterManager.getSyncMap(CLUSTER_MAP_NAME);
     this.nodeID = clusterManager.getNodeID();
+    synchronized (haInfo) {
+      clusterMap.put(nodeID, haInfo.encode());
+    }
     clusterManager.nodeListener(new NodeListener() {
       @Override
       public void nodeAdded(String nodeID) {
@@ -154,7 +157,6 @@ public class HAManager {
         HAManager.this.nodeLeft(leftNodeID);
       }
     });
-    clusterMap.put(nodeID, haInfo.encode());
     quorumTimerID = vertx.setPeriodic(QUORUM_CHECK_PERIOD, tid -> checkHADeployments());
     // Call check quorum to compute whether we have an initial quorum
     synchronized (this) {

--- a/src/main/java/io/vertx/core/impl/HAManager.java
+++ b/src/main/java/io/vertx/core/impl/HAManager.java
@@ -28,14 +28,17 @@ import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.core.spi.cluster.NodeListener;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static java.util.concurrent.TimeUnit.*;
 
@@ -122,10 +125,10 @@ public class HAManager {
   private long quorumTimerID;
   private volatile boolean attainedQuorum;
   private volatile FailoverCompleteHandler failoverCompleteHandler;
-  private volatile FailoverCompleteHandler nodeCrashedHandler;
   private volatile boolean failDuringFailover;
   private volatile boolean stopped;
   private volatile boolean killed;
+  private Consumer<Set<String>> clusterViewChangedHandler;
 
   public HAManager(VertxInternal vertx, DeploymentManager deploymentManager,
                    ClusterManager clusterManager, int quorumSize, String group, boolean enabled) {
@@ -248,8 +251,8 @@ public class HAManager {
     this.failoverCompleteHandler = failoverCompleteHandler;
   }
 
-  public void setNodeCrashedHandler(FailoverCompleteHandler removeSubsHandler) {
-    this.nodeCrashedHandler = removeSubsHandler;
+  public void setClusterViewChangedHandler(Consumer<Set<String>> handler) {
+    this.clusterViewChangedHandler = handler;
   }
 
   public boolean isKilled() {
@@ -284,7 +287,8 @@ public class HAManager {
   // A node has joined the cluster
   // synchronize this in case the cluster manager is naughty and calls it concurrently
   private synchronized void nodeAdded(final String nodeID) {
-     // This is not ideal but we need to wait for the group information to appear - and this will be shortly
+    addHaInfoIfLost();
+    // This is not ideal but we need to wait for the group information to appear - and this will be shortly
     // after the node has been added
     checkQuorumWhenAdded(nodeID, System.currentTimeMillis());
   }
@@ -292,9 +296,11 @@ public class HAManager {
   // A node has left the cluster
   // synchronize this in case the cluster manager is naughty and calls it concurrently
   private synchronized void nodeLeft(String leftNodeID) {
+    addHaInfoIfLost();
 
     checkQuorum();
     if (attainedQuorum) {
+      checkSubs(leftNodeID);
 
       // Check for failover
       String sclusterInfo = clusterMap.get(leftNodeID);
@@ -303,7 +309,6 @@ public class HAManager {
         // Clean close - do nothing
       } else {
         JsonObject clusterInfo = new JsonObject(sclusterInfo);
-        checkRemoveSubs(leftNodeID, clusterInfo);
         checkFailover(leftNodeID, clusterInfo);
       }
 
@@ -314,9 +319,16 @@ public class HAManager {
       for (Map.Entry<String, String> entry: clusterMap.entrySet()) {
         if (!leftNodeID.equals(entry.getKey()) && !nodes.contains(entry.getKey())) {
           JsonObject haInfo = new JsonObject(entry.getValue());
-          checkRemoveSubs(entry.getKey(), haInfo);
           checkFailover(entry.getKey(), haInfo);
         }
+      }
+    }
+  }
+
+  private void addHaInfoIfLost() {
+    if (clusterManager.getNodes().contains(nodeID) && !clusterMap.containsKey(nodeID)) {
+      synchronized (haInfo) {
+        clusterMap.put(nodeID, haInfo.encode());
       }
     }
   }
@@ -324,6 +336,9 @@ public class HAManager {
   private synchronized void checkQuorumWhenAdded(final String nodeID, final long start) {
     if (clusterMap.containsKey(nodeID)) {
       checkQuorum();
+      if (attainedQuorum) {
+        checkSubs(nodeID);
+      }
     } else {
       vertx.setTimer(200, tid -> {
         // This can block on a monitor so it needs to run as a worker
@@ -479,37 +494,45 @@ public class HAManager {
         }
         // Failover is complete! We can now remove the failed node from the cluster map
         clusterMap.remove(failedNodeID);
-        callFailoverCompleteHandler(failedNodeID, theHAInfo, true);
+        runOnContextAndWait(() -> {
+          if (failoverCompleteHandler != null) {
+            failoverCompleteHandler.handle(failedNodeID, theHAInfo, true);
+          }
+        });
       }
     } catch (Throwable t) {
       log.error("Failed to handle failover", t);
-      callFailoverCompleteHandler(failedNodeID, theHAInfo, false);
+      runOnContextAndWait(() -> {
+        if (failoverCompleteHandler != null) {
+          failoverCompleteHandler.handle(failedNodeID, theHAInfo, false);
+        }
+      });
     }
   }
 
-  private void checkRemoveSubs(String failedNodeID, JsonObject theHAInfo) {
+  private void checkSubs(String failedNodeID) {
+    if (clusterViewChangedHandler == null) {
+      return;
+    }
     String chosen = chooseHashedNode(null, failedNodeID.hashCode());
     if (chosen != null && chosen.equals(this.nodeID)) {
-      callFailoverCompleteHandler(nodeCrashedHandler, failedNodeID, theHAInfo, true);
+      runOnContextAndWait(() -> clusterViewChangedHandler.accept(new HashSet<>(clusterManager.getNodes())));
     }
   }
 
-  private void callFailoverCompleteHandler(String nodeID, JsonObject haInfo, boolean result) {
-    callFailoverCompleteHandler(failoverCompleteHandler, nodeID, haInfo, result);
-  }
-
-  private void callFailoverCompleteHandler(FailoverCompleteHandler handler, String nodeID, JsonObject haInfo, boolean result) {
-    if (handler != null) {
-      CountDownLatch latch = new CountDownLatch(1);
-      // The testsuite requires that this is called on a Vert.x thread
-      vertx.runOnContext(v -> {
-        handler.handle(nodeID, haInfo, result);
-        latch.countDown();
-      });
+  private void runOnContextAndWait(Runnable runnable) {
+    CountDownLatch latch = new CountDownLatch(1);
+    // The testsuite requires that this is called on a Vert.x thread
+    vertx.runOnContext(v -> {
       try {
-        latch.await(30, TimeUnit.SECONDS);
-      } catch (InterruptedException ignore) {
+        runnable.run();
+      } finally {
+        latch.countDown();
       }
+    });
+    try {
+      latch.await(30, TimeUnit.SECONDS);
+    } catch (InterruptedException ignore) {
     }
   }
 
@@ -580,6 +603,4 @@ public class HAManager {
       return null;
     }
   }
-
-
 }

--- a/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
+++ b/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
@@ -19,6 +19,8 @@ package io.vertx.core.spi.cluster;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
+import java.util.function.Predicate;
+
 /**
  *
  * An asynchronous multi-map.
@@ -63,4 +65,6 @@ public interface AsyncMultiMap<K, V> {
    * @param completionHandler This will be called when the remove is complete
    */
   void removeAllForValue(V v, Handler<AsyncResult<Void>> completionHandler);
+
+  void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler);
 }

--- a/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
+++ b/src/main/java/io/vertx/core/spi/cluster/AsyncMultiMap.java
@@ -66,5 +66,11 @@ public interface AsyncMultiMap<K, V> {
    */
   void removeAllForValue(V v, Handler<AsyncResult<Void>> completionHandler);
 
-  void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler);
+  /**
+   * Remove pairs which value sastifies the given predicate.
+   *
+   * @param p                 The predicate
+   * @param completionHandler This will be called when the remove is complete
+   */
+  void removeAllMatching(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler);
 }

--- a/src/test/java/io/vertx/test/core/FaultToleranceTest.java
+++ b/src/test/java/io/vertx/test/core/FaultToleranceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.Launcher;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.cluster.ClusterManager;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+/**
+ * @author Thomas Segismont
+ */
+public abstract class FaultToleranceTest extends VertxTestBase {
+
+  private static final int NODE_COUNT = 3;
+  private static final int ADDRESSES_COUNT = 10;
+
+  private final List<Process> externalNodes = new ArrayList<>();
+  private final AtomicLong externalNodesStarted = new AtomicLong();
+  private final AtomicLong pongsReceived = new AtomicLong();
+  private final AtomicLong noHandlersErrors = new AtomicLong();
+
+  @Test
+  public void testFaultTolerance() throws Exception {
+    startNodes(1);
+    VertxInternal vertx = (VertxInternal) vertices[0];
+
+    vertx.eventBus().<String>consumer("control", msg -> {
+      switch (msg.body()) {
+        case "start":
+          externalNodesStarted.incrementAndGet();
+          break;
+        case "pong":
+          pongsReceived.incrementAndGet();
+          break;
+        case "noHandlers":
+          noHandlersErrors.incrementAndGet();
+          break;
+      }
+    });
+
+    for (int i = 0; i < NODE_COUNT; i++) {
+      Process process = startExternalNode(i);
+      externalNodes.add(process);
+    }
+    waitUntil(() -> externalNodesStarted.get() == NODE_COUNT, 30_000);
+
+    JsonArray message1 = new JsonArray();
+    IntStream.range(0, NODE_COUNT).forEach(message1::add);
+    vertx.eventBus().publish("ping", message1);
+    waitUntil(() -> pongsReceived.get() == NODE_COUNT * NODE_COUNT * ADDRESSES_COUNT, 30_000);
+
+    for (int i = 0; i < NODE_COUNT - 1; i++) {
+      externalNodes.get(i).destroyForcibly();
+    }
+    waitForClusterStability(vertx);
+
+    pongsReceived.set(0);
+    JsonArray message2 = new JsonArray().add(NODE_COUNT - 1);
+    vertx.eventBus().publish("ping", message2);
+    waitUntil(() -> pongsReceived.get() == ADDRESSES_COUNT, 30_000);
+
+    JsonArray message3 = new JsonArray();
+    IntStream.range(0, NODE_COUNT - 1).forEach(message3::add);
+    vertx.eventBus().publish("ping", message3);
+    waitUntil(() -> noHandlersErrors.get() == (NODE_COUNT - 1) * ADDRESSES_COUNT, 30_000);
+  }
+
+  protected void waitForClusterStability(VertxInternal vertx) throws Exception {
+    ClusterManager clusterManager = vertx.getClusterManager();
+    waitUntil(() -> clusterManager.getNodes().size() == 2, 30_000);
+  }
+
+  private Process startExternalNode(int id) throws Exception {
+    String javaHome = System.getProperty("java.home");
+    String classpath = System.getProperty("java.class.path");
+    List<String> command = new ArrayList<>();
+    command.add(javaHome + File.separator + "bin" + File.separator + "java");
+    command.add("-classpath");
+    command.add(classpath);
+    command.addAll(getExternalNodeSystemProperties());
+    command.add(Launcher.class.getName());
+    command.add("run");
+    command.add(FaultToleranceVerticle.class.getName());
+    command.add("-cluster");
+    command.add("-conf");
+    command.add(new JsonObject().put("id", id).put("addressesCount", ADDRESSES_COUNT).encode());
+    return new ProcessBuilder(command).inheritIO().start();
+  }
+
+  protected List<String> getExternalNodeSystemProperties() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    externalNodes.forEach(Process::destroyForcibly);
+    super.tearDown();
+  }
+}

--- a/src/test/java/io/vertx/test/core/FaultToleranceVerticle.java
+++ b/src/test/java/io/vertx/test/core/FaultToleranceVerticle.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Thomas Segismont
+ */
+public class FaultToleranceVerticle extends AbstractVerticle {
+
+  private int numAddresses;
+
+  @Override
+  public void start() throws Exception {
+    JsonObject config = config();
+    int id = config.getInteger("id");
+    numAddresses = config.getInteger("addressesCount");
+    List<Future> registrationFutures = new ArrayList<>(numAddresses);
+    for (int i = 0; i < numAddresses; i++) {
+      Future<Void> registrationFuture = Future.future();
+      registrationFutures.add(registrationFuture);
+      vertx.eventBus().consumer(createAddress(id, i), msg -> msg.reply("pong")).completionHandler(registrationFuture.completer());
+    }
+    Future<Void> registrationFuture = Future.future();
+    registrationFutures.add(registrationFuture);
+    vertx.eventBus().consumer("ping", this::ping).completionHandler(registrationFuture.completer());
+    CompositeFuture.all(registrationFutures).setHandler(ar -> {
+      if (ar.succeeded()) {
+        vertx.eventBus().send("control", "start");
+      }
+    });
+  }
+
+  private void ping(Message<JsonArray> message) {
+    JsonArray jsonArray = message.body();
+    for (int i = 0; i < jsonArray.size(); i++) {
+      int node = jsonArray.getInteger(i);
+      for (int j = 0; j < numAddresses; j++) {
+        vertx.eventBus().send(createAddress(node, j), "ping", new DeliveryOptions().setSendTimeout(1000), ar -> {
+          if (ar.succeeded()) {
+            vertx.eventBus().send("control", "pong");
+          } else {
+            Throwable cause = ar.cause();
+            if (cause instanceof ReplyException) {
+              ReplyException replyException = (ReplyException) cause;
+              if (replyException.failureType() == ReplyFailure.NO_HANDLERS) {
+                vertx.eventBus().send("control", "noHandlers");
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+
+  private String createAddress(int id, int i) {
+    return "address-" + id + "-" + i;
+  }
+}

--- a/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 public class FakeClusterManager implements ClusterManager {
 
@@ -368,6 +369,11 @@ public class FakeClusterManager implements ClusterManager {
 
     @Override
     public void removeAllForValue(final V v, Handler<AsyncResult<Void>> completionHandler) {
+      removeAll(v::equals, completionHandler);
+    }
+
+    @Override
+    public void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler) {
       workerExecutor.executeBlocking(fut -> {
         Iterator<Map.Entry<K, ChoosableSet<V>>> mapIter = map.entrySet().iterator();
         while (mapIter.hasNext()) {
@@ -376,7 +382,7 @@ public class FakeClusterManager implements ClusterManager {
           Iterator<V> iter = vals.iterator();
           while (iter.hasNext()) {
             V val = iter.next();
-            if (val.equals(v)) {
+            if (p.test(val)) {
               iter.remove();
             }
           }

--- a/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -369,11 +369,11 @@ public class FakeClusterManager implements ClusterManager {
 
     @Override
     public void removeAllForValue(final V v, Handler<AsyncResult<Void>> completionHandler) {
-      removeAll(v::equals, completionHandler);
+      removeAllMatching(v::equals, completionHandler);
     }
 
     @Override
-    public void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler) {
+    public void removeAllMatching(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler) {
       workerExecutor.executeBlocking(fut -> {
         Iterator<Map.Entry<K, ChoosableSet<V>>> mapIter = map.entrySet().iterator();
         while (mapIter.hasNext()) {


### PR DESCRIPTION
This PR supersedes #1735 

It includes the original commit from @rikardscm as well my updates and a test which cluster manager implementations should run. I've tried it with Hazelcast and Infinispan cluster managers successfully.

Note that with this change, it won't be possible connect older versions to the cluster, because the data format of the the subs multimap is not compatible. As a workaround, one can use the TCP bridge.