### PR TITLE
Elaborating dependencies in the build.gradle

### DIFF
--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -16,5 +16,5 @@ project descriptor to access the Vert.x Core API:
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-core:3.4.2-SNAPSHOT
+compile 'io.vertx:vertx-core:3.4.2-SNAPSHOT'
 ----

--- a/src/main/asciidoc/java/override/dependencies.adoc
+++ b/src/main/asciidoc/java/override/dependencies.adoc
@@ -16,5 +16,7 @@ project descriptor to access the Vert.x Core API:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-core:3.4.2-SNAPSHOT'
+dependencies {
+ compile 'io.vertx:vertx-core:3.4.2-SNAPSHOT'
+}
 ----

--- a/src/main/java/docoverride/dependencies/package-info.java
+++ b/src/main/java/docoverride/dependencies/package-info.java
@@ -33,7 +33,9 @@
  *
  * [source,groovy,subs="+attributes"]
  * ----
- * compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+ * dependencies {
+ *  compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
+ * }
  * ----
  */
 @Document(fileName = "override/dependencies.adoc")

--- a/src/main/java/docoverride/dependencies/package-info.java
+++ b/src/main/java/docoverride/dependencies/package-info.java
@@ -33,7 +33,7 @@
  *
  * [source,groovy,subs="+attributes"]
  * ----
- * compile ${maven.groupId}:${maven.artifactId}:${maven.version}
+ * compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
  * ----
  */
 @Document(fileName = "override/dependencies.adoc")


### PR DESCRIPTION
Hi there:

Currently the dependency part in build.gradle is pretty simple and missing single quotation mark which may cause problems in the build.gradle.

Thus we elaborate this part and make it consistent to the other module gradle dependencies descriptor.

using:

```
dependencies {
  compile '${maven.groupId}:${maven.artifactId}:${maven.version}'
}
```

to replace

`compile '${maven.groupId}:${maven.artifactId}:${maven.version}`