### PR TITLE
Improve the redeploy documentation

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1235,7 +1235,7 @@ java io.vertx.core.Launcher run org.acme.MyVerticle --redeploy="**/*.class"  --l
 
 The redeployment process is implemented as follows. First your application is launched as a background application
 (with the `start` command). On matching file changes, the process is stopped and the application is restarted.
-This way avoids leaks (as the process is restarted).
+This avoids leaks, as the process is restarted.
 
 To enable the live redeploy, pass the `--redeploy` option to the `run` command. The `--redeploy` indicates the
 set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and `?`). You can specify
@@ -1273,7 +1273,7 @@ java -jar build/libs/my-fat-jar.jar --redeploy="src/**/*.java" --on-redeploy='./
 
 The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
 restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
-or `grunt` to update your resources. Don't forget that passing parameter to your application requires the
+or `grunt` to update your resources. Don't forget that passing parameters to your application requires the
 `--java-opts` param:
 
 [source]

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1235,14 +1235,15 @@ java io.vertx.core.Launcher run org.acme.MyVerticle --redeploy="**/*.class"  --l
 
 The redeployment process is implemented as follows. First your application is launched as a background application
 (with the `start` command). On matching file changes, the process is stopped and the application is restarted.
-This way avoids leaks.
+This way avoids leaks (as the process is restarted).
 
 To enable the live redeploy, pass the `--redeploy` option to the `run` command. The `--redeploy` indicates the
 set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and `?`). You can specify
 several sets by separating them using a comma (`,`). Patterns are relative to the current working directory.
 
 Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
-configured using `--java-opts`.
+configured using `--java-opts`. For instance, to pass the the `conf` parameter or a system property, you need to
+use: `--java-opts="-conf=my-conf.json -Dkey=value"`
 
 The `--launcher-class` option determine with with _main_ class the application is launcher. It's generally
 `link:../../apidocs/io/vertx/core/Launcher.html[Launcher]`, but you have use you own _main_.
@@ -1272,7 +1273,14 @@ java -jar build/libs/my-fat-jar.jar --redeploy="src/**/*.java" --on-redeploy='./
 
 The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
 restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
-or `grunt` to update your resources.
+or `grunt` to update your resources. Don't forget that passing parameter to your application requires the
+`--java-opts` param:
+
+[source]
+----
+java -jar target/my-fat-jar.jar --redeploy="**/*.java" --on-redeploy="mvn package" --java-opts="-Dkey=val"
+java -jar build/libs/my-fat-jar.jar --redeploy="src/**/*.java" --on-redeploy='./gradlew shadowJar' --java-opts="-Dkey=val"
+----
 
 The redeploy feature also supports the following settings:
 

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1138,14 +1138,15 @@
  *
  * The redeployment process is implemented as follows. First your application is launched as a background application
  * (with the `start` command). On matching file changes, the process is stopped and the application is restarted.
- * This way avoids leaks.
+ * This way avoids leaks (as the process is restarted).
  *
  * To enable the live redeploy, pass the `--redeploy` option to the `run` command. The `--redeploy` indicates the
  * set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and `?`). You can specify
  * several sets by separating them using a comma (`,`). Patterns are relative to the current working directory.
  *
  * Parameters passed to the `run` command are passed to the application. Java Virtual Machine options can be
- * configured using `--java-opts`.
+ * configured using `--java-opts`. For instance, to pass the the `conf` parameter or a system property, you need to
+ * use: `--java-opts="-conf=my-conf.json -Dkey=value"`
  *
  * The `--launcher-class` option determine with with _main_ class the application is launcher. It's generally
  * {@link io.vertx.core.Launcher}, but you have use you own _main_.
@@ -1175,7 +1176,14 @@
  *
  * The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
  * restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
- * or `grunt` to update your resources.
+ * or `grunt` to update your resources. Don't forget that passing parameter to your application requires the
+ * `--java-opts` param:
+ *
+ * [source]
+ * ----
+ * java -jar target/my-fat-jar.jar --redeploy="**&#47;*.java" --on-redeploy="mvn package" --java-opts="-Dkey=val"
+ * java -jar build/libs/my-fat-jar.jar --redeploy="src&#47;**&#47;*.java" --on-redeploy='./gradlew shadowJar' --java-opts="-Dkey=val"
+ * ----
  *
  * The redeploy feature also supports the following settings:
  *

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1138,7 +1138,7 @@
  *
  * The redeployment process is implemented as follows. First your application is launched as a background application
  * (with the `start` command). On matching file changes, the process is stopped and the application is restarted.
- * This way avoids leaks (as the process is restarted).
+ * This avoids leaks, as the process is restarted.
  *
  * To enable the live redeploy, pass the `--redeploy` option to the `run` command. The `--redeploy` indicates the
  * set of file to _watch_. This set can use Ant-style patterns (with `\**`, `*` and `?`). You can specify
@@ -1176,7 +1176,7 @@
  *
  * The "on-redeploy" option specifies a command invoked after the shutdown of the application and before the
  * restart. So you can hook your build tool if it updates some runtime artifacts. For instance, you can launch `gulp`
- * or `grunt` to update your resources. Don't forget that passing parameter to your application requires the
+ * or `grunt` to update your resources. Don't forget that passing parameters to your application requires the
  * `--java-opts` param:
  *
  * [source]


### PR DESCRIPTION
Explicitly mention the --java-opts parameter used to configure the forked process.
This issue is related to #1960 (and hopefully fix it)
