### PR TITLE
Fixed issues with the FakeClusterManager

### DIFF
--- a/src/test/java/io/vertx/test/core/ComplexHATest.java
+++ b/src/test/java/io/vertx/test/core/ComplexHATest.java
@@ -182,7 +182,7 @@ public class ComplexHATest extends VertxTestBase {
     v.executeBlocking(fut -> {
       v.simulateKill();
       fut.complete();
-    }, ar -> {
+    }, false, ar -> {
       assertTrue(ar.succeeded());
     });
 


### PR DESCRIPTION
- Node added/left methods are expected to be called by a cluster manager thread
- join/leave/nodeAdded/nodeLeft should not happen concurrently
- NodeListener should not be invoked if the CM is no longer active

Also, in ComplexHATest, it's not necessary to use ordering for simulating kill.
Besides as most CM implementations use executeBlocking, they would not be able to process the event until the kill timeout expires.