### PR TITLE
Fixes intermittent failure in io.vertx.test.core.Http2ClientTest.test100Continue

### DIFF
--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -1290,7 +1290,7 @@ public class Http2ClientTest extends Http2TestBase {
     server.close();
     server = vertx.createHttpServer(serverOptions.setHandle100ContinueAutomatically(true));
     server.requestHandler(req -> {
-      assertEquals(0, status.getAndIncrement());
+      status.getAndIncrement();
       HttpServerResponse resp = req.response();
       req.bodyHandler(body -> {
         assertEquals(2, status.getAndIncrement());
@@ -1311,7 +1311,7 @@ public class Http2ClientTest extends Http2TestBase {
     req.continueHandler(v -> {
       Context ctx = Vertx.currentContext();
       assertOnIOContext(ctx);
-      assertEquals(1, status.getAndIncrement());
+      status.getAndIncrement();
       req.end(Buffer.buffer("request-body"));
     });
     req.sendHead(version -> {


### PR DESCRIPTION
```
java.lang.AssertionError: expected:<0> but was:<1>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at io.vertx.test.core.AsyncTestBase.assertEquals(AsyncTestBase.java:235)
	at io.vertx.test.core.Http2ClientTest.lambda$test100Continue$170(Http2ClientTest.java:1293)
```

We know the body handler should be called after both the request handler and the continue handler have been called.
But we don't know which one will be called first: in Http2ServerConnection.onHeadersRead, we write continue headers to the response then schedule the request handler execution.