### PR TITLE
Load the rotate option from /etc/resolv.conf on Linux

### DIFF
--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -130,6 +130,7 @@ public class AddressResolverOptions {
     this.rdFlag = other.rdFlag;
     this.searchDomains = other.searchDomains != null ? new ArrayList<>(other.searchDomains) : null;
     this.ndots = other.ndots;
+    this.rotateServers = other.rotateServers;
   }
 
   public AddressResolverOptions(JsonObject json) {

--- a/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
+++ b/src/main/java/io/vertx/core/dns/AddressResolverOptions.java
@@ -82,12 +82,12 @@ public class AddressResolverOptions {
   /**
    * The default ndots value = loads the value from the OS on Linux otherwise use the value 1
    */
-  public static final int DEFAULT_NDOTS = AddressResolver.DEFAULT_NDOTS_RESOLV_OPTION;
+  public static final int DEFAULT_NDOTS = AddressResolver.DEFAULT_RESOLV_CONF.getNdots();
 
   /**
    * The default servers rotate value = loads the value from the OS on Linux otherwise use the value false
    */
-  public static final boolean DEFAULT_ROTATE_SERVERS = AddressResolver.DEFAULT_ROTATE_RESOLV_OPTION;
+  public static final boolean DEFAULT_ROTATE_SERVERS = AddressResolver.DEFAULT_RESOLV_CONF.isRotate();
 
   private String hostsPath;
   private Buffer hostsValue;

--- a/src/main/java/io/vertx/core/impl/ResolvConf.java
+++ b/src/main/java/io/vertx/core/impl/ResolvConf.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Resolver options.
+ *
+ * @author Thomas Segismont
+ */
+public class ResolvConf {
+
+  public static final ResolvConf DEFAULT = new ResolvConf(1, false);
+
+  private final int ndots;
+  private final boolean rotate;
+
+  public ResolvConf(int ndots, boolean rotate) {
+    this.ndots = ndots;
+    this.rotate = rotate;
+  }
+
+  public int getNdots() {
+    return ndots;
+  }
+
+  public boolean isRotate() {
+    return rotate;
+  }
+
+  /**
+   * Parses {@code resolv.conf} options.
+   *
+   * @param env  comma separated list of options, retrieved from environment (per-process override)
+   * @param path path to the {@code resolv.conf} file
+   * @return options parsed
+   */
+  public static ResolvConf load(String env, String path) {
+    Map<String, String> options;
+
+    if (env != null) {
+      options = Arrays.stream(env.split("\\s+"))
+        .collect(HashMap::new, ResolvConf::addOption, HashMap::putAll);
+    } else if (path != null) {
+      File f = new File(path);
+      if (!f.isFile() || !f.canRead()) {
+        return DEFAULT;
+      }
+      try (Stream<String> lines = Files.lines(f.toPath())) {
+        options = lines.map(line -> line.trim().split("\\s+"))
+          .filter(tokens -> tokens.length > 1 && tokens[0].equals("options"))
+          .flatMap(tokens -> Arrays.stream(tokens).skip(1))
+          .collect(HashMap::new, ResolvConf::addOption, HashMap::putAll);
+      } catch (IOException ignore) {
+        return DEFAULT;
+      }
+    } else {
+      return DEFAULT;
+    }
+
+    String ndotsStr = options.get("ndots");
+    int ndots;
+    try {
+      ndots = ndotsStr != null ? Integer.parseInt(ndotsStr) : 1;
+    } catch (NumberFormatException ignore) {
+      return DEFAULT;
+    }
+    boolean rotate = options.containsKey("rotate");
+    return new ResolvConf(ndots, rotate);
+  }
+
+  private static void addOption(Map<String, String> map, String option) {
+    String[] split = option.split(":");
+    if (split.length == 1) {
+      map.put(split[0], null);
+    } else if (split.length == 2) {
+      map.put(split[0], split[1]);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ResolvConf that = (ResolvConf) o;
+    return ndots == that.ndots && rotate == that.rotate;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = ndots;
+    result = 31 * result + (rotate ? 1 : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "ResolvConf{" + "ndots=" + ndots + ", rotate=" + rotate + '}';
+  }
+}

--- a/src/test/java/io/vertx/core/impl/ResolvConfTest.java
+++ b/src/test/java/io/vertx/core/impl/ResolvConfTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.impl;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import java.io.FileNotFoundException;
+import java.net.URL;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ResolvConfTest {
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
+  public void testEnv() throws Exception {
+    assertEquals(new ResolvConf(1, false), ResolvConf.load("debug", null));
+    assertEquals(new ResolvConf(4, true), ResolvConf.load("rotate debug ndots:4", null));
+    assertEquals(new ResolvConf(3, true), ResolvConf.load("rotate ndots:4 debug ndots:3", null));
+    assertEquals(new ResolvConf(4, false), ResolvConf.load("ndots:4 debug", null));
+    assertEquals(new ResolvConf(1, true), ResolvConf.load("debug rotate", null));
+  }
+
+  @Test
+  public void testFile() throws Exception {
+    assertEquals(new ResolvConf(1, false), ResolvConf.load(null, getPath("resolv-default")));
+    assertEquals(new ResolvConf(4, true), ResolvConf.load(null, getPath("resolv-singleline")));
+    assertEquals(new ResolvConf(4, true), ResolvConf.load(null, getPath("resolv-multiline")));
+  }
+
+  @Test
+  public void testPrecedence() throws Exception {
+    assertEquals(new ResolvConf(6, false), ResolvConf.load("debug ndots:6", getPath("resolv-multiline")));
+  }
+
+  private String getPath(String filename) throws FileNotFoundException {
+    URL resource = getClass().getClassLoader().getResource(filename);
+    if (resource == null) {
+      throw new FileNotFoundException(filename);
+    }
+    return resource.getPath();
+  }
+}

--- a/src/test/java/io/vertx/core/impl/ResolvConfTest.java
+++ b/src/test/java/io/vertx/core/impl/ResolvConfTest.java
@@ -16,9 +16,7 @@
 
 package io.vertx.core.impl;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 
 import java.io.FileNotFoundException;
 import java.net.URL;
@@ -29,9 +27,6 @@ import static org.junit.Assert.*;
  * @author Thomas Segismont
  */
 public class ResolvConfTest {
-
-  @Rule
-  public TestName testName = new TestName();
 
   @Test
   public void testEnv() throws Exception {

--- a/src/test/java/io/vertx/test/core/HostnameResolutionTest.java
+++ b/src/test/java/io/vertx/test/core/HostnameResolutionTest.java
@@ -685,44 +685,6 @@ public class HostnameResolutionTest extends VertxTestBase {
   }
 
   @Test
-  public void testParseResolvConf() {
-    assertEquals(-1, AddressResolver.parseNdotsOptionFromResolvConf("options"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("\noptions ndots: 4"));
-    assertEquals(-1, AddressResolver.parseNdotsOptionFromResolvConf("boptions ndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf(" options ndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("\toptions ndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("\foptions ndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("\n options ndots: 4"));
-
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options\tndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options\fndots: 4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options  ndots: 4"));
-    assertEquals(-1, AddressResolver.parseNdotsOptionFromResolvConf("options\nndots: 4"));
-
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:\t4"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:  4"));
-    assertEquals(-1, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:\n4"));
-
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4 "));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4\t"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4\f"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4\n"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4\r"));
-    assertEquals(-1, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4_"));
-
-    assertEquals(2, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4\noptions ndots:2"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options ndots:4 debug"));
-    assertEquals(4, AddressResolver.parseNdotsOptionFromResolvConf("options debug ndots:4"));
-
-    assertEquals(false, AddressResolver.parseRotateOptionFromResolvConf("options"));
-    assertEquals(true, AddressResolver.parseRotateOptionFromResolvConf("options rotate"));
-    assertEquals(true, AddressResolver.parseRotateOptionFromResolvConf("options rotate\n"));
-    assertEquals(false, AddressResolver.parseRotateOptionFromResolvConf("options\nrotate"));
-  }
-
-  @Test
   public void testResolveLocalhost() {
     AddressResolver resolver = new AddressResolver((VertxImpl) vertx, new AddressResolverOptions());
 

--- a/src/test/resources/resolv-default
+++ b/src/test/resources/resolv-default
@@ -1,0 +1,3 @@
+nameserver 8.8.8.8
+nameserver 8.8.8.9
+options debug timeout:1

--- a/src/test/resources/resolv-multiline
+++ b/src/test/resources/resolv-multiline
@@ -1,0 +1,6 @@
+nameserver 8.8.8.8
+nameserver 8.8.8.9
+options debug
+options ndots:4
+options timeout:1
+options rotate

--- a/src/test/resources/resolv-singleline
+++ b/src/test/resources/resolv-singleline
@@ -1,0 +1,3 @@
+nameserver 8.8.8.8
+nameserver 8.8.8.9
+options debug ndots:4 timeout:1 rotate


### PR DESCRIPTION
Fixes the AddressResolverOptions copy constructor and adds the ability to override options on a per-process basis with the RES_OPTIONS environment var.