### PR TITLE
Fixes intermittent failure in io.vertx.test.core.NamedWorkerPoolTest.testOrdered

### DIFF
--- a/src/test/java/io/vertx/test/core/NamedWorkerPoolTest.java
+++ b/src/test/java/io/vertx/test/core/NamedWorkerPoolTest.java
@@ -97,8 +97,8 @@ public class NamedWorkerPoolTest extends VertxTestBase {
           }
         });
       }
+      submitted.countDown();
     });
-    submitted.countDown();
     await();
   }
 


### PR DESCRIPTION
```
java.lang.AssertionError: expected:<Thread[vert.x-GSTPGFHKBV-0,5,main]> but was:<Thread[vert.x-GSTPGFHKBV-1,5,main]>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at io.vertx.test.core.AsyncTestBase.assertEquals(AsyncTestBase.java:354)
	at io.vertx.test.core.NamedWorkerPoolTest.lambda$null$3(NamedWorkerPoolTest.java:90)
```

The `submitted` latch must be updated after all blocking tasks have been submitted, not after the test task has been scheduled for execution on context.
