### PR TITLE
Fix NullPointerException in JsonObject.mergeIn

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -728,18 +728,22 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
       return this;
     }
     for (Map.Entry<String, Object> e: other.map.entrySet()) {
-      map.merge(e.getKey(), e.getValue(), (oldVal, newVal) -> {
-        if (oldVal instanceof Map) {
-          oldVal = new JsonObject((Map)oldVal);
-        }
-        if (newVal instanceof Map) {
-          newVal = new JsonObject((Map)newVal);
-        }
-        if (oldVal instanceof JsonObject && newVal instanceof JsonObject) {
-          return ((JsonObject) oldVal).mergeIn((JsonObject)newVal, depth - 1);
-        }
-        return newVal;
-      });
+      if (e.getValue() == null){
+        map.put(e.getKey(), null);
+      } else {
+        map.merge(e.getKey(), e.getValue(), (oldVal, newVal) -> {
+          if (oldVal instanceof Map) {
+            oldVal = new JsonObject((Map)oldVal);
+          }
+          if (newVal instanceof Map) {
+            newVal = new JsonObject((Map)newVal);
+          }
+          if (oldVal instanceof JsonObject && newVal instanceof JsonObject) {
+            return ((JsonObject) oldVal).mergeIn((JsonObject)newVal, depth - 1);
+          }
+          return newVal;
+        });
+      }
     }
     return this;
   }

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -1724,6 +1724,18 @@ public class JsonObjectTest {
     assertEquals(expectedKeys, keys);
   }
 
+  @Test
+  public void testMergeInNullValue() {
+    JsonObject obj = new JsonObject();
+    obj.put("key", "value");
+
+    JsonObject otherObj = new JsonObject();
+    otherObj.putNull("key");
+
+    obj.mergeIn(otherObj, true);
+    assertNull(obj.getString("key"));
+  }
+
   private void testStreamCorrectTypes(JsonObject object) {
     object.stream().forEach(entry -> {
       String key = entry.getKey();


### PR DESCRIPTION
Merge of `java.util.LinkedHashMap` throws NullPointerException when value is null.

Example to force the error.
```
JsonObject json = new JsonObject();
json.put("key", "value");

JsonObject otherJson = new JsonObject();
otherJson.putNull("key");

json.mergeIn(otherJson, true);
```