### PR TITLE
Exception cause lost if result already complete.

### DIFF
--- a/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/CompositeFutureImpl.java
@@ -17,8 +17,8 @@
 package io.vertx.core.impl;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 import java.util.function.Function;
@@ -226,22 +226,26 @@ public class CompositeFutureImpl implements CompositeFuture, Handler<AsyncResult
   @Override
   public void complete(CompositeFuture result) {
     if (!tryComplete(result)) {
-      throw new IllegalStateException("Result is already complete: " + (this.cause == null ? "succeeded" : "failed"));
+      String msg = "Result is already complete: " + (this.cause == null ? "succeeded" : "failed");
+      if (result.succeeded()) {
+        throw new IllegalStateException(msg);
+      } else {
+        throw new IllegalStateException(msg, result.cause());
+      }
     }
   }
 
   @Override
   public void fail(Throwable cause) {
     if (!tryFail(cause)) {
-      throw new IllegalStateException("Result is already complete: " + (this.cause == null ? "succeeded" : "failed"));
+      throw new IllegalStateException("Result is already complete: " + (this.cause == null ? "succeeded" : "failed"), cause);
     }
   }
 
   @Override
   public void fail(String failureMessage) {
-    if (!tryFail(failureMessage)) {
-      throw new IllegalStateException("Result is already complete: " + (this.cause == null ? "succeeded" : "failed"));
-    }
+    NoStackTraceThrowable cause = new NoStackTraceThrowable(failureMessage);
+    fail(cause);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/FutureImpl.java
+++ b/src/main/java/io/vertx/core/impl/FutureImpl.java
@@ -118,15 +118,14 @@ class FutureImpl<T> implements Future<T>, Handler<AsyncResult<T>> {
   @Override
   public void fail(Throwable cause) {
     if (!tryFail(cause)) {
-      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"));
+      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"), cause);
     }
   }
 
   @Override
   public void fail(String failureMessage) {
-    if (!tryFail(failureMessage)) {
-      throw new IllegalStateException("Result is already complete: " + (succeeded ? "succeeded" : "failed"));
-    }
+    NoStackTraceThrowable cause = new NoStackTraceThrowable(failureMessage);
+    fail(cause);
   }
 
   @Override


### PR DESCRIPTION
It's impossible to fix the original issue without the cause. Found this while trying to debug a test failure:

```
Caught unexpected Throwable
java.lang.IllegalStateException: Result is already complete: failed
	at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:121)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:277)
	at io.vertx.core.impl.TaskQueue.lambda$new$0(TaskQueue.java:60)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```