### PR TITLE
Move to build-helper-maven-plugin 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.12</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>add-source</id>


### PR DESCRIPTION
It makes importing the Vert.x project in Eclipse/m2e (and VS Code) work OOTB.

Signed-off-by: Fred Bricon <fbricon@gmail.com>