### PR TITLE
Fix all places where stackTrace was discarded

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -158,7 +158,7 @@ public class ClusteredEventBus extends EventBusImpl {
             if (resultHandler != null) {
               resultHandler.handle(Future.failedFuture(asyncResult.cause()));
             } else {
-              log.error(asyncResult.cause());
+              log.error("Cannot start ClusteredEventBus", asyncResult.cause());
             }
           }
         });
@@ -166,7 +166,7 @@ public class ClusteredEventBus extends EventBusImpl {
         if (resultHandler != null) {
           resultHandler.handle(Future.failedFuture(ar2.cause()));
         } else {
-          log.error(ar2.cause());
+          log.error("Cannot start ClusteredEventBus", ar2.cause());
         }
       }
     });

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -135,7 +135,7 @@ abstract class HttpClientRequestBase implements HttpClientRequest {
       if (exceptionHandler != null) {
         exceptionHandler.handle(t);
       } else {
-        log.error(t);
+        log.error("Error in http request "+getClass().getName(), t);
       }
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -301,7 +301,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             vertx.runOnContext(v -> listenHandler.handle(Future.failedFuture(t)));
           } else {
             // No handler - log so user can see failure
-            log.error(t);
+            log.error("Error listen", t);
           }
           listening = false;
           return this;
@@ -328,7 +328,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
         } else if (future.failed()) {
           listening  = false;
           // No handler - log so user can see failure
-          log.error(future.cause());
+          log.error("Error listen", future.cause());
         }
       });
     }

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -184,7 +184,7 @@ public abstract class ConnectionBase {
     if (exceptionHandler != null) {
       exceptionHandler.handle(t);
     } else {
-      log.error(t);
+      log.error("Error in connection "+getClass().getName(), t);
     }
   }
 

--- a/src/main/java/io/vertx/core/net/impl/NetServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerBase.java
@@ -173,7 +173,7 @@ public abstract class NetServerBase<C extends ConnectionBase> implements Closeab
             vertx.runOnContext(v ->  listenHandler.handle(Future.failedFuture(t)));
           } else {
             // No handler - log so user can see failure
-            log.error(t);
+            log.error("Error in "+getClass().getName(), t);
           }
           listening = false;
           return;

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -277,7 +277,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
       if (future.isSuccess()) {
         handler.handle(null);
       } else {
-        log.error(future.cause());
+        log.error("SSL handshake failure", future.cause());
       }
     }));
     return this;


### PR DESCRIPTION
log exception using correct method, no e.tostring as when you pass it to message, so user can see failure (for example having only exception message without original trace for npe, like i see in logs of our application when some developer made mistake, is very annoying)