### PR TITLE
Fixes #1870 In case of NO_HANDLERS, vertx handler executed in wrong context and thread type

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -254,7 +254,6 @@ public class ClusteredEventBus extends EventBusImpl {
     Context context = Vertx.currentContext();
     if (context == null || !context.isEventLoopContext()) {
       // Guarantees the order when there is no current context
-      // Or, when there is a worker context, makes sure message can be sent instantly
       sendNoContext.runOnContext(v -> {
         subs.get(address, resultHandler);
       });

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -251,8 +251,7 @@ public class ClusteredEventBus extends EventBusImpl {
         log.error("Failed to send message", asyncResult.cause());
       }
     };
-    Context context = Vertx.currentContext();
-    if (context == null || !context.isEventLoopContext()) {
+    if (Vertx.currentContext() == null) {
       // Guarantees the order when there is no current context
       sendNoContext.runOnContext(v -> {
         subs.get(address, resultHandler);

--- a/src/test/java/io/vertx/test/core/EventBusTestBase.java
+++ b/src/test/java/io/vertx/test/core/EventBusTestBase.java
@@ -343,28 +343,6 @@ public abstract class EventBusTestBase extends VertxTestBase {
   }
 
   @Test
-  public void testSendFromWorker() throws Exception {
-    String expectedBody = TestUtils.randomAlphaString(20);
-    CountDownLatch receivedLatch = new CountDownLatch(1);
-    startNodes(2);
-    vertices[1].eventBus().<String>consumer(ADDRESS1, msg -> {
-      assertEquals(expectedBody, msg.body());
-      receivedLatch.countDown();
-    }).completionHandler(ar -> {
-      assertTrue(ar.succeeded());
-      vertices[0].deployVerticle(new AbstractVerticle() {
-        @Override
-        public void start() throws Exception {
-          vertices[0].eventBus().send(ADDRESS1, expectedBody);
-          awaitLatch(receivedLatch); // Make sure message is sent even if we're busy
-          testComplete();
-        }
-      }, new DeploymentOptions().setWorker(true));
-    });
-    await();
-  }
-
-  @Test
   public void testReplyFromWorker() throws Exception {
     String expectedBody = TestUtils.randomAlphaString(20);
     startNodes(2);


### PR DESCRIPTION
This PR reverts a previous patch consisting in sending on an arbitrary EL context if sending from a worker context.