### PR TITLE
Make the logic of NetClientImpl reusable in NetClientBase

### DIFF
--- a/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
+++ b/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
@@ -33,7 +33,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.spi.metrics.*;
-import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
@@ -82,7 +81,7 @@ public class DummyVertxMetrics implements VertxMetrics {
   }
 
   @Override
-  public TCPMetrics createMetrics(NetClient client, NetClientOptions options) {
+  public TCPMetrics createMetrics(NetClientOptions options) {
     return DummyTCPMetrics.INSTANCE;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/NetClientBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientBase.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.net.impl;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.ssl.SslHandler;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Closeable;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.spi.metrics.Metrics;
+import io.vertx.core.spi.metrics.MetricsProvider;
+import io.vertx.core.spi.metrics.TCPMetrics;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ *
+ * This class is thread-safe
+ *
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public abstract class NetClientBase<C extends ConnectionBase> implements MetricsProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(NetClientBase.class);
+
+  private final VertxInternal vertx;
+  private final NetClientOptions options;
+  protected final SSLHelper sslHelper;
+  private final Map<Channel, C> socketMap = new ConcurrentHashMap<>();
+  private final Closeable closeHook;
+  private final ContextImpl creatingContext;
+  private final TCPMetrics metrics;
+  private volatile boolean closed;
+
+  public NetClientBase(VertxInternal vertx, NetClientOptions options, boolean useCreatingContext) {
+    this.vertx = vertx;
+    this.options = new NetClientOptions(options);
+    this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
+    this.closeHook = completionHandler -> {
+      NetClientBase.this.close();
+      completionHandler.handle(Future.succeededFuture());
+    };
+    if (useCreatingContext) {
+      creatingContext = vertx.getContext();
+      if (creatingContext != null) {
+        if (creatingContext.isMultiThreadedWorkerContext()) {
+          throw new IllegalStateException("Cannot use NetClient in a multi-threaded worker verticle");
+        }
+        creatingContext.addCloseHook(closeHook);
+      }
+    } else {
+      creatingContext = null;
+    }
+    this.metrics = vertx.metricsSPI().createMetrics(options);
+  }
+
+  /**
+   * Create a connection for a channel.
+   *
+   * @return the created connection
+   */
+  protected abstract C createConnection(VertxInternal vertx, Channel channel, String host, int port,
+                                        ContextImpl context, SSLHelper helper, TCPMetrics metrics);
+
+  protected abstract void handleMsgReceived(C conn, Object msg);
+
+  protected abstract void initChannel(ChannelPipeline pipeline);
+
+  protected abstract Object safeObject(Object msg, ByteBufAllocator allocator);
+
+  public void close() {
+    if (!closed) {
+      for (C sock : socketMap.values()) {
+        sock.close();
+      }
+      if (creatingContext != null) {
+        creatingContext.removeCloseHook(closeHook);
+      }
+      closed = true;
+      metrics.close();
+    }
+  }
+
+  @Override
+  public boolean isMetricsEnabled() {
+    return metrics != null && metrics.isEnabled();
+  }
+
+  @Override
+  public Metrics getMetrics() {
+    return metrics;
+  }
+
+  private void checkClosed() {
+    if (closed) {
+      throw new IllegalStateException("Client is closed");
+    }
+  }
+
+  private void applyConnectionOptions(Bootstrap bootstrap) {
+    if (options.getLocalAddress() != null) {
+      bootstrap.localAddress(options.getLocalAddress(), 0);
+    }
+    bootstrap.option(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
+    if (options.getSendBufferSize() != -1) {
+      bootstrap.option(ChannelOption.SO_SNDBUF, options.getSendBufferSize());
+    }
+    if (options.getReceiveBufferSize() != -1) {
+      bootstrap.option(ChannelOption.SO_RCVBUF, options.getReceiveBufferSize());
+      bootstrap.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(options.getReceiveBufferSize()));
+    }
+    if (options.getSoLinger() != -1) {
+      bootstrap.option(ChannelOption.SO_LINGER, options.getSoLinger());
+    }
+    if (options.getTrafficClass() != -1) {
+      bootstrap.option(ChannelOption.IP_TOS, options.getTrafficClass());
+    }
+    bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, options.getConnectTimeout());
+    bootstrap.option(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
+    bootstrap.option(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
+  }
+
+  protected void doConnect(int port, String host, String serverName, Handler<AsyncResult<C>> connectHandler) {
+    doConnect(port, host, serverName, connectHandler, options.getReconnectAttempts());
+  }
+
+  protected void doConnect(int port, String host, String serverName, Handler<AsyncResult<C>> connectHandler,
+                           int remainingAttempts) {
+    checkClosed();
+    Objects.requireNonNull(host, "No null host accepted");
+    Objects.requireNonNull(connectHandler, "No null connectHandler accepted");
+    ContextImpl context = vertx.getOrCreateContext();
+    sslHelper.validate(vertx);
+    Bootstrap bootstrap = new Bootstrap();
+    bootstrap.group(context.nettyEventLoop());
+    bootstrap.channel(NioSocketChannel.class);
+
+    applyConnectionOptions(bootstrap);
+
+    ChannelProvider channelProvider;
+    if (options.getProxyOptions() == null) {
+      channelProvider = ChannelProvider.INSTANCE;
+    } else {
+      channelProvider = ProxyChannelProvider.INSTANCE;
+    }
+
+    Handler<Channel> channelInitializer = ch -> {
+      ChannelPipeline pipeline = ch.pipeline();
+      if (sslHelper.isSSL()) {
+        SslHandler sslHandler = new SslHandler(sslHelper.createEngine(vertx, host, port, serverName));
+        ch.pipeline().addLast("ssl", sslHandler);
+      }
+      initChannel(pipeline);
+      pipeline.addLast("handler", new VertxNetHandler<C>(ch, socketMap) {
+        @Override
+        protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+          return NetClientBase.this.safeObject(msg, allocator);
+        }
+        @Override
+        protected void handleMsgReceived(C conn, Object msg) {
+          NetClientBase.this.handleMsgReceived(conn, msg);
+        }
+      });
+    };
+
+    Handler<AsyncResult<Channel>> channelHandler = res -> {
+      if (res.succeeded()) {
+
+        Channel ch = res.result();
+
+        if (sslHelper.isSSL()) {
+          // TCP connected, so now we must do the SSL handshake
+          SslHandler sslHandler = (SslHandler) ch.pipeline().get("ssl");
+
+          io.netty.util.concurrent.Future<Channel> fut = sslHandler.handshakeFuture();
+          fut.addListener(future2 -> {
+            if (future2.isSuccess()) {
+              connected(context, ch, connectHandler, host, port);
+            } else {
+              failed(context, ch, future2.cause(), connectHandler);
+            }
+          });
+        } else {
+          connected(context, ch, connectHandler, host, port);
+        }
+
+      } else {
+        if (remainingAttempts > 0 || remainingAttempts == -1) {
+          context.executeFromIO(() -> {
+            log.debug("Failed to create connection. Will retry in " + options.getReconnectInterval() + " milliseconds");
+            //Set a timer to retry connection
+            vertx.setTimer(options.getReconnectInterval(), tid ->
+                doConnect(port, host, serverName, connectHandler, remainingAttempts == -1 ? remainingAttempts : remainingAttempts - 1)
+            );
+          });
+        } else {
+          failed(context, null, res.cause(), connectHandler);
+        }
+      }
+    };
+
+    channelProvider.connect(vertx, bootstrap, options.getProxyOptions(), host, port, channelInitializer, channelHandler);
+  }
+
+  private void connected(ContextImpl context, Channel ch, Handler<AsyncResult<C>> connectHandler, String host, int port) {
+    // Need to set context before constructor is called as writehandler registration needs this
+    ContextImpl.setContext(context);
+    C sock = createConnection(vertx, ch, host, port, context, sslHelper, metrics);
+    VertxNetHandler handler = ch.pipeline().get(VertxNetHandler.class);
+    handler.conn = sock;
+    socketMap.put(ch, sock);
+    context.executeFromIO(() -> {
+      sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
+      connectHandler.handle(Future.succeededFuture(sock));
+    });
+  }
+
+  private void failed(ContextImpl context, Channel ch, Throwable th, Handler<AsyncResult<C>> connectHandler) {
+    if (ch != null) {
+      ch.close();
+    }
+    context.executeFromIO(() -> doFailed(connectHandler, th));
+  }
+
+  private void doFailed(Handler<AsyncResult<C>> connectHandler, Throwable th) {
+    connectHandler.handle(Future.failedFuture(th));
+  }
+}
+

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -16,36 +16,25 @@
 
 package io.vertx.core.net.impl;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-
-import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.FixedRecvByteBufAllocator;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Closeable;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.TCPMetrics;
+
+import static io.vertx.core.net.impl.VertxHandler.safeBuffer;
 
 /**
  *
@@ -53,220 +42,63 @@ import io.vertx.core.spi.metrics.TCPMetrics;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class NetClientImpl implements NetClient, MetricsProvider {
+public class NetClientImpl extends NetClientBase<NetSocketImpl> implements NetClient, MetricsProvider {
 
-  private static final Logger log = LoggerFactory.getLogger(NetClientImpl.class);
-
-  private final VertxInternal vertx;
-  private final NetClientOptions options;
-  private final SSLHelper sslHelper;
-  private final Map<Channel, NetSocketImpl> socketMap = new ConcurrentHashMap<>();
-  private final Closeable closeHook;
-  private final ContextImpl creatingContext;
-  private final TCPMetrics metrics;
+  private final int idleTimeout;
   private final boolean logEnabled;
-  private volatile boolean closed;
 
   public NetClientImpl(VertxInternal vertx, NetClientOptions options) {
     this(vertx, options, true);
   }
 
   public NetClientImpl(VertxInternal vertx, NetClientOptions options, boolean useCreatingContext) {
-    this.vertx = vertx;
-    this.options = new NetClientOptions(options);
-    this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
-    this.logEnabled = options.getLogActivity();
-    this.closeHook = completionHandler -> {
-      NetClientImpl.this.close();
-      completionHandler.handle(Future.succeededFuture());
-    };
-    if (useCreatingContext) {
-      creatingContext = vertx.getContext();
-      if (creatingContext != null) {
-        if (creatingContext.isMultiThreadedWorkerContext()) {
-          throw new IllegalStateException("Cannot use NetClient in a multi-threaded worker verticle");
-        }
-        creatingContext.addCloseHook(closeHook);
-      }
-    } else {
-      creatingContext = null;
-    }
-    this.metrics = vertx.metricsSPI().createMetrics(this, options);
+    super(vertx, options, useCreatingContext);
+    logEnabled = options.getLogActivity();
+    idleTimeout = options.getIdleTimeout();
   }
 
   public synchronized NetClient connect(int port, String host, Handler<AsyncResult<NetSocket>> connectHandler) {
-    checkClosed();
-    connect(port, host, null, connectHandler, options.getReconnectAttempts());
+    connect(port, host, null, connectHandler);
     return this;
   }
 
   @Override
   public NetClient connect(int port, String host, String serverName, Handler<AsyncResult<NetSocket>> connectHandler) {
-    checkClosed();
-    connect(port, host, serverName, connectHandler, options.getReconnectAttempts());
+    doConnect(port, host, serverName, connectHandler != null ? ar -> connectHandler.handle(ar.map(s -> (NetSocket) s)) : null);
     return this;
   }
 
   @Override
-  public void close() {
-    if (!closed) {
-      for (NetSocket sock : socketMap.values()) {
-        sock.close();
-      }
-      if (creatingContext != null) {
-        creatingContext.removeCloseHook(closeHook);
-      }
-      closed = true;
-      metrics.close();
+  protected Object safeObject(Object msg, ByteBufAllocator allocator) {
+    if (msg instanceof ByteBuf) {
+      return safeBuffer((ByteBuf) msg, allocator);
+    }
+    return msg;
+  }
+
+  @Override
+  protected void initChannel(ChannelPipeline pipeline) {
+    if (logEnabled) {
+      pipeline.addLast("logging", new LoggingHandler());
+    }
+    if (sslHelper.isSSL()) {
+      // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.
+      pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());       // For large file / sendfile support
+    }
+    if (idleTimeout > 0) {
+      pipeline.addLast("idle", new IdleStateHandler(0, 0, idleTimeout));
     }
   }
 
   @Override
-  public boolean isMetricsEnabled() {
-    return metrics != null && metrics.isEnabled();
+  protected NetSocketImpl createConnection(VertxInternal vertx, Channel channel, String host, int port, ContextImpl context, SSLHelper helper, TCPMetrics metrics) {
+    return new NetSocketImpl(vertx, channel, host, port, context, helper, metrics);
   }
 
   @Override
-  public Metrics getMetrics() {
-    return metrics;
-  }
-
-  private void checkClosed() {
-    if (closed) {
-      throw new IllegalStateException("Client is closed");
-    }
-  }
-
-  private void applyConnectionOptions(Bootstrap bootstrap) {
-    if (options.getLocalAddress() != null) {
-      bootstrap.localAddress(options.getLocalAddress(), 0);
-    }
-    bootstrap.option(ChannelOption.TCP_NODELAY, options.isTcpNoDelay());
-    if (options.getSendBufferSize() != -1) {
-      bootstrap.option(ChannelOption.SO_SNDBUF, options.getSendBufferSize());
-    }
-    if (options.getReceiveBufferSize() != -1) {
-      bootstrap.option(ChannelOption.SO_RCVBUF, options.getReceiveBufferSize());
-      bootstrap.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(options.getReceiveBufferSize()));
-    }
-    if (options.getSoLinger() != -1) {
-      bootstrap.option(ChannelOption.SO_LINGER, options.getSoLinger());
-    }
-    if (options.getTrafficClass() != -1) {
-      bootstrap.option(ChannelOption.IP_TOS, options.getTrafficClass());
-    }
-    bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, options.getConnectTimeout());
-    bootstrap.option(ChannelOption.ALLOCATOR, PartialPooledByteBufAllocator.INSTANCE);
-    bootstrap.option(ChannelOption.SO_KEEPALIVE, options.isTcpKeepAlive());
-  }
-
-  private void connect(int port, String host, String serverName, Handler<AsyncResult<NetSocket>> connectHandler,
-      int remainingAttempts) {
-    Objects.requireNonNull(host, "No null host accepted");
-    Objects.requireNonNull(connectHandler, "No null connectHandler accepted");
-    ContextImpl context = vertx.getOrCreateContext();
-    sslHelper.validate(vertx);
-    Bootstrap bootstrap = new Bootstrap();
-    bootstrap.group(context.nettyEventLoop());
-    bootstrap.channel(NioSocketChannel.class);
-
-    applyConnectionOptions(bootstrap);
-
-    ChannelProvider channelProvider;
-    if (options.getProxyOptions() == null) {
-      channelProvider = ChannelProvider.INSTANCE;
-    } else {
-      channelProvider = ProxyChannelProvider.INSTANCE;
-    }
-
-    Handler<Channel> channelInitializer = ch -> {
-
-      if (sslHelper.isSSL()) {
-        SslHandler sslHandler = new SslHandler(sslHelper.createEngine(vertx, host, port, serverName));
-        ch.pipeline().addLast("ssl", sslHandler);
-      }
-
-      ChannelPipeline pipeline = ch.pipeline();
-      if (logEnabled) {
-        pipeline.addLast("logging", new LoggingHandler());
-      }
-      if (sslHelper.isSSL()) {
-        // only add ChunkedWriteHandler when SSL is enabled otherwise it is not needed as FileRegion is used.
-        pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());       // For large file / sendfile support
-      }
-      if (options.getIdleTimeout() > 0) {
-        pipeline.addLast("idle", new IdleStateHandler(0, 0, options.getIdleTimeout()));
-      }
-      pipeline.addLast("handler", new VertxNetHandler<NetSocketImpl>(ch, socketMap) {
-        @Override
-        protected void handleMsgReceived(NetSocketImpl conn, Object msg) {
-          ByteBuf buf = (ByteBuf) msg;
-          conn.handleDataReceived(Buffer.buffer(buf));
-        }
-      });
-    };
-
-    Handler<AsyncResult<Channel>> channelHandler = res -> {
-      if (res.succeeded()) {
-
-        Channel ch = res.result();
-
-        if (sslHelper.isSSL()) {
-          // TCP connected, so now we must do the SSL handshake
-          SslHandler sslHandler = (SslHandler) ch.pipeline().get("ssl");
-
-          io.netty.util.concurrent.Future<Channel> fut = sslHandler.handshakeFuture();
-          fut.addListener(future2 -> {
-            if (future2.isSuccess()) {
-              connected(context, ch, connectHandler, host, port);
-            } else {
-              failed(context, ch, future2.cause(), connectHandler);
-            }
-          });
-        } else {
-          connected(context, ch, connectHandler, host, port);
-        }
-
-      } else {
-        if (remainingAttempts > 0 || remainingAttempts == -1) {
-          context.executeFromIO(() -> {
-            log.debug("Failed to create connection. Will retry in " + options.getReconnectInterval() + " milliseconds");
-            //Set a timer to retry connection
-            vertx.setTimer(options.getReconnectInterval(), tid ->
-                connect(port, host, serverName, connectHandler, remainingAttempts == -1 ? remainingAttempts : remainingAttempts - 1)
-            );
-          });
-        } else {
-          failed(context, null, res.cause(), connectHandler);
-        }
-      }
-    };
-
-    channelProvider.connect(vertx, bootstrap, options.getProxyOptions(), host, port, channelInitializer, channelHandler);
-  }
-
-  private void connected(ContextImpl context, Channel ch, Handler<AsyncResult<NetSocket>> connectHandler, String host, int port) {
-    // Need to set context before constructor is called as writehandler registration needs this
-    ContextImpl.setContext(context);
-    NetSocketImpl sock = new NetSocketImpl(vertx, ch, host, port, context, sslHelper, metrics);
-    VertxNetHandler handler = ch.pipeline().get(VertxNetHandler.class);
-    handler.conn = sock;
-    socketMap.put(ch, sock);
-    context.executeFromIO(() -> {
-      sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
-      connectHandler.handle(Future.succeededFuture(sock));
-    });
-  }
-
-  private void failed(ContextImpl context, Channel ch, Throwable th, Handler<AsyncResult<NetSocket>> connectHandler) {
-    if (ch != null) {
-      ch.close();
-    }
-    context.executeFromIO(() -> doFailed(connectHandler, th));
-  }
-
-  private static void doFailed(Handler<AsyncResult<NetSocket>> connectHandler, Throwable th) {
-    connectHandler.handle(Future.failedFuture(th));
+  protected void handleMsgReceived(NetSocketImpl conn, Object msg) {
+    ByteBuf buf = (ByteBuf) msg;
+    conn.handleDataReceived(Buffer.buffer(buf));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -137,11 +137,10 @@ public interface VertxMetrics extends Metrics, Measured {
    * <p>
    * No specific thread and context can be expected when this method is called.
    *
-   * @param client  the Vert.x net client
-   * @param options the options used to create the {@link io.vertx.core.net.NetClient}
+   * @param options the options used to create the {@link NetClient}
    * @return the net client metrics SPI
    */
-  TCPMetrics<?> createMetrics(NetClient client, NetClientOptions options);
+  TCPMetrics<?> createMetrics(NetClientOptions options);
 
   /**
    * Provides the datagram/udp metrics SPI when a datagram socket is created.<p/>

--- a/src/test/java/io/vertx/test/core/MetricsContextTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsContextTest.java
@@ -636,7 +636,7 @@ public class MetricsContextTest extends VertxTestBase {
     AtomicBoolean closeCalled = new AtomicBoolean();
     VertxMetricsFactory factory = (vertx, options) -> new DummyVertxMetrics() {
       @Override
-      public TCPMetrics createMetrics(NetClient client, NetClientOptions options) {
+      public TCPMetrics createMetrics(NetClientOptions options) {
         return new DummyTCPMetrics() {
           @Override
           public Void connected(SocketAddress remoteAddress, String remoteName) {

--- a/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeVertxMetrics.java
@@ -25,7 +25,6 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
@@ -101,7 +100,7 @@ public class FakeVertxMetrics extends FakeMetricsBase implements VertxMetrics {
     };
   }
 
-  public TCPMetrics<?> createMetrics(NetClient client, NetClientOptions options) {
+  public TCPMetrics<?> createMetrics(NetClientOptions options) {
     return new TCPMetrics<Object>() {
 
       public Object connected(SocketAddress remoteAddress, String remoteName) {


### PR DESCRIPTION
This shall be used by the upcoming mqtt client to reuse the connection handing provided by Vert.x