### PR TITLE
Amannocci faster json parsing

### DIFF
--- a/src/main/asciidoc/java/http.adoc
+++ b/src/main/asciidoc/java/http.adoc
@@ -1993,7 +1993,7 @@ also overrides the default client setting.
 
 ==== Server Name Indication (SNI)
 
-Vert.x http servers can be configured to use SNI in exactly the same way as net servers.
+Vert.x http servers can be configured to use SNI in exactly the same way as net.adoc.
 
 Vert.x http client will present the actual hostname as _server name_ during the TLS handshake.
 

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -21,15 +21,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
-import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -82,12 +79,12 @@ public class BufferImpl implements Buffer {
 
   @Override
   public JsonObject toJsonObject() {
-    return new JsonObject(Json.decodeValue(this, Map.class));
+    return new JsonObject(this);
   }
 
   @Override
   public JsonArray toJsonArray() {
-    return new JsonArray(Json.decodeValue(this, List.class));
+    return new JsonArray(this);
   }
 
   public byte getByte(int pos) {

--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -21,12 +21,15 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.impl.Arguments;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -79,12 +82,12 @@ public class BufferImpl implements Buffer {
 
   @Override
   public JsonObject toJsonObject() {
-    return new JsonObject(toString());
+    return new JsonObject(Json.decodeValue(this, Map.class));
   }
 
   @Override
   public JsonArray toJsonArray() {
-    return new JsonArray(toString());
+    return new JsonArray(Json.decodeValue(this, List.class));
   }
 
   public byte getByte(int pos) {

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ByteArraySerializer;
+import io.netty.buffer.ByteBufInputStream;
+import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -82,6 +84,14 @@ public class Json {
       return mapper.readValue(str, clazz);
     }
     catch (Exception e) {
+      throw new DecodeException("Failed to decode:" + e.getMessage(), e);
+    }
+  }
+
+  public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
+    try {
+      return mapper.readValue(new ByteBufInputStream(buf.getByteBuf()), clazz);
+    } catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }
   }

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -25,6 +25,7 @@ import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Base64;
@@ -89,8 +90,12 @@ public class Json {
   }
 
   public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
+    return decodeValue(new ByteBufInputStream(buf.getByteBuf()), clazz);
+  }
+
+  public static <T> T decodeValue(InputStream stream, Class<T> clazz) throws DecodeException {
     try {
-      return mapper.readValue(new ByteBufInputStream(buf.getByteBuf()), clazz);
+      return mapper.readValue(stream, clazz);
     } catch (Exception e) {
       throw new DecodeException("Failed to decode:" + e.getMessage(), e);
     }

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -25,6 +25,7 @@ import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Base64;
@@ -66,6 +67,24 @@ public class Json {
   public static String encode(Object obj) throws EncodeException {
     try {
       return mapper.writeValueAsString(obj);
+    } catch (Exception e) {
+      throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
+    }
+  }
+
+  public static Buffer encodeToBuffer(Object obj) throws EncodeException {
+    try {
+      final Buffer buffer = Buffer.buffer();
+
+      mapper.writeValue(new OutputStream() {
+        @Override
+        public void write(int b) throws IOException {
+          buffer.appendByte((byte) b);
+        }
+      }, obj);
+
+      return buffer;
+
     } catch (Exception e) {
       throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -64,6 +64,13 @@ public class Json {
     prettyMapper.registerModule(module);
   }
 
+  /**
+   * Encode a POJO to JSON using the underlying Jackson mapper.
+   *
+   * @param obj a POJO
+   * @return a String containing the JSON representation of the given POJO.
+   * @throws EncodeException if a property cannot be encoded.
+   */
   public static String encode(Object obj) throws EncodeException {
     try {
       return mapper.writeValueAsString(obj);
@@ -72,6 +79,13 @@ public class Json {
     }
   }
 
+  /**
+   * Encode a POJO to JSON using the underlying Jackson mapper.
+   *
+   * @param obj a POJO
+   * @return a Buffer containing the JSON representation of the given POJO.
+   * @throws EncodeException if a property cannot be encoded.
+   */
   public static Buffer encodeToBuffer(Object obj) throws EncodeException {
     try {
       Buffer buf = Buffer.buffer();
@@ -82,6 +96,13 @@ public class Json {
     }
   }
 
+  /**
+   * Encode a POJO to JSON with pretty indentation, using the underlying Jackson mapper.
+   *
+   * @param obj a POJO
+   * @return a String containing the JSON representation of the given POJO.
+   * @throws EncodeException if a property cannot be encoded.
+   */
   public static String encodePrettily(Object obj) throws EncodeException {
     try {
       return prettyMapper.writeValueAsString(obj);
@@ -90,6 +111,14 @@ public class Json {
     }
   }
 
+  /**
+   * Decode a given JSON string to a POJO of the given class type.
+   * @param str the JSON string.
+   * @param clazz the class to map to.
+   * @param <T> the generic type.
+   * @return an instance of T
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
   public static <T> T decodeValue(String str, Class<T> clazz) throws DecodeException {
     try {
       return mapper.readValue(str, clazz);
@@ -98,6 +127,14 @@ public class Json {
     }
   }
 
+  /**
+   * Decode a given JSON string to a POJO of the given type.
+   * @param str the JSON string.
+   * @param type the type to map to.
+   * @param <T> the generic type.
+   * @return an instance of T
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
   public static <T> T decodeValue(String str, TypeReference<T> type) throws DecodeException {
     try {
       return mapper.readValue(str, type);
@@ -106,6 +143,14 @@ public class Json {
     }
   }
 
+  /**
+   * Decode a given JSON buffer to a POJO of the given class type.
+   * @param buf the JSON buffer.
+   * @param type the type to map to.
+   * @param <T> the generic type.
+   * @return an instance of T
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
   public static <T> T decodeValue(Buffer buf, TypeReference<T> type) throws DecodeException {
     try {
       return mapper.readValue(new ByteBufInputStream(buf.getByteBuf()), type);
@@ -114,6 +159,14 @@ public class Json {
     }
   }
 
+  /**
+   * Decode a given JSON buffer to a POJO of the given class type.
+   * @param buf the JSON buffer.
+   * @param clazz the class to map to.
+   * @param <T> the generic type.
+   * @return an instance of T
+   * @throws DecodeException when there is a parsing or invalid mapping.
+   */
   public static <T> T decodeValue(Buffer buf, Class<T> clazz) throws DecodeException {
     try {
       return mapper.readValue(new ByteBufInputStream(buf.getByteBuf()), clazz);

--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -26,7 +26,6 @@ import io.vertx.core.buffer.Buffer;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Base64;
@@ -75,17 +74,7 @@ public class Json {
 
   public static Buffer encodeToBuffer(Object obj) throws EncodeException {
     try {
-      final Buffer buffer = Buffer.buffer();
-
-      mapper.writeValue(new OutputStream() {
-        @Override
-        public void write(int b) throws IOException {
-          buffer.appendByte((byte) b);
-        }
-      }, obj);
-
-      return buffer;
-
+      return Buffer.buffer(mapper.writeValueAsBytes(obj));
     } catch (Exception e) {
       throw new EncodeException("Failed to encode as JSON: " + e.getMessage());
     }

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -19,7 +19,6 @@ package io.vertx.core.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
@@ -662,10 +661,6 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
 
   private void fromBuffer(Buffer buf) {
     list = Json.decodeValue(buf, List.class);
-  }
-
-  private void fromStream(InputStream stream) {
-    list = Json.decodeValue(stream, List.class);
   }
 
   private class Iter implements Iterator<Object> {

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -555,6 +555,15 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
   }
 
   /**
+   * Encode this JSON object as a string.
+   *
+   * @return the string encoding.
+   */
+  public Buffer toBuffer() {
+    return Json.encodeToBuffer(list);
+  }
+
+  /**
    * Encode the JSON array prettily as a string
    *
    * @return the string encoding

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -554,9 +554,9 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
   }
 
   /**
-   * Encode this JSON object as a string.
+   * Encode this JSON object as buffer.
    *
-   * @return the string encoding.
+   * @return the buffer encoding.
    */
   public Buffer toBuffer() {
     return Json.encodeToBuffer(list);

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -78,15 +78,6 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
   }
 
   /**
-   * Create an instance from a stream of JSON.
-   *
-   * @param stream  the stream of JSON.
-   */
-  public JsonArray(InputStream stream) {
-    fromStream(stream);
-  }
-
-  /**
    * Get the String at position {@code pos} in the array,
    *
    * @param pos  the position in the array

--- a/src/main/java/io/vertx/core/json/JsonArray.java
+++ b/src/main/java/io/vertx/core/json/JsonArray.java
@@ -19,6 +19,7 @@ package io.vertx.core.json;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
+import java.io.InputStream;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Stream;
@@ -65,6 +66,24 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
    */
   public JsonArray(List list) {
     this.list = list;
+  }
+
+  /**
+   * Create an instance from a Buffer of JSON.
+   *
+   * @param buf  the buffer of JSON.
+   */
+  public JsonArray(Buffer buf) {
+    fromBuffer(buf);
+  }
+
+  /**
+   * Create an instance from a stream of JSON.
+   *
+   * @param stream  the stream of JSON.
+   */
+  public JsonArray(InputStream stream) {
+    fromStream(stream);
   }
 
   /**
@@ -639,6 +658,14 @@ public class JsonArray implements Iterable<Object>, ClusterSerializable {
 
   private void fromJson(String json) {
     list = Json.decodeValue(json, List.class);
+  }
+
+  private void fromBuffer(Buffer buf) {
+    list = Json.decodeValue(buf, List.class);
+  }
+
+  private void fromStream(InputStream stream) {
+    list = Json.decodeValue(stream, List.class);
   }
 
   private class Iter implements Iterator<Object> {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -82,7 +82,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   /**
    * Create a JsonObject from the fields of a Java object.
    * Faster than calling `new JsonObject(Json.encode(obj))`.
-   * 
+   *
    * @param obj
    *          The object to convert to a JsonObject.
    * @throws IllegalArgumentException
@@ -96,7 +96,7 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   /**
    * Instantiate a Java object from a JsonObject.
    * Faster than calling `Json.decodeValue(Json.encode(jsonObject), type)`.
-   * 
+   *
    * @param type
    *          The type to instantiate from the JsonObject.
    * @throws IllegalArgumentException
@@ -771,6 +771,15 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    */
   public String encodePrettily() {
     return Json.encodePrettily(map);
+  }
+
+  /**
+   * Encode this JSON object as a string.
+   *
+   * @return the string encoding.
+   */
+  public Buffer toBuffer() {
+    return Json.encodeToBuffer(map);
   }
 
   /**

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -80,15 +80,6 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
-   * Create an instance from a stream.
-   *
-   * @param stream  the stream to create the instance from.
-   */
-  public JsonObject(InputStream stream) {
-    fromStream(stream);
-  }
-
-  /**
    * Create a JsonObject from the fields of a Java object.
    * Faster than calling `new JsonObject(Json.encode(obj))`.
    * 

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -20,6 +20,7 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
@@ -67,6 +68,24 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
    */
   public JsonObject(Map<String, Object> map) {
     this.map = map;
+  }
+
+  /**
+   * Create an instance from a buffer.
+   *
+   * @param buf  the buffer to create the instance from.
+   */
+  public JsonObject(Buffer buf) {
+    fromBuffer(buf);
+  }
+
+  /**
+   * Create an instance from a stream.
+   *
+   * @param stream  the stream to create the instance from.
+   */
+  public JsonObject(InputStream stream) {
+    fromStream(stream);
   }
 
   /**
@@ -930,6 +949,14 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
 
   private void fromJson(String json) {
     map = Json.decodeValue(json, Map.class);
+  }
+
+  private void fromBuffer(Buffer buf) {
+    map = Json.decodeValue(buf, Map.class);
+  }
+
+  private void fromStream(InputStream stream) {
+    map = Json.decodeValue(stream, Map.class);
   }
 
   private class Iter implements Iterator<Map.Entry<String, Object>> {

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -773,9 +773,9 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
   }
 
   /**
-   * Encode this JSON object as a string.
+   * Encode this JSON object as buffer.
    *
-   * @return the string encoding.
+   * @return the buffer encoding.
    */
   public Buffer toBuffer() {
     return Json.encodeToBuffer(map);

--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -20,7 +20,6 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
@@ -953,10 +952,6 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
 
   private void fromBuffer(Buffer buf) {
     map = Json.decodeValue(buf, Map.class);
-  }
-
-  private void fromStream(InputStream stream) {
-    map = Json.decodeValue(stream, Map.class);
   }
 
   private class Iter implements Iterator<Map.Entry<String, Object>> {

--- a/src/test/java/io/vertx/test/core/JsonArrayTest.java
+++ b/src/test/java/io/vertx/test/core/JsonArrayTest.java
@@ -1028,6 +1028,15 @@ public class JsonArrayTest {
   }
 
   @Test
+  public void testCreateFromBuffer() {
+    JsonArray excepted = new JsonArray();
+    excepted.add("foobar");
+    excepted.add(123);
+    Buffer buf = Buffer.buffer(excepted.encode());
+    assertEquals(excepted, new JsonArray(buf));
+  }
+
+  @Test
   public void testClusterSerializable() {
     jsonArray.add("foo").add(123);
     Buffer buff = Buffer.buffer();

--- a/src/test/java/io/vertx/test/core/JsonArrayTest.java
+++ b/src/test/java/io/vertx/test/core/JsonArrayTest.java
@@ -303,7 +303,7 @@ public class JsonArrayTest {
 
   @Test
   public void testGetJsonObject() {
-    JsonObject obj = new JsonObject().put("foo", "bar");    
+    JsonObject obj = new JsonObject().put("foo", "bar");
     jsonArray.add(obj);
     assertEquals(obj, jsonArray.getJsonObject(0));
     try {
@@ -844,6 +844,25 @@ public class JsonArrayTest {
     String expected = "[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
     String json = jsonArray.encode();
     assertEquals(expected, json);
+  }
+
+  @Test
+  public void testEncodeToBuffer() throws Exception {
+    jsonArray.add("foo");
+    jsonArray.add(123);
+    jsonArray.add(1234l);
+    jsonArray.add(1.23f);
+    jsonArray.add(2.34d);
+    jsonArray.add(true);
+    byte[] bytes = TestUtils.randomByteArray(10);
+    jsonArray.add(bytes);
+    jsonArray.addNull();
+    jsonArray.add(new JsonObject().put("foo", "bar"));
+    jsonArray.add(new JsonArray().add("foo").add(123));
+    String strBytes = Base64.getEncoder().encodeToString(bytes);
+    Buffer expected = Buffer.buffer("[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]", "UTF-8");
+    Buffer json = jsonArray.toBuffer();
+    assertArrayEquals(expected.getBytes(), json.getBytes());
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/JsonMapperTest.java
+++ b/src/test/java/io/vertx/test/core/JsonMapperTest.java
@@ -17,6 +17,7 @@
 package io.vertx.test.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.Json;
 import org.junit.Test;
 
@@ -83,5 +84,13 @@ public class JsonMapperTest extends VertxTestBase {
     String json = Json.encode(data);
     assertNotNull(json);
     assertEquals("null", json);
+  }
+
+  @Test
+  public void encodeToBuffer() {
+    Buffer json = Json.encodeToBuffer("Hello World!");
+    assertNotNull(json);
+    // json strings are always UTF8
+    assertEquals("\"Hello World!\"", json.toString("UTF-8"));
   }
 }

--- a/src/test/java/io/vertx/test/core/JsonMapperTest.java
+++ b/src/test/java/io/vertx/test/core/JsonMapperTest.java
@@ -106,8 +106,14 @@ public class JsonMapperTest extends VertxTestBase {
     original.value = "test";
 
     String json = Json.encode(Collections.singletonList(original));
+    List<Pojo> correct;
 
-    List<Pojo> correct = Json.decodeValue(json, new TypeReference<List<Pojo>>() {});
+    correct = Json.decodeValue(json, new TypeReference<List<Pojo>>() {});
+    assertTrue(((List)correct).get(0) instanceof Pojo);
+    assertEquals(original.value, correct.get(0).value);
+
+    // same must apply if instead of string we use a buffer
+    correct = Json.decodeValue(Buffer.buffer(json, "UTF8"), new TypeReference<List<Pojo>>() {});
     assertTrue(((List)correct).get(0) instanceof Pojo);
     assertEquals(original.value, correct.get(0).value);
 

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -1211,6 +1211,31 @@ public class JsonObjectTest {
   }
 
   @Test
+  public void testEncodeToBuffer() throws Exception {
+    jsonObject.put("mystr", "foo");
+    jsonObject.put("mycharsequence", new StringBuilder("oob"));
+    jsonObject.put("myint", 123);
+    jsonObject.put("mylong", 1234l);
+    jsonObject.put("myfloat", 1.23f);
+    jsonObject.put("mydouble", 2.34d);
+    jsonObject.put("myboolean", true);
+    byte[] bytes = TestUtils.randomByteArray(10);
+    jsonObject.put("mybinary", bytes);
+    Instant now = Instant.now();
+    jsonObject.put("myinstant", now);
+    jsonObject.putNull("mynull");
+    jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
+    jsonObject.put("myarr", new JsonArray().add("foo").add(123));
+    String strBytes = Base64.getEncoder().encodeToString(bytes);
+
+    Buffer expected = Buffer.buffer("{\"mystr\":\"foo\",\"mycharsequence\":\"oob\",\"myint\":123,\"mylong\":1234,\"myfloat\":1.23,\"mydouble\":2.34,\"" +
+      "myboolean\":true,\"mybinary\":\"" + strBytes + "\",\"myinstant\":\"" + ISO_INSTANT.format(now) + "\",\"mynull\":null,\"myobj\":{\"foo\":\"bar\"},\"myarr\":[\"foo\",123]}", "UTF-8");
+
+    Buffer json = jsonObject.toBuffer();
+    assertArrayEquals(expected.getBytes(), json.getBytes());
+  }
+
+  @Test
   public void testDecode() throws Exception {
     byte[] bytes = TestUtils.randomByteArray(10);
     String strBytes = Base64.getEncoder().encodeToString(bytes);

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -24,10 +24,6 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.StringBufferInputStream;
-import java.io.StringReader;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;

--- a/src/test/java/io/vertx/test/core/JsonObjectTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectTest.java
@@ -24,6 +24,10 @@ import io.vertx.core.json.JsonObject;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringBufferInputStream;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -1507,6 +1511,15 @@ public class JsonObjectTest {
     assertEquals("bar", obj.getString("foo"));
     assertEquals(Integer.valueOf(123), obj.getInteger("quux"));
     assertSame(map, obj.getMap());
+  }
+
+  @Test
+  public void testCreateFromBuffer() {
+    JsonObject excepted = new JsonObject();
+    excepted.put("foo", "bar");
+    excepted.put("quux", 123);
+    Buffer buf = Buffer.buffer(excepted.encode());
+    assertEquals(excepted, new JsonObject(buf));
   }
 
   @Test


### PR DESCRIPTION
Implement a `toBuffer` to all json objects.

This PR extends #1976 and fixes the ip-check that was resolved using the github web interface which does not sign off commits.