### PR TITLE
Customization of Netty "initialBufferSize" #1750

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -715,6 +715,10 @@ Set a client limit of the number concurrent streams for each HTTP/2 connection, 
 Set the idle timeout, in seconds. zero means don't timeout.
  This determines if a connection will timeout and be closed if no data is received within the timeout.
 +++
+|[[initialBufferSizeHttpDecoder]]`initialBufferSizeHttpDecoder`|`Number (int)`|
++++
+set to <code>initialBufferSizeHttpDecoder</code> the initial buffer of the HttpDecoder.
++++
 |[[initialSettings]]`initialSettings`|`link:dataobjects.html#Http2Settings[Http2Settings]`|
 +++
 Set the HTTP/2 connection settings immediately sent by to the server when the client connects.
@@ -921,10 +925,10 @@ This method allows to set the compression level to be used in http1.x/2 response
  
  While one can think that best value is always the maximum compression ratio, 
  there's a trade-off to consider: the most compressed level requires the most
- computatinal work to compress/decompress data, e.g. more dictionary lookups and loops.
+ computational work to compress/decompress data, e.g. more dictionary lookups and loops.
  
  E.g. you have it set fairly high on a high-volume website, you may experience performance degradation 
- and latency on resource serving due to CPU overload, and, however - as the comptational work is required also client side 
+ and latency on resource serving due to CPU overload, and, however - as the computational work is required also client side
  while decompressing - setting an higher compression level can result in an overall higher page load time
  especially nowadays when many clients are handled mobile devices with a low CPU profile.
  
@@ -975,6 +979,10 @@ Set the default HTTP/2 connection window size. It overrides the initial window
 +++
 Set the idle timeout, in seconds. zero means don't timeout.
  This determines if a connection will timeout and be closed if no data is received within the timeout.
