### PR TITLE
Change "blocking code pool" to "worker pool"

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -291,7 +291,7 @@ An alternative way to run blocking code is to use a <<worker_verticles, worker v
 
 A worker verticle is always executed with a thread from the worker pool.
 
-By default blocking code is executed on the Vert.x blocking code pool, configured with `link:../../apidocs/io/vertx/core/VertxOptions.html#setWorkerPoolSize-int-[setWorkerPoolSize]`.
+By default blocking code is executed on the Vert.x worker pool, configured with `link:../../apidocs/io/vertx/core/VertxOptions.html#setWorkerPoolSize-int-[setWorkerPoolSize]`.
 
 Additional pools can be created for different purposes:
 


### PR DESCRIPTION
Since " it is called worker pool in other places" :)
This change is based on following enhancement suggestion:
https://github.com/vert-x3/vertx-web-site/issues/210#issuecomment-293002313