### PR TITLE
Add json path support to JsonObject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.2.0</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>${log4j.version}</version>

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -25,6 +25,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
 
+import com.jayway.jsonpath.JsonPath;
+
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 /**
@@ -463,6 +465,17 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
     Objects.requireNonNull(key);
     Object val = getValue(key);
     return val != null || map.containsKey(key) ? val : def;
+  }
+
+  /**
+   * Resolve the given JSON path to load the value.
+   *
+   * @param jsonPath the JSON path
+   * @param <T>      expected return type
+   * @return list of objects matched by the given path
+   */
+  public <T> T getByPath(String jsonPath) {
+    return JsonPath.read(toString(), jsonPath);
   }
 
   /**

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -33,6 +33,8 @@ import java.util.stream.Collectors;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 import static org.junit.Assert.*;
 
+import com.jayway.jsonpath.PathNotFoundException;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -78,6 +80,18 @@ public class JsonObjectTest {
       // OK
     }
 
+  }
+
+  @Test
+  public void testGetByPath() {
+    jsonObject.put("level1", new JsonObject().put("level2", new JsonObject().put("value1", "abc")));
+    String value = jsonObject.getByPath("$.level1.level2.value1");
+    assertEquals("The resolved value did not match with the expected one.", "abc", value);
+  }
+
+  @Test(expected = PathNotFoundException.class)
+  public void testGetByBogusPath() {
+    jsonObject.getByPath("$.level1.levelbogus.value1");
   }
 
   @Test


### PR DESCRIPTION
## Motivation

Loading specific nested values from a Vert.x JsonObject is very cumbersome because each level of nesting would need to be accessed individually. I propose adding JSON Path support in order to make accessing nested values easier.

## Example Usage

```java
jsonObject.put("level1", new JsonObject().put("level2", new JsonObject().put("value1", "abc")));
String value = jsonObject.getByPath("$.level1.level2.value1");
```

Used library is well maintained: https://github.com/jayway/JsonPath