++++
+|[[initialBufferSizeHttpDecoder]]`initialBufferSizeHttpDecoder`|`Number (int)`|
++++
+Set the initial buffer size for the HTTP decoder
 +++
 |[[initialSettings]]`initialSettings`|`link:dataobjects.html#Http2Settings[Http2Settings]`|
 +++

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -53,6 +53,9 @@ public class HttpClientOptionsConverter {
     if (json.getValue("http2MultiplexingLimit") instanceof Number) {
       obj.setHttp2MultiplexingLimit(((Number)json.getValue("http2MultiplexingLimit")).intValue());
     }
+    if (json.getValue("initialBufferSizeHttpDecoder") instanceof Number) {
+      obj.setInitialBufferSizeHttpDecoder(((Number)json.getValue("initialBufferSizeHttpDecoder")).intValue());
+    }
     if (json.getValue("initialSettings") instanceof JsonObject) {
       obj.setInitialSettings(new io.vertx.core.http.Http2Settings((JsonObject)json.getValue("initialSettings")));
     }
@@ -117,6 +120,7 @@ public class HttpClientOptionsConverter {
     json.put("http2ConnectionWindowSize", obj.getHttp2ConnectionWindowSize());
     json.put("http2MaxPoolSize", obj.getHttp2MaxPoolSize());
     json.put("http2MultiplexingLimit", obj.getHttp2MultiplexingLimit());
+    json.put("initialBufferSizeHttpDecoder", obj.getInitialBufferSizeHttpDecoder());
     if (obj.getInitialSettings() != null) {
       json.put("initialSettings", obj.getInitialSettings().toJson());
     }

--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -53,6 +53,9 @@ public class HttpServerOptionsConverter {
     if (json.getValue("http2ConnectionWindowSize") instanceof Number) {
       obj.setHttp2ConnectionWindowSize(((Number)json.getValue("http2ConnectionWindowSize")).intValue());
     }
+    if (json.getValue("initialBufferSizeHttpDecoder") instanceof Number) {
+      obj.setInitialBufferSizeHttpDecoder(((Number)json.getValue("initialBufferSizeHttpDecoder")).intValue());
+    }
     if (json.getValue("initialSettings") instanceof JsonObject) {
       obj.setInitialSettings(new io.vertx.core.http.Http2Settings((JsonObject)json.getValue("initialSettings")));
     }
@@ -88,6 +91,7 @@ public class HttpServerOptionsConverter {
     json.put("decompressionSupported", obj.isDecompressionSupported());
     json.put("handle100ContinueAutomatically", obj.isHandle100ContinueAutomatically());
     json.put("http2ConnectionWindowSize", obj.getHttp2ConnectionWindowSize());
+    json.put("initialBufferSizeHttpDecoder", obj.getInitialBufferSizeHttpDecoder());
     if (obj.getInitialSettings() != null) {
       json.put("initialSettings", obj.getInitialSettings().toJson());
     }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -18,6 +18,7 @@ package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 
@@ -144,6 +145,12 @@ public class HttpClientOptions extends ClientOptionsBase {
    */
   public static final int DEFAULT_MAX_REDIRECTS = 16;
 
+  /**
+   * Default initial buffer size for HttpObjectDecoder = 128 bytes
+   */
+  public static final int DEFAULT_INITIAL_BUFFER_SIZE_HTTP_DECODER = 128;
+
+
   private boolean verifyHost = true;
   private int maxPoolSize;
   private boolean keepAlive;
@@ -168,6 +175,7 @@ public class HttpClientOptions extends ClientOptionsBase {
   private boolean http2ClearTextUpgrade;
   private boolean sendUnmaskedFrames;
   private int maxRedirects;
+  private int initialBufferSizeHttpDecoder;
 
   /**
    * Default constructor
@@ -207,6 +215,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.http2ClearTextUpgrade = other.http2ClearTextUpgrade;
     this.sendUnmaskedFrames = other.isSendUnmaskedFrames();
     this.maxRedirects = other.maxRedirects;
+    this.initialBufferSizeHttpDecoder = other.getInitialBufferSizeHttpDecoder();
   }
 
   /**
@@ -255,6 +264,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     http2ClearTextUpgrade = DEFAULT_HTTP2_CLEAR_TEXT_UPGRADE;
     sendUnmaskedFrames = DEFAULT_SEND_UNMASKED_FRAMES;
     maxRedirects = DEFAULT_MAX_REDIRECTS;
+    initialBufferSizeHttpDecoder = DEFAULT_INITIAL_BUFFER_SIZE_HTTP_DECODER;
   }
 
   @Override
@@ -906,6 +916,22 @@ public class HttpClientOptions extends ClientOptionsBase {
     return (HttpClientOptions) super.setLogActivity(logEnabled);
   }
 
+  /**
+   * @return the initial buffer size for the HTTP decoder
+   */
+  public int getInitialBufferSizeHttpDecoder() { return initialBufferSizeHttpDecoder; }
+
+  /**
+   * set to {@code initialBufferSizeHttpDecoder} the initial buffer of the HttpDecoder.
+   * @param initialBufferSizeHttpDecoder the initial buffer size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpClientOptions setInitialBufferSizeHttpDecoder(int initialBufferSizeHttpDecoder) {
+    Arguments.require(initialBufferSizeHttpDecoder > 0, "initialBufferSizeHttpDecoder must be > 0");
+    this.initialBufferSizeHttpDecoder = initialBufferSizeHttpDecoder;
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -934,6 +960,7 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (http2ConnectionWindowSize != that.http2ConnectionWindowSize) return false;
     if (sendUnmaskedFrames != that.sendUnmaskedFrames) return false;
     if (maxRedirects != that.maxRedirects) return false;
+    if (initialBufferSizeHttpDecoder != that.initialBufferSizeHttpDecoder) return false;
 
     return true;
   }
@@ -961,6 +988,8 @@ public class HttpClientOptions extends ClientOptionsBase {
     result = 31 * result + http2ConnectionWindowSize;
     result = 31 * result + (sendUnmaskedFrames ? 1 : 0);
     result = 31 * result + maxRedirects;
+    result = 31 * result + initialBufferSizeHttpDecoder;
     return result;
   }
+
 }

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -18,6 +18,7 @@ package io.vertx.core.http;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.Arguments;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.*;
 
@@ -86,7 +87,7 @@ public class HttpServerOptions extends NetServerOptions {
   public static final List<HttpVersion> DEFAULT_ALPN_VERSIONS = Collections.unmodifiableList(Arrays.asList(HttpVersion.HTTP_2, HttpVersion.HTTP_1_1));
 
   /**
-   * The default inital settings max concurrent stream for an HTTP/2 server = 100
+   * The default initial settings max concurrent stream for an HTTP/2 server = 100
    */
   public static final long DEFAULT_INITIAL_SETTINGS_MAX_CONCURRENT_STREAMS = 100;
 
@@ -105,6 +106,11 @@ public class HttpServerOptions extends NetServerOptions {
    */
   public static final boolean DEFAULT_ACCEPT_UNMASKED_FRAMES = false;
 
+  /**
+   * Default initial buffer size for HttpObjectDecoder = 128 bytes
+   */
+  public static final int DEFAULT_INITIAL_BUFFER_SIZE_HTTP_DECODER = 128;
+
   private boolean compressionSupported;
   private int compressionLevel;
   private int maxWebsocketFrameSize;
@@ -119,6 +125,7 @@ public class HttpServerOptions extends NetServerOptions {
   private int http2ConnectionWindowSize;
   private boolean decompressionSupported;
   private boolean acceptUnmaskedFrames;
+  private int initialBufferSizeHttpDecoder;
 
   /**
    * Default constructor
@@ -150,6 +157,7 @@ public class HttpServerOptions extends NetServerOptions {
     this.http2ConnectionWindowSize = other.http2ConnectionWindowSize;
     this.decompressionSupported = other.isDecompressionSupported();
     this.acceptUnmaskedFrames = other.isAcceptUnmaskedFrames();
+    this.initialBufferSizeHttpDecoder = other.getInitialBufferSizeHttpDecoder();
   }
 
   /**
@@ -189,6 +197,7 @@ public class HttpServerOptions extends NetServerOptions {
     http2ConnectionWindowSize = DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     acceptUnmaskedFrames = DEFAULT_ACCEPT_UNMASKED_FRAMES;
+    initialBufferSizeHttpDecoder = DEFAULT_INITIAL_BUFFER_SIZE_HTTP_DECODER;
   }
 
   @Override
@@ -411,10 +420,10 @@ public class HttpServerOptions extends NetServerOptions {
    * 
    * While one can think that best value is always the maximum compression ratio, 
    * there's a trade-off to consider: the most compressed level requires the most
-   * computatinal work to compress/decompress data, e.g. more dictionary lookups and loops.
+   * computational work to compress/decompress data, e.g. more dictionary lookups and loops.
    * 
    * E.g. you have it set fairly high on a high-volume website, you may experience performance degradation 
-   * and latency on resource serving due to CPU overload, and, however - as the comptational work is required also client side 
+   * and latency on resource serving due to CPU overload, and, however - as the computational work is required also client side
    * while decompressing - setting an higher compression level can result in an overall higher page load time
    * especially nowadays when many clients are handled mobile devices with a low CPU profile.
    * 
@@ -652,6 +661,22 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  /**
+   * @return the initial buffer size for the HTTP decoder
+   */
+  public int getInitialBufferSizeHttpDecoder() { return initialBufferSizeHttpDecoder; }
+
+  /**
+   * Set the initial buffer size for the HTTP decoder
+   * @param initialBufferSizeHttpDecoder the initial size
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setInitialBufferSizeHttpDecoder(int initialBufferSizeHttpDecoder) {
+    Arguments.require(initialBufferSizeHttpDecoder > 0, "initialBufferSizeHttpDecoder must be > 0");
+    this.initialBufferSizeHttpDecoder = initialBufferSizeHttpDecoder;
+    return this;
+  }
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -672,6 +697,7 @@ public class HttpServerOptions extends NetServerOptions {
     if (http2ConnectionWindowSize != that.http2ConnectionWindowSize) return false;
     if (decompressionSupported != that.decompressionSupported) return false;
     if (acceptUnmaskedFrames != that.acceptUnmaskedFrames) return false;
+    if (initialBufferSizeHttpDecoder != that.initialBufferSizeHttpDecoder) return false;
 
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
 
@@ -693,6 +719,7 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + http2ConnectionWindowSize;
     result = 31 * result + (decompressionSupported ? 1 : 0);
     result = 31 * result + (acceptUnmaskedFrames ? 1 : 0);
+    result = 31 * result + initialBufferSizeHttpDecoder;
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -566,7 +566,8 @@ public class ConnectionManager {
       if (logEnabled) {
         pipeline.addLast("logging", new LoggingHandler());
       }
-      pipeline.addLast("codec", new HttpClientCodec(options.getMaxInitialLineLength(), options.getMaxHeaderSize(), options.getMaxChunkSize(), false, false));
+      pipeline.addLast("codec", new HttpClientCodec(options.getMaxInitialLineLength(), options.getMaxHeaderSize(),
+              options.getMaxChunkSize(), false, false, options.getInitialBufferSizeHttpDecoder()));
       if (options.isTryUseCompression()) {
         pipeline.addLast("inflater", new HttpContentDecompressor(true));
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -374,7 +374,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       pipeline.addLast("flashpolicy", new FlashPolicyHandler());
     }
     pipeline.addLast("httpDecoder", new HttpRequestDecoder(options.getMaxInitialLineLength()
-        , options.getMaxHeaderSize(), options.getMaxChunkSize(), false));
+        , options.getMaxHeaderSize(), options.getMaxChunkSize(), false, options.getInitialBufferSizeHttpDecoder()));
     pipeline.addLast("httpEncoder", new VertxHttpResponseEncoder());
     if (options.isDecompressionSupported()) {
       pipeline.addLast("inflater", new HttpContentDecompressor(true));

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -243,6 +243,11 @@ public class Http1xTest extends HttpTest {
     assertEquals(false,options.isSendUnmaskedFrames());
     assertEquals(options,options.setSendUnmaskedFrames(true));
     assertEquals(true,options.isSendUnmaskedFrames());
+
+    assertEquals(HttpClientOptions.DEFAULT_INITIAL_BUFFER_SIZE_HTTP_DECODER, options.getInitialBufferSizeHttpDecoder());
+    assertEquals(options, options.setInitialBufferSizeHttpDecoder(256));
+    assertEquals(256, options.getInitialBufferSizeHttpDecoder());
+    assertIllegalArgumentException(() -> options.setInitialBufferSizeHttpDecoder(-1));
   }
 
   @Test
@@ -384,6 +389,12 @@ public class Http1xTest extends HttpTest {
     assertFalse(options.isDecompressionSupported());
     assertEquals(options, options.setDecompressionSupported(true));
     assertTrue(options.isDecompressionSupported());
+
+    assertEquals(HttpServerOptions.DEFAULT_INITIAL_BUFFER_SIZE_HTTP_DECODER, options.getInitialBufferSizeHttpDecoder());
+    assertEquals(options, options.setInitialBufferSizeHttpDecoder(256));
+    assertEquals(256, options.getInitialBufferSizeHttpDecoder());
+    assertIllegalArgumentException(() -> options.setInitialBufferSizeHttpDecoder(-1));
+
   }
 
   @Test
@@ -430,6 +441,7 @@ public class Http1xTest extends HttpTest {
     boolean openSslSessionCacheEnabled = rand.nextBoolean();
     boolean sendUnmaskedFrame = rand.nextBoolean();
     String localAddress = TestUtils.randomAlphaString(10);
+    int initialSizeBufferHttpDecoder = TestUtils.randomPositiveInt();
 
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -469,6 +481,7 @@ public class Http1xTest extends HttpTest {
     options.setHttp2ClearTextUpgrade(h2cUpgrade);
     options.setLocalAddress(localAddress);
     options.setSendUnmaskedFrames(sendUnmaskedFrame);
+    options.setInitialBufferSizeHttpDecoder(initialSizeBufferHttpDecoder);
     HttpClientOptions copy = new HttpClientOptions(options);
     checkCopyHttpClientOptions(options, copy);
     HttpClientOptions copy2 = new HttpClientOptions(options.toJson());
@@ -558,6 +571,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getAlpnVersions(), json.getAlpnVersions());
     assertEquals(def.isHttp2ClearTextUpgrade(), json.isHttp2ClearTextUpgrade());
     assertEquals(def.getLocalAddress(), json.getLocalAddress());
+    assertEquals(def.getInitialBufferSizeHttpDecoder(), json.getInitialBufferSizeHttpDecoder());
   }
 
   @Test
@@ -608,6 +622,7 @@ public class Http1xTest extends HttpTest {
     boolean h2cUpgrade = rand.nextBoolean();
     boolean openSslSessionCacheEnabled = rand.nextBoolean();
     String localAddress = TestUtils.randomAlphaString(10);
+    int initialBufferSizeHttpDecoder = TestUtils.randomPositiveInt();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -652,7 +667,8 @@ public class Http1xTest extends HttpTest {
       .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
       .put("http2ClearTextUpgrade", h2cUpgrade)
       .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled)
-      .put("localAddress", localAddress);
+      .put("localAddress", localAddress)
+      .put("initialBufferSizeHttpDecoder", initialBufferSizeHttpDecoder);
 
     HttpClientOptions options = new HttpClientOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -707,6 +723,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(alpnVersions, options.getAlpnVersions());
     assertEquals(h2cUpgrade, options.isHttp2ClearTextUpgrade());
     assertEquals(localAddress, options.getLocalAddress());
+    assertEquals(initialBufferSizeHttpDecoder, options.getInitialBufferSizeHttpDecoder());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");
@@ -765,6 +782,7 @@ public class Http1xTest extends HttpTest {
     List<HttpVersion> alpnVersions = Collections.singletonList(HttpVersion.values()[TestUtils.randomPositiveInt() % 3]);
     boolean decompressionSupported = rand.nextBoolean();
     boolean acceptUnmaskedFrames = rand.nextBoolean();
+    int initialSizeBufferHttpDecoder = TestUtils.randomPositiveInt();
 
     options.setSendBufferSize(sendBufferSize);
     options.setReceiveBufferSize(receiverBufferSize);
@@ -796,6 +814,7 @@ public class Http1xTest extends HttpTest {
     options.setAlpnVersions(alpnVersions);
     options.setDecompressionSupported(decompressionSupported);
     options.setAcceptUnmaskedFrames(acceptUnmaskedFrames);
+    options.setInitialBufferSizeHttpDecoder(initialSizeBufferHttpDecoder);
 
     HttpServerOptions copy = new HttpServerOptions(options);
     checkCopyHttpServerOptions(options, copy);
@@ -843,6 +862,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(options.getAlpnVersions(), copy.getAlpnVersions());
     assertEquals(options.isDecompressionSupported(), copy.isDecompressionSupported());
     assertEquals(options.isAcceptUnmaskedFrames(), copy.isAcceptUnmaskedFrames());
+    assertEquals(options.getInitialBufferSizeHttpDecoder(), copy.getInitialBufferSizeHttpDecoder());
   }
 
   @Test
@@ -874,6 +894,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(def.getHttp2ConnectionWindowSize(), json.getHttp2ConnectionWindowSize());
     assertEquals(def.isDecompressionSupported(), json.isDecompressionSupported());
     assertEquals(def.isAcceptUnmaskedFrames(), json.isAcceptUnmaskedFrames());
+    assertEquals(def.getInitialBufferSizeHttpDecoder(), json.getInitialBufferSizeHttpDecoder());
   }
 
   @Test
@@ -920,6 +941,7 @@ public class Http1xTest extends HttpTest {
     boolean openSslSessionCacheEnabled = TestUtils.randomBoolean();
     boolean decompressionSupported = TestUtils.randomBoolean();
     boolean acceptUnmaskedFrames = TestUtils.randomBoolean();
+    int initialBufferSizeHttpDecoder = TestUtils.randomPositiveInt();
 
     JsonObject json = new JsonObject();
     json.put("sendBufferSize", sendBufferSize)
@@ -960,7 +982,8 @@ public class Http1xTest extends HttpTest {
       .put("alpnVersions", new JsonArray().add(alpnVersions.get(0).name()))
       .put("openSslSessionCacheEnabled", openSslSessionCacheEnabled)
       .put("decompressionSupported", decompressionSupported)
-      .put("acceptUnmaskedFrames", acceptUnmaskedFrames);
+      .put("acceptUnmaskedFrames", acceptUnmaskedFrames)
+      .put("initialBufferSizeHttpDecoder", initialBufferSizeHttpDecoder);
 
     HttpServerOptions options = new HttpServerOptions(json);
     assertEquals(sendBufferSize, options.getSendBufferSize());
@@ -1010,6 +1033,7 @@ public class Http1xTest extends HttpTest {
     assertEquals(alpnVersions, options.getAlpnVersions());
     assertEquals(decompressionSupported, options.isDecompressionSupported());
     assertEquals(acceptUnmaskedFrames, options.isAcceptUnmaskedFrames());
+    assertEquals(initialBufferSizeHttpDecoder, options.getInitialBufferSizeHttpDecoder());
 
     // Test other keystore/truststore types
     json.remove("keyStoreOptions");


### PR DESCRIPTION
Motivation:
Under load and with HTTP requests or responses with multiple headers, a
lot of CPU-time can be spent on "AppendableCharSequence.append", which
has to always grow and so has to copy char arrays.

Modifications:
Changed HttpClientOptions and HttpServerOptions to allow the user to
pass an initial buffer size for Netty’s HTTP decoder that fits her
needs when not happy with the default initial buffer size, i.e. 128
bytes. Also, fixed some typos in documentation.

Result:
Initial buffer size for HTTP decoder is customisable.