### PR TITLE
Fixes #1905 EventBus interceptor does not get message body when clustered

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/SendContext.java
+++ b/src/main/java/io/vertx/core/eventbus/SendContext.java
@@ -22,8 +22,12 @@ public interface SendContext<T> {
   void next();
 
   /**
-   *
    * @return true if the message is being sent (point to point) or False if the message is being published
    */
   boolean send();
+
+  /**
+   * @return the value sent or published (before being processed by the codec)
+   */
+  Object sentBody();
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -16,8 +16,22 @@
 
 package io.vertx.core.eventbus.impl;
 
-import io.vertx.core.*;
-import io.vertx.core.eventbus.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.eventbus.MessageProducer;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.core.eventbus.SendContext;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -454,6 +468,11 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     @Override
     public boolean send() {
       return message.isSend();
+    }
+
+    @Override
+    public Object sentBody() {
+      return message.sentBody;
     }
   }
 


### PR DESCRIPTION
Fixes #1905 EventBus interceptor does not get message body when clustered

ClusteredMessage#body returns null for a clustered message not yet sent.
 The fix consists in using the codec #transform method in this case