### PR TITLE
JSON spec states that JSON is UTF-8 encoded, not platform dependent

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/RunCommand.java
@@ -405,7 +405,7 @@ public class RunCommand extends BareCommand {
   protected JsonObject getConfiguration() {
     JsonObject conf;
     if (config != null) {
-      try (Scanner scanner = new Scanner(new File(config)).useDelimiter("\\A")) {
+      try (Scanner scanner = new Scanner(new File(config), "UTF-8").useDelimiter("\\A")) {
         String sconf = scanner.next();
         try {
           conf = new JsonObject(sconf);


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Fixes: #1836 