### PR TITLE
Parameterized logging is not portable and may not be supported

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -1367,6 +1367,9 @@ logger.info("something happened");
 logger.error("oops!", exception);
 ----
 
+CAUTION: Logging backends use different formats to represent replaceable tokens in parameterized messages.
+As a consequence, if you rely on Vert.x parameterized logging methods, you won't be able to switch backends without changing your code.
+
 [[netty-logging]]
 === Netty logging
 

--- a/src/main/java/io/vertx/core/logging/Logger.java
+++ b/src/main/java/io/vertx/core/logging/Logger.java
@@ -31,6 +31,9 @@ import io.vertx.core.spi.logging.LogDelegate;
  * For Log4J the value is {@code io.vertx.core.logging.Log4jLogDelegateFactory}, for SLF4J the value
  * is {@code io.vertx.core.logging.SLF4JLogDelegateFactory}. You will need to ensure whatever jar files
  * required by your favourite log framework are on your classpath.
+ * <p>
+ * Keep in mind that logging backends use different formats to represent replaceable tokens in parameterized messages.
+ * As a consequence, if you rely on parameterized logging methods, you won't be able to switch backends without changing your code.
  *
  * @author <a href="mailto:tim.fox@jboss.com">Tim Fox</a>
  */
@@ -70,10 +73,16 @@ public class Logger {
     delegate.error(message, t);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void error(final Object message, final Object... objects) {
     delegate.error(message, objects);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void error(final Object message, final Throwable t, final Object... objects) {
     delegate.error(message, t, objects);
   }
@@ -86,10 +95,16 @@ public class Logger {
     delegate.warn(message, t);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void warn(final Object message, final Object... objects) {
     delegate.warn(message, objects);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void warn(final Object message, final Throwable t, final Object... objects) {
     delegate.warn(message, t, objects);
   }
@@ -102,10 +117,16 @@ public class Logger {
     delegate.info(message, t);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void info(final Object message, final Object... objects) {
     delegate.info(message, objects);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void info(final Object message, final Throwable t, final Object... objects) {
     delegate.info(message, t, objects);
   }
@@ -118,10 +139,16 @@ public class Logger {
     delegate.debug(message, t);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void debug(final Object message, final Object... objects) {
     delegate.debug(message, objects);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void debug(final Object message, final Throwable t, final Object... objects) {
     delegate.debug(message, t, objects);
   }
@@ -134,10 +161,16 @@ public class Logger {
     delegate.trace(message, t);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void trace(final Object message, final Object... objects) {
     delegate.trace(message, objects);
   }
 
+  /**
+   * @throws UnsupportedOperationException if the logging backend does not support parameterized messages
+   */
   public void trace(final Object message, final Throwable t, final Object... objects) {
     delegate.trace(message, t, objects);
   }

--- a/src/main/java/io/vertx/core/package-info.java
+++ b/src/main/java/io/vertx/core/package-info.java
@@ -1267,6 +1267,9 @@
  * {@link examples.CoreExamples#example18}
  * ----
  *
+ * CAUTION: Logging backends use different formats to represent replaceable tokens in parameterized messages.
+ * As a consequence, if you rely on Vert.x parameterized logging methods, you won't be able to switch backends without changing your code.
+ *
  * [[netty-logging]]
  * === Netty logging
  *
@@ -1287,33 +1290,33 @@
  * // Force logging to Log4j
  * InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
  * ----
- * 
+ *
  * === Troubleshooting
- * 
+ *
  * ==== SLF4J warning at startup
- * 
+ *
  * If, when you start your application, you see the following message:
- * 
+ *
  * ----
  * SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
  * SLF4J: Defaulting to no-operation (NOP) logger implementation
  * SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
  * ----
- * 
+ *
  * It means that you have SLF4J-API in your classpath but no actual binding. Messages logged with SLF4J will be dropped.
  * You should add a binding to your classpath. Check https://www.slf4j.org/manual.html#swapping to pick a binding and configure it.
- * 
+ *
  * Be aware that Netty looks for the SLF4-API jar and uses it by default.
- * 
+ *
  * ==== Connection reset by peer
- * 
+ *
  * If your logs show a bunch of:
- * 
+ *
  * ----
  * io.vertx.core.net.impl.ConnectionBase
  * SEVERE: java.io.IOException: Connection reset by peer
  * ----
- * 
+ *
  * It means that the client is resetting the HTTP connection instead of closing it. This message also indicates that you
  * may have not consumed the complete payload (the connection was cut before you were able to).
  *


### PR DESCRIPTION
Updated the docs to indicate that parameterized logging:

* is not portable
* may not be supported (log4j backend throws `UnsupportedOperationException`)