### PR TITLE
FIX #1802 - Better failure logging when handleMessage failes

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -212,7 +212,7 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
       theHandler.handle(message);
       metrics.endHandleMessage(metric, null);
     } catch (Exception e) {
-      log.error("Failed to handleMessage", e);
+      log.error("Failed to handleMessage. address: " + message.address(), e);
       metrics.endHandleMessage(metric, e);
       throw e;
     }


### PR DESCRIPTION
I fix issue #1802 from @rscorer. Message can't be null at catch as being dereferenced 9 lines earlier.
Signed-off-by: jzajic <jan.zajic@corpus.cz>