### PR TITLE
fixes #1752: DNSclient.lookup4 does not return the ip address when a CNAME is used

### DIFF
--- a/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -245,9 +245,11 @@ public final class DnsClientImpl implements DnsClient {
 
                   List<T> records = new ArrayList<>(count);
                   for (int idx = 0;idx < count;idx++) {
-                    DnsRecord a = msg.recordAt(DnsSection.ANSWER);
+                    DnsRecord a = msg.recordAt(DnsSection.ANSWER, idx);
                     T record = RecordDecoder.decode(a);
-                    records.add(record);
+                    if (isRequestedType(a.type(), types)) {
+                      records.add(record);
+                    }
                   }
 
                   if (records.size() > 0 && (records.get(0) instanceof MxRecordImpl || records.get(0) instanceof SrvRecordImpl)) {
@@ -259,6 +261,15 @@ public final class DnsClientImpl implements DnsClient {
                   setFailure(result, new DnsException(code));
                 }
                 ctx.close();
+              }
+
+              private boolean isRequestedType(DnsRecordType dnsRecordType, DnsRecordType[] types) {
+                for (DnsRecordType t : types) {
+                  if (t.equals(dnsRecordType)) {
+                    return true;
+                  }
+                }
+                return false;
               }
 
               @Override

--- a/src/test/java/io/vertx/test/core/DNSTest.java
+++ b/src/test/java/io/vertx/test/core/DNSTest.java
@@ -318,6 +318,21 @@ public class DNSTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  public void testLookup4CNAME() throws Exception {
+    final String cname = "cname.vertx.io";
+    final String ip = "10.0.0.1";
+    DnsClient dns = prepareDns(FakeDNSServer.testLookup4CNAME(cname, ip));
+
+    dns.lookup4("vertx.io", ar -> {
+      String result = ar.result();
+      assertEquals(ip, result);
+      testComplete();
+    });
+    await();
+    dnsServer.stop();
+  }
+
   private DnsClient prepareDns(FakeDNSServer server) throws Exception {
     dnsServer = server;
     dnsServer.start();


### PR DESCRIPTION
fix and unit test for the CNAME resolve issue
