### PR TITLE
Test case showing retrieved buffer does not match created size.

### DIFF
--- a/src/test/java/io/vertx/test/core/BufferTest.java
+++ b/src/test/java/io/vertx/test/core/BufferTest.java
@@ -605,6 +605,7 @@ public class BufferTest {
     Buffer b = Buffer.buffer(bytes);
 
     assertTrue(TestUtils.byteArraysEqual(bytes, b.getBytes()));
+    assertEquals(100, b.getBytes(0, 99).length);
   }
 
   @Test


### PR DESCRIPTION
The returned array misses the last element.
Merging this test will cause the test suite to fail.