### PR TITLE
Correct java generics in CompositeFuture.all

### DIFF
--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -128,7 +128,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static CompositeFuture any(List<Future> futures) {
+  static <X extends Future<?>> CompositeFuture any(List<X> futures) {
     return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
   }
 
@@ -178,7 +178,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static CompositeFuture join(List<Future> futures) {
+  static <X extends Future<?>> CompositeFuture join(List<X> futures) {
     return CompositeFutureImpl.join(futures.toArray(new Future[futures.size()]));
   }
 

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -17,6 +17,8 @@
 package io.vertx.core;
 
 import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.GenTypeParams;
+import io.vertx.codegen.annotations.GenTypeParams.Param;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.impl.CompositeFutureImpl;
 
@@ -78,6 +80,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
+  @GenTypeParams({@Param(name="X",generated=Future.class)})
   static <X extends Future<?>> CompositeFuture all(List<X> futures) {
     return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
   }
@@ -128,6 +131,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
+  @GenTypeParams({@Param(name="X",generated=Future.class)})
   static <X extends Future<?>> CompositeFuture any(List<X> futures) {
     return CompositeFutureImpl.any(futures.toArray(new Future[futures.size()]));
   }
@@ -178,6 +182,7 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
+  @GenTypeParams({@Param(name="X",generated=Future.class)})
   static <X extends Future<?>> CompositeFuture join(List<X> futures) {
     return CompositeFutureImpl.join(futures.toArray(new Future[futures.size()]));
   }

--- a/src/main/java/io/vertx/core/CompositeFuture.java
+++ b/src/main/java/io/vertx/core/CompositeFuture.java
@@ -78,10 +78,10 @@ public interface CompositeFuture extends Future<CompositeFuture> {
    *
    * When the list is empty, the returned future will be already completed.
    */
-  static CompositeFuture all(List<Future> futures) {
+  static <X extends Future<?>> CompositeFuture all(List<X> futures) {
     return CompositeFutureImpl.all(futures.toArray(new Future[futures.size()]));
   }
-
+  
   /**
    * Return a composite future, succeeded when any futures is succeeded, failed when all futures are failed.
    * <p/>

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -15,13 +15,6 @@
  */
 package io.vertx.test.core;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.impl.NoStackTraceThrowable;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,6 +25,14 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import org.junit.Test;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.impl.NoStackTraceThrowable;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -369,6 +370,37 @@ public class FutureTest extends VertxTestBase {
     }
   }
 
+  @Test
+  public void testAllListWithFutureGenerics() {
+    @SuppressWarnings("rawtypes")
+    List<Future> nonGenericFutureList = new ArrayList<>();
+    nonGenericFutureList.add(Future.succeededFuture());
+    nonGenericFutureList.add(Future.succeededFuture(new Object()));
+    nonGenericFutureList.add(Future.succeededFuture(new FutureTest()));
+    CompositeFuture all = CompositeFuture.all(nonGenericFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<Object>> genericObjectFutureList = new ArrayList<>();
+    genericObjectFutureList.add(Future.succeededFuture());
+    genericObjectFutureList.add(Future.succeededFuture(new Object()));
+    genericObjectFutureList.add(Future.succeededFuture(new FutureTest()));
+    all = CompositeFuture.all(genericObjectFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<?>> wildcardFutureList = new ArrayList<>();
+    wildcardFutureList.add(Future.succeededFuture());
+    wildcardFutureList.add(Future.succeededFuture(new Object()));
+    wildcardFutureList.add(Future.succeededFuture(new FutureTest()));
+    all = CompositeFuture.all(wildcardFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<VertxTestBase>> specificFutureList = new ArrayList<>();
+    specificFutureList.add(Future.succeededFuture(new FutureTest()));
+    specificFutureList.add(Future.succeededFuture(new VertxTestBase()));
+    all = CompositeFuture.all(wildcardFutureList);
+    new Checker<>(all).assertSucceeded(all);
+  }
+  
   @Test
   public void testAnySucceeded1() {
     testAnySucceeded1(CompositeFuture::any);

--- a/src/test/java/io/vertx/test/core/FutureTest.java
+++ b/src/test/java/io/vertx/test/core/FutureTest.java
@@ -509,6 +509,37 @@ public class FutureTest extends VertxTestBase {
   }
 
   @Test
+  public void testAnyListWithFutureGenerics() {
+    @SuppressWarnings("rawtypes")
+    List<Future> nonGenericFutureList = new ArrayList<>();
+    nonGenericFutureList.add(Future.failedFuture("failed"));
+    nonGenericFutureList.add(Future.succeededFuture(new Object()));
+    nonGenericFutureList.add(Future.succeededFuture(new FutureTest()));
+    CompositeFuture all = CompositeFuture.any(nonGenericFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<Object>> genericObjectFutureList = new ArrayList<>();
+    genericObjectFutureList.add(Future.failedFuture("failed"));
+    genericObjectFutureList.add(Future.succeededFuture(new Object()));
+    genericObjectFutureList.add(Future.succeededFuture(new FutureTest()));
+    all = CompositeFuture.any(genericObjectFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<?>> wildcardFutureList = new ArrayList<>();
+    wildcardFutureList.add(Future.failedFuture("failed"));
+    wildcardFutureList.add(Future.succeededFuture(new Object()));
+    wildcardFutureList.add(Future.succeededFuture(new FutureTest()));
+    all = CompositeFuture.any(wildcardFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<VertxTestBase>> specificFutureList = new ArrayList<>();
+    specificFutureList.add(Future.failedFuture("failed"));
+    specificFutureList.add(Future.succeededFuture(new VertxTestBase()));
+    all = CompositeFuture.any(wildcardFutureList);
+    new Checker<>(all).assertSucceeded(all);
+  }
+  
+  @Test
   public void testJoinSucceeded() {
     testJoinSucceeded(CompositeFuture::join);
   }
@@ -606,6 +637,37 @@ public class FutureTest extends VertxTestBase {
     assertTrue(composite.isComplete());
   }
 
+  @Test
+  public void testJoinListWithFutureGenerics() {
+    @SuppressWarnings("rawtypes")
+    List<Future> nonGenericFutureList = new ArrayList<>();
+    nonGenericFutureList.add(Future.succeededFuture());
+    nonGenericFutureList.add(Future.succeededFuture(new Object()));
+    nonGenericFutureList.add(Future.succeededFuture(new FutureTest()));
+    CompositeFuture all = CompositeFuture.join(nonGenericFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<Object>> genericObjectFutureList = new ArrayList<>();
+    genericObjectFutureList.add(Future.succeededFuture());
+    genericObjectFutureList.add(Future.succeededFuture(new Object()));
+    genericObjectFutureList.add(Future.succeededFuture(new FutureTest()));
+    all = CompositeFuture.join(genericObjectFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<?>> wildcardFutureList = new ArrayList<>();
+    wildcardFutureList.add(Future.succeededFuture());
+    wildcardFutureList.add(Future.succeededFuture(new Object()));
+    wildcardFutureList.add(Future.succeededFuture(new FutureTest()));
+    all = CompositeFuture.join(wildcardFutureList);
+    new Checker<>(all).assertSucceeded(all);
+    
+    List<Future<VertxTestBase>> specificFutureList = new ArrayList<>();
+    specificFutureList.add(Future.succeededFuture(new FutureTest()));
+    specificFutureList.add(Future.succeededFuture(new VertxTestBase()));
+    all = CompositeFuture.join(wildcardFutureList);
+    new Checker<>(all).assertSucceeded(all);
+  }
+  
   @Test
   public void testCompositeFutureToList() {
     Future<String> f1 = Future.future();


### PR DESCRIPTION
Method CompositeFuture.all accept List<Future>. Future is a raw type. References to generic type Future<T> should be parameterized. 

We can't currently call this method with any generic list without specific cast, or we are forced to use non generic list. It's ugly, produce warnings in every popular IDE, produce bugs in the final, so please merge this non breaking change.