### PR TITLE
Fix Http2ServerResponse.putHeader to match the Http1ServerResponse implementation

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerResponseImpl.java
@@ -214,7 +214,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse putHeader(String name, String value) {
     synchronized (conn) {
       checkHeadWritten();
-      headers().add(name, value);
+      headers().set(name, value);
       return this;
     }
   }
@@ -223,7 +223,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse putHeader(CharSequence name, CharSequence value) {
     synchronized (conn) {
       checkHeadWritten();
-      headers().add(name, value);
+      headers().set(name, value);
       return this;
     }
   }
@@ -232,7 +232,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse putHeader(String name, Iterable<String> values) {
     synchronized (conn) {
       checkHeadWritten();
-      headers().add(name, values);
+      headers().set(name, values);
       return this;
     }
   }
@@ -241,7 +241,7 @@ public class Http2ServerResponseImpl implements HttpServerResponse {
   public HttpServerResponse putHeader(CharSequence name, Iterable<CharSequence> values) {
     synchronized (conn) {
       checkHeadWritten();
-      headers().add(name, values);
+      headers().set(name, values);
       return this;
     }
   }

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -79,6 +79,7 @@ import java.util.stream.IntStream;
 import static io.vertx.test.core.TestUtils.assertIllegalArgumentException;
 import static io.vertx.test.core.TestUtils.assertIllegalStateException;
 import static io.vertx.test.core.TestUtils.assertNullPointerException;
+import static java.util.Collections.singletonList;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -283,6 +284,22 @@ public abstract class HttpTest extends HttpTestBase {
         assertEquals(200, resp.statusCode());
         testComplete();
       }).putHeader("foo", "bar").end();
+    }));
+    await();
+  }
+
+  @Test
+  public void testPutHeaderReplacesPreviousHeaders() throws Exception {
+    server.requestHandler(req ->
+      req.response()
+        .putHeader("Location", "http://example1.org")
+        .putHeader("location", "http://example2.org")
+        .end());
+    server.listen(onSuccess(server -> {
+      client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        assertEquals(singletonList("http://example2.org"), resp.headers().getAll("LocatioN"));
+        testComplete();
+       }).end();
     }));
     await();
   }


### PR DESCRIPTION
The Http2 putHeader implementation did not replace but instead appended.

This broke for example pac4j authentication with Safari browser when using HTTP2 connections.