### PR TITLE
Faster json parsing #1975

### DIFF
--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -21,15 +21,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -82,12 +79,12 @@ public class BufferImpl implements Buffer {
 
   @Override
   public JsonObject toJsonObject() {
-    return new JsonObject(Json.decodeValue(this, Map.class));
+    return new JsonObject(this);
   }
 
   @Override
   public JsonArray toJsonArray() {
-    return new JsonArray(Json.decodeValue(this, List.class));
+    return new JsonArray(this);
   }
 
   public byte getByte(int pos) {

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -21,12 +21,15 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -79,12 +82,12 @@ public class BufferImpl implements Buffer {
 
   @Override
   public JsonObject toJsonObject() {
-    return new JsonObject(toString());
+    return new JsonObject(Json.decodeValue(this, Map.class));
   }
 
   @Override
   public JsonArray toJsonArray() {
-    return new JsonArray(toString());
+    return new JsonArray(Json.decodeValue(this, List.class));
   }
 
   public byte getByte(int pos) {

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ByteArraySerializer;
+import io.netty.buffer.ByteBufInputStream;
+import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -82,6 +84,14 @@ public class Json {
       return mapper.readValue(str, clazz);
     }
     catch (Exception e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+  public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
+    try {
+      return mapper.readValue(new ByteBufInputStream(buf.getByteBuf()), clazz);
+    } catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }
   }

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Base64;
@@ -89,8 +90,12 @@ public class Json {
   }
 
   public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
+    return decodeValue(new ByteBufInputStream(buf.getByteBuf()), clazz);
+  }
+
+  public static <T> T decodeValue(InputStream stream, Class<T> clazz) throws DecodeException {
     try {
-      return mapper.readValue(new ByteBufInputStream(buf.getByteBuf()), clazz);
+      return mapper.readValue(stream, clazz);
     } catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -78,15 +78,6 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
   }
 
   /**
-   * Create an instance from a stream of JSON.
-   *
-   * @param stream  the stream of JSON.
-   */
-  public JsonArray(InputStream stream) {
-    fromStream(stream);
-  }
-
-  /**
    * Get the String at position {@code pos} in the array,
    *
    * @param pos  the position in the array

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -19,6 +19,7 @@ package io.vertx.core.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
+import java.io.InputStream;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
@@ -65,6 +66,24 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
    */
   public JsonArray(List list) {
     this.list = list;
+  }
+
+  /**
+   * Create an instance from a Buffer of JSON.
+   *
+   * @param buf  the buffer of JSON.
+   */
+  public JsonArray(Buffer buf) {
+    fromBuffer(buf);
+  }
+
+  /**
+   * Create an instance from a stream of JSON.
+   *
+   * @param stream  the stream of JSON.
+   */
+  public JsonArray(InputStream stream) {
+    fromStream(stream);
   }
 
   /**
@@ -639,6 +658,14 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
 
   private void fromJson(String json) {
     list = Json.decodeValue(json, List.class);
+  }
+
+  private void fromBuffer(Buffer buf) {
+    list = Json.decodeValue(buf, List.class);
+  }
+
+  private void fromStream(InputStream stream) {
+    list = Json.decodeValue(stream, List.class);
   }
 
   private class Iter implements Iterator<Object> {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -80,15 +80,6 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
-   * Create an instance from a stream.
-   *
-   * @param stream  the stream to create the instance from.
-   */
-  public JsonObject(InputStream stream) {
-    fromStream(stream);
-  }
-
-  /**
    * Create a JsonObject from the fields of a Java object.
    * Faster than calling `new JsonObject(Json.encode(obj))`.
    * 

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
@@ -67,6 +68,24 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    */
   public JsonObject(Map<String, Object> map) {
     this.map = map;
+  }
+
+  /**
+   * Create an instance from a buffer.
+   *
+   * @param buf  the buffer to create the instance from.
+   */
+  public JsonObject(Buffer buf) {
+    fromBuffer(buf);
+  }
+
+  /**
+   * Create an instance from a stream.
+   *
+   * @param stream  the stream to create the instance from.
+   */
+  public JsonObject(InputStream stream) {
+    fromStream(stream);
   }
 
   /**
@@ -930,6 +949,14 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
 
   private void fromJson(String json) {
     map = Json.decodeValue(json, Map.class);
+  }
+
+  private void fromBuffer(Buffer buf) {
+    map = Json.decodeValue(buf, Map.class);
+  }
+
+  private void fromStream(InputStream stream) {
+    map = Json.decodeValue(stream, Map.class);
   }
 
   private class Iter implements Iterator<Map.Entry<String, Object>> {

--- a/src/test/java/io/vertx/test/core/JsonArrayTest.java
+++ b/src/test/java/io/vertx/test/core/JsonArrayTest.java
@@ -1028,6 +1028,15 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testCreateFromBuffer() {
+    JsonArray excepted = new JsonArray();
+    excepted.add("foobar");
+    excepted.add(123);
+    Buffer buf = Buffer.buffer(excepted.encode());
+    assertEquals(excepted, new JsonArray(buf));
+  }
+
+  @Test
   public void testClusterSerializable() {
     jsonArray.add("foo").add(123);
     Buffer buff = Buffer.buffer();

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -24,10 +24,6 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.StringBufferInputStream;
-import java.io.StringReader;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -24,6 +24,10 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringBufferInputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -1507,6 +1511,15 @@ public class JsonObjectTest {
     assertEquals("bar", obj.getString("foo"));
     assertEquals(Integer.valueOf(123), obj.getInteger("quux"));
     assertSame(map, obj.getMap());
+  }
+
+  @Test
+  public void testCreateFromBuffer() {
+    JsonObject excepted = new JsonObject();
+    excepted.put("foo", "bar");
+    excepted.put("quux", 123);
+    Buffer buf = Buffer.buffer(excepted.encode());
+    assertEquals(excepted, new JsonObject(buf));
   }
 
   @Test


### PR DESCRIPTION
Motivation:
We can speed up json parsing provide in Buffer. 
In fact, Jackson is a bit more efficient when the parsing is based on byte[] or InputStream ([Jackson-Performance](https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance)).
In addition, this will reduce intermediate String allocation.
We can use the underlying netty ByteBuf to achieve this.

Modification:
We need to add a method in Json to be able to decodeValue from Buffer.
And then we can modify toJsonObject and toJsonArray implementation in Buffer.

Result:
Better performance for json parsing based on Buffer.

Signed-off-by: amannocci <adrien.mannocci@gmail.com>