### PR TITLE
Handle message that's throwable

### DIFF
--- a/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
+++ b/src/main/java/io/vertx/core/logging/SLF4JLogDelegate.java
@@ -145,7 +145,13 @@ public class SLF4JLogDelegate implements LogDelegate {
   }
 
   private void log(int level, Object message) {
-    log(level, message, null);
+    if (message instanceof Throwable) {
+      // We often send a throwable inside the message and
+      // therefore we will lack the stacktrace in the rendered log entry
+      log(level, "", (Throwable) message);
+    } else {
+      log(level, message, null);
+    }
   }
 
   private void log(int level, Object message, Throwable t) {


### PR DESCRIPTION
If a throwable is passed as message with throwable param explicitly
set to `null` (the current behavior), effectively only t.getMessage() is
printed when message.toString() is called. Let's pass the message in
place of throwable if the message object is throwable.