### PR TITLE
Perf improvements

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -8,6 +8,9 @@ The benchmarks configures a JMH executor that uses `VertxThread`.
 
 Benchmarks are located in the `src/test/benchmarks` folder.
 
+Note that these benchmarks have been added to quickly see the impact of changes but do not replace real benchmarking
+done in a lab.
+
 ### How-to
 
 Package the JMH microbenchmarks

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -1,0 +1,47 @@
+## Microbenchmarks
+
+A few JMH benchmarks are available to measure performance of some Vert.x sensistive parts.
+
+The benchmarks are executed with biased locking enabled.
+
+The benchmarks configures a JMH executor that uses `VertxThread`.
+
+Benchmarks are located in the `src/test/benchmarks` folder.
+
+### How-to
+
+Package the JMH microbenchmarks
+
+```
+> mvn package -DskipTests -Pbenchmarks
+```
+
+Run them all
+
+```
+> java -jar target/vertx-core-$VERSION-benchmarks.jar
+```
+
+### HttpHeaders benchmarks
+
+- `HeadersEncodeBenchmark`: encode HttpHeaders
+- `HeadersContainsBenchmarkv: HttpHeaders contains method
+- `HeadersSetBenchmark`: HttpHeaders set method
+
+```
+> java -jar target/vertx-core-$VERSION-benchmarks.jar HeadersEncodeBenchmark
+```
+
+### HttpServer handler benchmarks
+
+The `HttpServerHandlerBenchmark` benchmarks the `HttpServer` that deals with `HttpRequest` and `HttpResponse`
+ objects. It mainly compares a simple  _hello world_ application written with Vert.x and Netty.
+
+```
+> java -jar target/vertx-core-$VERSION-benchmarks.jar HttpServerHandlerBenchmark
+```
+
+### Context benchmarks
+
+The `RunOnContextBenchmark` measures the impact of the disabling thread checks, context timing that are done
+when running Vert.x context tasks.

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <stack.version>3.5.0-SNAPSHOT</stack.version>
     <jetty.alpnAgent.version>2.0.6</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
+    <jmh.version>1.17.3</jmh.version>
 
   </properties>
 
@@ -167,6 +168,7 @@
       <artifactId>vertx-docgen</artifactId>
       <optional>true</optional>
     </dependency>
+
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -202,6 +204,14 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>${tcnative.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- JMH -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -310,7 +320,6 @@
             <configuration>
               <processors>
                 <processor>io.vertx.codegen.CodeGenProcessor</processor>
-                <processor>io.vertx.docgen.JavaDocGenProcessor</processor>
               </processors>
               <optionMap>
                 <codegen.output>${project.basedir}/src/main</codegen.output>
@@ -365,6 +374,7 @@
             </goals>
             <configuration>
               <sources>
+                <source>${project.basedir}/src/test/benchmarks</source>
                 <source>${project.basedir}/src/test/generated</source>
               </sources>
             </configuration>
@@ -686,6 +696,44 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>benchmarks</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>assemble-docs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <configuration>
+                  <archive>
+                    <manifest>
+                      <mainClass>org.openjdk.jmh.Main</mainClass>
+                    </manifest>
+                  </archive>
+                  <descriptors>
+                    <descriptor>src/test/assembly/benchmarks.xml</descriptor>
+                  </descriptors>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-generator-annprocess</artifactId>
+          <version>${jmh.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <stack.version>3.5.0-SNAPSHOT</stack.version>
     <jetty.alpnAgent.version>2.0.6</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
-    <jmh.version>1.17.3</jmh.version>
+    <jmh.version>1.19</jmh.version>
 
   </properties>
 

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramChannelFutureListener.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramChannelFutureListener.java
@@ -38,7 +38,10 @@ final class DatagramChannelFutureListener<T> implements ChannelFutureListener {
 
   @Override
   public void operationComplete(final ChannelFuture future) throws Exception {
-    context.executeFromIO(() -> notifyHandler(future));
+
+    context.executeFromIO(() ->
+        notifyHandler(future));
+
   }
 
   private void notifyHandler(ChannelFuture future) {

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
@@ -51,12 +51,12 @@ final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl.Connec
   }
 
   @Override
-  protected void channelRead(final DatagramSocketImpl.Connection server, final ContextImpl context, ChannelHandlerContext chctx, final Object msg) throws Exception {
-    context.executeFromIO(() -> server.handlePacket((io.vertx.core.datagram.DatagramPacket) msg));
+  protected void handleMessage(final DatagramSocketImpl.Connection server, final ContextImpl context, ChannelHandlerContext chctx, final Object msg) throws Exception {
+    server.handlePacket((io.vertx.core.datagram.DatagramPacket) msg);
   }
 
   @Override
-  protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+  protected Object decode(Object msg, ByteBufAllocator allocator) throws Exception {
     if (msg instanceof DatagramPacket) {
       DatagramPacket packet = (DatagramPacket) msg;
       ByteBuf content = packet.content();

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
@@ -40,10 +40,6 @@ final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl.Connec
   }
 
   @Override
-  protected void removeConnection() {
-  }
-
-  @Override
   protected void handleMessage(final DatagramSocketImpl.Connection server, final ContextImpl context, ChannelHandlerContext chctx, final Object msg) throws Exception {
     server.handlePacket((io.vertx.core.datagram.DatagramPacket) msg);
   }

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
@@ -29,7 +29,6 @@ import io.vertx.core.net.impl.VertxHandler;
 final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl.Connection> {
 
   private final DatagramSocketImpl socket;
-  private DatagramSocketImpl.Connection conn;
 
   DatagramServerHandler(DatagramSocketImpl socket) {
     this.socket = socket;
@@ -37,17 +36,11 @@ final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl.Connec
 
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-    conn = socket.createConnection(ctx);
+    setConnection(socket.createConnection(ctx));
   }
 
   @Override
-  protected DatagramSocketImpl.Connection getConnection() {
-    return conn;
-  }
-
-  @Override
-  protected DatagramSocketImpl.Connection removeConnection() {
-    return conn;
+  protected void removeConnection() {
   }
 
   @Override

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
@@ -26,28 +26,32 @@ import io.vertx.core.net.impl.VertxHandler;
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl> {
+final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl.Connection> {
 
   private final DatagramSocketImpl socket;
+  private DatagramSocketImpl.Connection conn;
 
   DatagramServerHandler(DatagramSocketImpl socket) {
     this.socket = socket;
   }
 
   @Override
-  protected DatagramSocketImpl getConnection() {
-    return socket;
+  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    conn = socket.createConnection();
   }
 
   @Override
-  protected DatagramSocketImpl removeConnection() {
-    return socket;
+  protected DatagramSocketImpl.Connection getConnection() {
+    return conn;
   }
 
-
-  @SuppressWarnings("unchecked")
   @Override
-  protected void channelRead(final DatagramSocketImpl server, final ContextImpl context, ChannelHandlerContext chctx, final Object msg) throws Exception {
+  protected DatagramSocketImpl.Connection removeConnection() {
+    return conn;
+  }
+
+  @Override
+  protected void channelRead(final DatagramSocketImpl.Connection server, final ContextImpl context, ChannelHandlerContext chctx, final Object msg) throws Exception {
     context.executeFromIO(() -> server.handlePacket((io.vertx.core.datagram.DatagramPacket) msg));
   }
 

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramServerHandler.java
@@ -37,7 +37,7 @@ final class DatagramServerHandler extends VertxHandler<DatagramSocketImpl.Connec
 
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-    conn = socket.createConnection();
+    conn = socket.createConnection(ctx);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -17,6 +17,7 @@ package io.vertx.core.datagram.impl;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.socket.DatagramChannel;
@@ -369,13 +370,13 @@ public class DatagramSocketImpl implements DatagramSocket, MetricsProvider {
     super.finalize();
   }
 
-  Connection createConnection() {
-    return new Connection(context.owner(), channel, context);
+  Connection createConnection(ChannelHandlerContext chctx) {
+    return new Connection(context.owner(), chctx, context);
   }
 
   class Connection extends ConnectionBase {
 
-    public Connection(VertxInternal vertx, Channel channel, ContextImpl context) {
+    public Connection(VertxInternal vertx, ChannelHandlerContext channel, ContextImpl context) {
       super(vertx, channel, context);
     }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -37,6 +37,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.spi.metrics.EventBusMetrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
+import io.vertx.core.spi.metrics.VertxMetrics;
 
 import java.util.Iterator;
 import java.util.List;
@@ -64,8 +65,9 @@ public class EventBusImpl implements EventBus, MetricsProvider {
   protected volatile boolean started;
 
   public EventBusImpl(VertxInternal vertx) {
+    VertxMetrics metrics = vertx.metricsSPI();
     this.vertx = vertx;
-    this.metrics = vertx.metricsSPI().createMetrics(this);
+    this.metrics = metrics != null ? metrics.createMetrics(this) : null;
   }
 
   @Override
@@ -214,7 +216,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
 
   @Override
   public boolean isMetricsEnabled() {
-    return metrics != null && metrics.isEnabled();
+    return metrics != null;
   }
 
   @Override
@@ -330,7 +332,9 @@ public class EventBusImpl implements EventBus, MetricsProvider {
 
   protected <T> void sendOrPub(SendContextImpl<T> sendContext) {
     MessageImpl message = sendContext.message;
-    metrics.messageSent(message.address(), !message.isSend(), true, false);
+    if (metrics != null) {
+      metrics.messageSent(message.address(), !message.isSend(), true, false);
+    }
     deliverMessageLocally(sendContext);
   }
 
@@ -340,7 +344,9 @@ public class EventBusImpl implements EventBus, MetricsProvider {
       if (reply.body() instanceof ReplyException) {
         // This is kind of clunky - but hey-ho
         ReplyException exception = (ReplyException) reply.body();
-        metrics.replyFailure(reply.address(), exception.failureType());
+        if (metrics != null) {
+          metrics.replyFailure(reply.address(), exception.failureType());
+        }
         result = Future.failedFuture(exception);
       } else {
         result = Future.succeededFuture(reply);
@@ -360,7 +366,9 @@ public class EventBusImpl implements EventBus, MetricsProvider {
   protected <T> void deliverMessageLocally(SendContextImpl<T> sendContext) {
     if (!deliverMessageLocally(sendContext.message)) {
       // no handlers
-      metrics.replyFailure(sendContext.message.address, ReplyFailure.NO_HANDLERS);
+      if (metrics != null) {
+        metrics.replyFailure(sendContext.message.address, ReplyFailure.NO_HANDLERS);
+      }
       if (sendContext.handlerRegistration != null) {
         sendContext.handlerRegistration.sendAsyncResultFailure(ReplyFailure.NO_HANDLERS, "No handlers for address "
                                                                + sendContext.message.address);
@@ -379,20 +387,26 @@ public class EventBusImpl implements EventBus, MetricsProvider {
       if (msg.isSend()) {
         //Choose one
         HandlerHolder holder = handlers.choose();
-        metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), holder != null ? 1 : 0);
+        if (metrics != null) {
+          metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), holder != null ? 1 : 0);
+        }
         if (holder != null) {
           deliverToHandler(msg, holder);
         }
       } else {
         // Publish
-        metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), handlers.list.size());
+        if (metrics != null) {
+          metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), handlers.list.size());
+        }
         for (HandlerHolder holder: handlers.list) {
           deliverToHandler(msg, holder);
         }
       }
       return true;
     } else {
-      metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), 0);
+      if (metrics != null) {
+        metrics.messageReceived(msg.address(), !msg.isSend(), isMessageLocal(msg), 0);
+      }
       return false;
     }
   }
@@ -512,7 +526,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     @SuppressWarnings("unchecked")
     Message<T> copied = msg.copyBeforeReceive();
 
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       metrics.scheduleMessage(holder.getHandler().getMetric(), msg.isLocal());
     }
 

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerHolder.java
@@ -33,7 +33,7 @@ public class HandlerHolder<T> {
         unregisterMetric = true;
       }
     }
-    if (unregisterMetric) {
+    if (metrics != null && unregisterMetric) {
       metrics.handlerUnregistered(handler.getMetric());
     }
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -244,7 +244,9 @@ public class ClusteredEventBus extends EventBusImpl {
         if (serverIDs != null && !serverIDs.isEmpty()) {
           sendToSubs(serverIDs, sendContext);
         } else {
-          metrics.messageSent(address, !sendContext.message.isSend(), true, false);
+          if (metrics != null) {
+            metrics.messageSent(address, !sendContext.message.isSend(), true, false);
+          }
           deliverMessageLocally(sendContext);
         }
       } else {
@@ -323,7 +325,9 @@ public class ClusteredEventBus extends EventBusImpl {
           } else {
             ClusteredMessage received = new ClusteredMessage();
             received.readFromWire(buff, codecManager);
-            metrics.messageRead(received.address(), buff.length());
+            if (metrics != null) {
+              metrics.messageRead(received.address(), buff.length());
+            }
             parser.fixedSizeMode(4);
             size = -1;
             if (received.codec() == CodecManager.PING_MESSAGE_CODEC) {
@@ -347,10 +351,14 @@ public class ClusteredEventBus extends EventBusImpl {
       ClusterNodeInfo ci = subs.choose();
       ServerID sid = ci == null ? null : ci.serverID;
       if (sid != null && !sid.equals(serverID)) {  //We don't send to this node
-        metrics.messageSent(address, false, false, true);
+        if (metrics != null) {
+          metrics.messageSent(address, false, false, true);
+        }
         sendRemote(sid, sendContext.message);
       } else {
-        metrics.messageSent(address, false, true, false);
+        if (metrics != null) {
+          metrics.messageSent(address, false, true, false);
+        }
         deliverMessageLocally(sendContext);
       }
     } else {
@@ -365,7 +373,9 @@ public class ClusteredEventBus extends EventBusImpl {
           local = true;
         }
       }
-      metrics.messageSent(address, true, local, remote);
+      if (metrics != null) {
+        metrics.messageSent(address, true, local, remote);
+      }
       if (local) {
         deliverMessageLocally(sendContext);
       }
@@ -376,10 +386,14 @@ public class ClusteredEventBus extends EventBusImpl {
     MessageImpl message = sendContext.message;
     String address = message.address();
     if (!replyDest.equals(serverID)) {
-      metrics.messageSent(address, false, false, true);
+      if (metrics != null) {
+        metrics.messageSent(address, false, false, true);
+      }
       sendRemote(replyDest, message);
     } else {
-      metrics.messageSent(address, false, true, false);
+      if (metrics != null) {
+        metrics.messageSent(address, false, true, false);
+      }
       deliverMessageLocally(sendContext);
     }
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ConnectionHolder.java
@@ -66,7 +66,9 @@ class ConnectionHolder {
   synchronized void writeMessage(ClusteredMessage message) {
     if (connected) {
       Buffer data = message.encodeToWire();
-      metrics.messageWritten(message.address(), data.length());
+      if (metrics != null) {
+        metrics.messageWritten(message.address(), data.length());
+      }
       socket.write(data);
     } else {
       if (pending == null) {
@@ -124,7 +126,9 @@ class ConnectionHolder {
     schedulePing();
     for (ClusteredMessage message : pending) {
       Buffer data = message.encodeToWire();
-      metrics.messageWritten(message.address(), data.length());
+      if (metrics != null) {
+        metrics.messageWritten(message.address(), data.length());
+      }
       socket.write(data);
     }
     pending.clear();

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -90,7 +90,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
   private boolean paused;
   private Buffer pausedChunk;
 
-  ClientConnection(HttpVersion version, HttpClientImpl client, Object endpointMetric, Channel channel, boolean ssl, String host,
+  ClientConnection(HttpVersion version, HttpClientImpl client, Object endpointMetric, ChannelHandlerContext channel, boolean ssl, String host,
                    int port, ContextImpl context, Http1xPool pool, HttpClientMetrics metrics) {
     super(client.getVertx(), channel, context);
     this.client = client;
@@ -577,7 +577,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
 
   public NetSocket createNetSocket() {
     // connection was upgraded to raw TCP socket
-    NetSocketImpl socket = new NetSocketImpl(vertx, channel, context, client.getSslHelper(), metrics);
+    NetSocketImpl socket = new NetSocketImpl(vertx, chctx, context, client.getSslHelper(), metrics);
     socket.metric(metric());
     Map<Channel, NetSocketImpl> connectionMap = new HashMap<>(1);
     connectionMap.put(channel, socket);

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -22,8 +22,6 @@ import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.websocketx.*;
 import io.netty.util.ReferenceCountUtil;
-import io.vertx.codegen.annotations.Nullable;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.VertxException;
@@ -36,7 +34,6 @@ import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.NetSocketImpl;
 import io.vertx.core.net.impl.VertxNetHandler;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
@@ -252,10 +249,6 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
         wsConnect.handle(webSocket);
       });
     }
-  }
-
-  public ClientConnection closeHandler(Handler<Void> handler) {
-    return (ClientConnection) super.closeHandler(handler);
   }
 
   public boolean isValid() {
@@ -643,72 +636,5 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
   @Override
   public int id() {
     return -1;
-  }
-
-  //
-
-  @Override
-  public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection goAwayHandler(@Nullable Handler<GoAway> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection shutdown() {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection shutdown(long timeoutMs) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public Http2Settings settings() {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection updateSettings(Http2Settings settings) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection updateSettings(Http2Settings settings, Handler<AsyncResult<Void>> completionHandler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public Http2Settings remoteSettings() {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection ping(Buffer data, Handler<AsyncResult<Buffer>> pongHandler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
-  }
-
-  @Override
-  public HttpConnection pingHandler(@Nullable Handler<Buffer> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
-  }
-
-  @Override
-  public ClientConnection exceptionHandler(Handler<Throwable> handler) {
-    return (ClientConnection) super.exceptionHandler(handler);
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -613,9 +613,9 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
       }
 
       @Override
-      protected void handleMsgReceived(NetSocketImpl conn, Object msg) {
+      protected void handleMessage(NetSocketImpl connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
         ByteBuf buf = (ByteBuf) msg;
-        conn.handleDataReceived(Buffer.buffer(buf));
+        connection.handleDataReceived(Buffer.buffer(buf));
       }
     });
     return socket;

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -246,7 +246,9 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
       handshaker.finishHandshake(channel, response);
       context.executeFromIO(() -> {
         log.debug("WebSocket handshake complete");
-        webSocket.setMetric(metrics().connected(endpointMetric, metric(), webSocket));
+        if (metrics != null ) {
+          webSocket.setMetric(metrics.connected(endpointMetric, metric(), webSocket));
+        }
         wsConnect.handle(webSocket);
       });
     }
@@ -301,7 +303,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
     }
     HttpClientResponseImpl nResp = new HttpClientResponseImpl(requestForResponse, vertxVersion, this, resp.status().code(), resp.status().reasonPhrase(), new HeadersAdaptor(resp.headers()));
     currentResponse = nResp;
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       metrics.responseBegin(requestForResponse.metric(), nResp);
     }
     if (vertxVersion != null) {
@@ -347,7 +349,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
   }
 
   void handleResponseEnd(LastHttpContent trailer) {
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       HttpClientRequestBase req = currentResponse.request();
       Object reqMetric = req.metric();
       if (req.exceptionOccurred != null) {
@@ -408,7 +410,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
     Exception e = new VertxException("Connection was closed");
 
     // Signal requests failed
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       for (HttpClientRequestImpl req: requests) {
         metrics.requestReset(req.metric());
       }
@@ -542,8 +544,8 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
     if (currentRequest != null) {
       throw new IllegalStateException("Connection is already writing a request");
     }
-    if (metrics.isEnabled()) {
-      Object reqMetric = client.httpClientMetrics().requestBegin(endpointMetric, metric(), localAddress(), remoteAddress(), req);
+    if (metrics != null) {
+      Object reqMetric = metrics.requestBegin(endpointMetric, metric(), localAddress(), remoteAddress(), req);
       req.metric(reqMetric);
     }
     this.currentRequest = req;
@@ -554,7 +556,7 @@ class ClientConnection extends ConnectionBase implements HttpClientConnection, H
     if (currentRequest == null) {
       throw new IllegalStateException("No write in progress");
     }
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       metrics.requestEnd(currentRequest.metric());
     }
     currentRequest = null;

--- a/src/main/java/io/vertx/core/http/impl/ClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientHandler.java
@@ -84,7 +84,7 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
   }
 
   @Override
-  protected void doMessageReceived(ClientConnection conn, ChannelHandlerContext ctx, Object msg) {
+  protected void handleMessage(ClientConnection connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
     if (conn == null) {
       return;
     }
@@ -124,7 +124,7 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
           break;
         case PING:
           // Echo back the content of the PING frame as PONG frame as specified in RFC 6455 Section 5.5.2
-          ctx.writeAndFlush(new WebSocketFrameImpl(FrameType.PONG, frame.getBinaryData()));
+          chctx.writeAndFlush(new WebSocketFrameImpl(FrameType.PONG, frame.getBinaryData()));
           break;
         case PONG:
           // Just ignore it
@@ -133,7 +133,7 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
           if (!closeFrameSent) {
             // Echo back close frame and close the connection once it was written.
             // This is specified in the WebSockets RFC 6455 Section  5.4.1
-            ctx.writeAndFlush(frame).addListener(ChannelFutureListener.CLOSE);
+            chctx.writeAndFlush(frame).addListener(ChannelFutureListener.CLOSE);
             closeFrameSent = true;
           }
           break;

--- a/src/main/java/io/vertx/core/http/impl/ClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientHandler.java
@@ -47,12 +47,11 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
 
   public ClientHandler(Channel ch,
                        ContextImpl context,
-                       Map<Channel, ClientConnection> connectionMap,
                        Http1xPool pool,
                        HttpClientImpl client,
                        Object endpointMetric,
                        HttpClientMetrics metrics) {
-    super(connectionMap, ch);
+    super(ch);
     this.context = context;
     this.pool = pool;
     this.client = client;

--- a/src/main/java/io/vertx/core/http/impl/ClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientHandler.java
@@ -63,8 +63,9 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     chctx = ctx;
-    conn = new ClientConnection(pool.version(), client, endpointMetric, ctx,
+    ClientConnection conn = new ClientConnection(pool.version(), client, endpointMetric, ctx,
       pool.ssl(), pool.host(), pool.port(), context, pool, metrics);
+    setConnection(conn);
     if (metrics != null) {
       context.executeFromIO(() -> {
         Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
@@ -84,10 +85,7 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
   }
 
   @Override
-  protected void handleMessage(ClientConnection connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
-    if (conn == null) {
-      return;
-    }
+  protected void handleMessage(ClientConnection conn, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
     if (msg instanceof HttpObject) {
       HttpObject obj = (HttpObject) msg;
       DecoderResult result = obj.decoderResult();

--- a/src/main/java/io/vertx/core/http/impl/ClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientHandler.java
@@ -16,7 +16,6 @@
 
 package io.vertx.core.http.impl;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderResult;
@@ -29,8 +28,6 @@ import io.vertx.core.http.impl.ws.WebSocketFrameImpl;
 import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
-
-import java.util.Map;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -45,13 +42,11 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
   private Object endpointMetric;
   private HttpClientMetrics metrics;
 
-  public ClientHandler(Channel ch,
-                       ContextImpl context,
+  public ClientHandler(ContextImpl context,
                        Http1xPool pool,
                        HttpClientImpl client,
                        Object endpointMetric,
                        HttpClientMetrics metrics) {
-    super(ch);
     this.context = context;
     this.pool = pool;
     this.client = client;

--- a/src/main/java/io/vertx/core/http/impl/ClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientHandler.java
@@ -39,10 +39,20 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
 
   private boolean closeFrameSent;
   private ContextImpl context;
+  private ChannelHandlerContext chctx;
 
   public ClientHandler(Channel ch, ContextImpl context, Map<Channel, ClientConnection> connectionMap) {
     super(connectionMap, ch);
     this.context = context;
+  }
+
+  @Override
+  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    chctx = ctx;
+  }
+
+  public ChannelHandlerContext context() {
+    return chctx;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientHandler.java
@@ -80,11 +80,6 @@ class ClientHandler extends VertxHttpHandler<ClientConnection> {
   }
 
   @Override
-  protected ContextImpl getContext(ClientConnection connection) {
-    return context;
-  }
-
-  @Override
   protected void handleMessage(ClientConnection conn, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
     if (msg instanceof HttpObject) {
       HttpObject obj = (HttpObject) msg;

--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -181,7 +181,9 @@ public class ConnectionManager {
   public void close() {
     wsQM.close();
     requestQM.close();
-    metrics.close();
+    if (metrics != null) {
+      metrics.close();
+    }
   }
 
   /**
@@ -217,12 +219,12 @@ public class ConnectionManager {
       this.mgr = mgr;
       if (version == HttpVersion.HTTP_2) {
         maxSize = options.getHttp2MaxPoolSize();
-        pool =  (Pool)new Http2Pool(this, client, ConnectionManager.this.metrics, mgr.connectionMap, http2MaxConcurrency, logEnabled, options.getHttp2MaxPoolSize(), options.getHttp2ConnectionWindowSize());
+        pool =  (Pool)new Http2Pool(this, client, metrics, mgr.connectionMap, http2MaxConcurrency, logEnabled, options.getHttp2MaxPoolSize(), options.getHttp2ConnectionWindowSize());
       } else {
         maxSize = options.getMaxPoolSize();
-        pool = (Pool)new Http1xPool(client, ConnectionManager.this.metrics, options, this, mgr.connectionMap, version, options.getMaxPoolSize());
+        pool = (Pool)new Http1xPool(client, metrics, options, this, mgr.connectionMap, version, options.getMaxPoolSize());
       }
-      this.metric = ConnectionManager.this.metrics.createEndpoint(host, port, maxSize);
+      this.metric = metrics != null ? metrics.createEndpoint(host, port, maxSize) : null;
     }
 
     public synchronized void getConnection(Waiter waiter) {
@@ -242,8 +244,8 @@ public class ConnectionManager {
         } else {
           // Wait in queue
           if (maxWaitQueueSize < 0 || waiters.size() < maxWaitQueueSize) {
-            if (ConnectionManager.this.metrics.isEnabled()) {
-              waiter.metric = ConnectionManager.this.metrics.enqueueRequest(metric);
+            if (metrics != null) {
+              waiter.metric = metrics.enqueueRequest(metric);
             }
             waiters.add(waiter);
           } else {
@@ -303,13 +305,13 @@ public class ConnectionManager {
      */
     Waiter getNextWaiter() {
       Waiter waiter = waiters.poll();
-      if (waiter != null && ConnectionManager.this.metrics.isEnabled()) {
-        ConnectionManager.this.metrics.dequeueRequest(metric, waiter.metric);
+      if (metrics != null && waiter != null) {
+        metrics.dequeueRequest(metric, waiter.metric);
       }
       while (waiter != null && waiter.isCancelled()) {
         waiter = waiters.poll();
-        if (waiter != null && ConnectionManager.this.metrics.isEnabled()) {
-          ConnectionManager.this.metrics.dequeueRequest(metric, waiter.metric);
+        if (metrics != null && waiter != null) {
+          metrics.dequeueRequest(metric, waiter.metric);
         }
       }
       return waiter;
@@ -325,8 +327,8 @@ public class ConnectionManager {
       } else if (connCount == 0) {
         // No waiters and no connections - remove the ConnQueue
         mgr.queueMap.remove(key);
-        if (ConnectionManager.this.metrics.isEnabled()) {
-          ConnectionManager.this.metrics.closeEndpoint(host, port, metric);
+        if (metrics != null) {
+          metrics.closeEndpoint(host, port, metric);
         }
       }
     }

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -24,6 +24,13 @@ import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.GoAway;
+import io.vertx.core.http.Http2Settings;
+import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
@@ -34,7 +41,7 @@ import static io.vertx.core.http.impl.Http2ConnectionBase.safeBuffer;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-abstract class Http1xConnectionBase extends ConnectionBase {
+abstract class Http1xConnectionBase extends ConnectionBase implements io.vertx.core.http.HttpConnection {
 
   Http1xConnectionBase(VertxInternal vertx, ChannelHandlerContext chctx, ContextImpl context) {
     super(vertx, chctx, context);
@@ -72,5 +79,75 @@ abstract class Http1xConnectionBase extends ConnectionBase {
       }
     }
     return super.encode(obj);
+  }
+
+  @Override
+  public Http1xConnectionBase closeHandler(Handler<Void> handler) {
+    return (Http1xConnectionBase) super.closeHandler(handler);
+  }
+
+  @Override
+  public Http1xConnectionBase exceptionHandler(Handler<Throwable> handler) {
+    return (Http1xConnectionBase) super.exceptionHandler(handler);
+  }
+
+  @Override
+  public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection goAwayHandler(@Nullable Handler<GoAway> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection shutdown() {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public HttpConnection shutdown(long timeoutMs) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
+  }
+
+  @Override
+  public Http2Settings settings() {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection updateSettings(Http2Settings settings) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection updateSettings(Http2Settings settings, Handler<AsyncResult<Void>> completionHandler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public Http2Settings remoteSettings() {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
+  }
+
+  @Override
+  public HttpConnection ping(Buffer data, Handler<AsyncResult<Buffer>> pongHandler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
+  }
+
+  @Override
+  public HttpConnection pingHandler(@Nullable Handler<Buffer> handler) {
+    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xConnectionBase.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
+import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.impl.ConnectionBase;
+
+import static io.vertx.core.http.impl.Http2ConnectionBase.safeBuffer;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+abstract class Http1xConnectionBase extends ConnectionBase {
+
+  Http1xConnectionBase(VertxInternal vertx, ChannelHandlerContext chctx, ContextImpl context) {
+    super(vertx, chctx, context);
+  }
+
+  @Override
+  protected Object encode(Object obj) {
+    if (obj instanceof WebSocketFrameInternal) {
+      WebSocketFrameInternal frame = (WebSocketFrameInternal) obj;
+      ByteBuf buf = frame.getBinaryData();
+      if (buf != Unpooled.EMPTY_BUFFER) {
+        buf = safeBuffer(buf, chctx.alloc());
+      }
+      switch (frame.type()) {
+        case BINARY:
+          obj = new BinaryWebSocketFrame(frame.isFinal(), 0, buf);
+          break;
+        case TEXT:
+          obj = new TextWebSocketFrame(frame.isFinal(), 0, buf);
+          break;
+        case CLOSE:
+          obj = new CloseWebSocketFrame(true, 0, buf);
+          break;
+        case CONTINUATION:
+          obj = new ContinuationWebSocketFrame(frame.isFinal(), 0, buf);
+          break;
+        case PONG:
+          obj = new PongWebSocketFrame(buf);
+          break;
+        case PING:
+          obj = new PingWebSocketFrame(buf);
+          break;
+        default:
+          throw new IllegalStateException("Unsupported websocket msg " + obj);
+      }
+    }
+    return super.encode(obj);
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -141,7 +141,6 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
 
   void createConn(HttpVersion version, ContextImpl context, int port, String host, Channel ch, Waiter waiter) {
     ClientHandler handler = new ClientHandler(
-      ch,
       context,
       this,
       client,

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -168,6 +168,7 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
   // gets the closed on, they will check if it's closed and if so get another one.
   private synchronized void connectionClosed(ClientConnection conn) {
     synchronized (queue) {
+      connectionMap.remove(conn.channel());
       allConnections.remove(conn);
       availableConnections.remove(conn);
       queue.connectionClosed();

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -117,14 +117,15 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
   }
 
   void createConn(HttpVersion version, ContextImpl context, int port, String host, Channel ch, Waiter waiter) {
-    ClientConnection conn = new ClientConnection(version, client, queue.metric, ch,
+    // Ugly : improve this
+    ClientHandler handler = ch.pipeline().get(ClientHandler.class);
+    ClientConnection conn = new ClientConnection(version, client, queue.metric, handler.context(),
         ssl, host, port, context, this, metrics);
     if (metrics != null) {
       Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
       conn.metric(metric);
       metrics.endpointConnected(queue.metric, metric);
     }
-    ClientHandler handler = ch.pipeline().get(ClientHandler.class);
     handler.conn = conn;
     synchronized (queue) {
       allConnections.add(conn);

--- a/src/main/java/io/vertx/core/http/impl/Http1xPool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xPool.java
@@ -119,9 +119,11 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
   void createConn(HttpVersion version, ContextImpl context, int port, String host, Channel ch, Waiter waiter) {
     ClientConnection conn = new ClientConnection(version, client, queue.metric, ch,
         ssl, host, port, context, this, metrics);
-    Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
-    conn.metric(metric);
-    metrics.endpointConnected(queue.metric, metric);
+    if (metrics != null) {
+      Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
+      conn.metric(metric);
+      metrics.endpointConnected(queue.metric, metric);
+    }
     ClientHandler handler = ch.pipeline().get(ClientHandler.class);
     handler.conn = conn;
     synchronized (queue) {
@@ -140,7 +142,9 @@ public class Http1xPool implements ConnectionManager.Pool<ClientConnection> {
       availableConnections.remove(conn);
       queue.connectionClosed();
     }
-    metrics.endpointDisconnected(queue.metric, conn.metric());
+    if (metrics != null) {
+      metrics.endpointDisconnected(queue.metric, conn.metric());
+    }
   }
 
   public void closeAllConnections() {

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -137,7 +137,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
           Http2Stream promisedStream = handler.connection().stream(promisedStreamId);
           int port = remoteAddress().port();
           HttpClientRequestPushPromise pushReq = new HttpClientRequestPushPromise(this, promisedStream, http2Pool.client, isSsl(), method, rawMethod, uri, host, port, headersMap);
-          if (metrics.isEnabled()) {
+          if (metrics != null) {
             pushReq.metric(metrics.responsePushed(queueMetric, metric(), localAddress(), remoteAddress(), pushReq));
           }
           streams.put(promisedStreamId, pushReq.getStream());
@@ -177,7 +177,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
 
     @Override
     void handleEnd(MultiMap trailers) {
-      if (conn.metrics.isEnabled()) {
+      if (conn.metrics != null) {
         if (request.exceptionOccurred != null) {
           conn.metrics.requestReset(request.metric());
         } else {
@@ -203,7 +203,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         return;
       }
       responseEnded = true;
-      if (conn.metrics.isEnabled()) {
+      if (conn.metrics != null) {
         conn.metrics.requestReset(request.metric());
       }
       handleException(new StreamResetException(errorCode));
@@ -213,7 +213,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     void handleClose() {
       if (!responseEnded) {
         responseEnded = true;
-        if (conn.metrics.isEnabled()) {
+        if (conn.metrics != null) {
           conn.metrics.requestReset(request.metric());
         }
         handleException(new VertxException("Connection was closed")); // Put that in utility class
@@ -261,7 +261,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
             statusMessage,
             new Http2HeadersAdaptor(headers)
         );
-        if (conn.metrics.isEnabled()) {
+        if (conn.metrics != null) {
           conn.metrics.responseBegin(request.metric(), response);
         }
         request.handleResponse(response);
@@ -319,7 +319,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
       if (conn.http2Pool.client.getOptions().isTryUseCompression() && h.get(HttpHeaderNames.ACCEPT_ENCODING) == null) {
         h.set(HttpHeaderNames.ACCEPT_ENCODING, DEFLATE_GZIP);
       }
-      if (conn.metrics.isEnabled()) {
+      if (conn.metrics != null) {
         request.metric(conn.metrics.requestBegin(conn.queueMetric, conn.metric(), conn.localAddress(), conn.remoteAddress(), request));
       }
       writeHeaders(h, end && content == null);
@@ -369,7 +369,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
 
     @Override
     public void endRequest() {
-      if (conn.metrics.isEnabled()) {
+      if (conn.metrics != null) {
         conn.metrics.requestEnd(request.metric());
       }
       requestEnded = true;
@@ -381,7 +381,7 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
         requestEnded = true;
         responseEnded = true;
         writeReset(code);
-        if (conn.metrics.isEnabled()) {
+        if (conn.metrics != null) {
           conn.metrics.requestReset(request.metric());
         }
       }

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -18,7 +18,6 @@ package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -41,7 +40,6 @@ import io.vertx.core.http.StreamResetException;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
-import io.vertx.core.spi.metrics.NetworkMetrics;
 
 import java.util.Map;
 
@@ -60,10 +58,9 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
   public Http2ClientConnection(Http2Pool http2Pool,
                                Object queueMetric,
                                ContextImpl context,
-                               Channel channel,
                                VertxHttp2ConnectionHandler connHandler,
                                HttpClientMetrics metrics) {
-    super(channel, context, connHandler);
+    super(context, connHandler);
     this.http2Pool = http2Pool;
     this.metrics = metrics;
     this.queueMetric = queueMetric;

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -78,8 +78,7 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   }
 
   protected final IntObjectMap<VertxHttp2Stream> streams = new IntObjectHashMap<>();
-  protected ChannelHandlerContext handlerContext;
-  protected final Channel channel;
+  protected final ChannelHandlerContext handlerContext;
   protected final VertxHttp2ConnectionHandler handler;
   private boolean shutdown;
   private Handler<io.vertx.core.http.Http2Settings> clientSettingsHandler;
@@ -94,9 +93,8 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
 
   public Http2ConnectionBase(ContextImpl context, VertxHttp2ConnectionHandler handler) {
     super(context.owner(), handler.context(), context);
-    this.channel = handler.context().channel();
-    this.handlerContext = channel.pipeline().context(handler);
     this.handler = handler;
+    this.handlerContext = chctx;
     this.windowSize = handler.connection().local().flowController().windowSize(handler.connection().connectionStream());
   }
 
@@ -337,7 +335,7 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
       throw new IllegalArgumentException("Invalid timeout value " + timeout);
     }
     handler.gracefulShutdownTimeoutMillis(timeout);
-    channel.close();
+    channel().close();
     return this;
   }
 
@@ -447,13 +445,6 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   @Override
   public synchronized Http2ConnectionBase exceptionHandler(Handler<Throwable> handler) {
     return (Http2ConnectionBase) super.exceptionHandler(handler);
-  }
-
-  /**
-   * @return the Netty channel - for internal usage only
-   */
-  public Channel channel() {
-    return channel;
   }
 
   // Private

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -92,16 +92,12 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
   private boolean closed;
   private int windowSize;
 
-  public Http2ConnectionBase(Channel channel, ContextImpl context, VertxHttp2ConnectionHandler handler) {
-    super((VertxInternal) context.owner(), channel, context);
-    this.channel = channel;
+  public Http2ConnectionBase(ContextImpl context, VertxHttp2ConnectionHandler handler) {
+    super(context.owner(), handler.context(), context);
+    this.channel = handler.context().channel();
     this.handlerContext = channel.pipeline().context(handler);
     this.handler = handler;
     this.windowSize = handler.connection().local().flowController().windowSize(handler.connection().connectionStream());
-  }
-
-  void setHandlerContext(ChannelHandlerContext handlerContext) {
-    this.handlerContext = handlerContext;
   }
 
   VertxInternal vertx() {

--- a/src/main/java/io/vertx/core/http/impl/Http2Pool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2Pool.java
@@ -19,17 +19,14 @@ package io.vertx.core.http.impl;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.timeout.IdleStateHandler;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 
 /**
@@ -85,15 +82,15 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
   }
 
   void createConn(ContextImpl context, Channel ch, Waiter waiter, boolean upgrade) throws Http2Exception {
-    ChannelPipeline p = ch.pipeline();
     synchronized (queue) {
-      VertxHttp2ConnectionHandler<Http2ClientConnection> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ClientConnection>()
+      VertxHttp2ConnectionHandler<Http2ClientConnection> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ClientConnection>(ch)
           .connectionMap(connectionMap)
           .server(false)
+          .upgrade(upgrade)
           .useCompression(client.getOptions().isTryUseCompression())
           .initialSettings(client.getOptions().getInitialSettings())
           .connectionFactory(connHandler -> {
-            Http2ClientConnection conn = new Http2ClientConnection(Http2Pool.this, queue.metric, context, ch, connHandler, metrics);
+            Http2ClientConnection conn = new Http2ClientConnection(Http2Pool.this, queue.metric, context, connHandler, metrics);
             if (metrics != null) {
               Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
               conn.metric(metric);
@@ -102,14 +99,10 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
           })
           .logEnabled(logEnabled)
           .build();
-      if (upgrade) {
-        handler.onHttpClientUpgrade();
-      }
       Http2ClientConnection conn = handler.connection;
       if (metrics != null) {
         metrics.endpointConnected(queue.metric, conn.metric());
       }
-      p.addLast(handler);
       allConnections.add(conn);
       if (windowSize > 0) {
         conn.setWindowSize(windowSize);

--- a/src/main/java/io/vertx/core/http/impl/Http2Pool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2Pool.java
@@ -17,7 +17,6 @@
 package io.vertx.core.http.impl;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.impl.ContextImpl;
@@ -86,7 +85,7 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
       VertxHttp2ConnectionHandler<Http2ClientConnection> handler = new VertxHttp2ConnectionHandlerBuilder<Http2ClientConnection>(ch)
           .connectionMap(connectionMap)
           .server(false)
-          .upgrade(upgrade)
+          .clientUpgrade(upgrade)
           .useCompression(client.getOptions().isTryUseCompression())
           .initialSettings(client.getOptions().getInitialSettings())
           .connectionFactory(connHandler -> {

--- a/src/main/java/io/vertx/core/http/impl/Http2Pool.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2Pool.java
@@ -94,8 +94,10 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
           .initialSettings(client.getOptions().getInitialSettings())
           .connectionFactory(connHandler -> {
             Http2ClientConnection conn = new Http2ClientConnection(Http2Pool.this, queue.metric, context, ch, connHandler, metrics);
-            Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
-            conn.metric(metric);
+            if (metrics != null) {
+              Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());
+              conn.metric(metric);
+            }
             return conn;
           })
           .logEnabled(logEnabled)
@@ -104,7 +106,9 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
         handler.onHttpClientUpgrade();
       }
       Http2ClientConnection conn = handler.connection;
-      metrics.endpointConnected(queue.metric, conn.metric());
+      if (metrics != null) {
+        metrics.endpointConnected(queue.metric, conn.metric());
+      }
       p.addLast(handler);
       allConnections.add(conn);
       if (windowSize > 0) {
@@ -138,7 +142,9 @@ class Http2Pool implements ConnectionManager.Pool<Http2ClientConnection> {
         queue.connectionClosed();
       }
     }
-    metrics.endpointDisconnected(queue.metric, conn.metric());
+    if (metrics != null) {
+      metrics.endpointDisconnected(queue.metric, conn.metric());
+    }
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerConnection.java
@@ -16,7 +16,6 @@
 
 package io.vertx.core.http.impl;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
@@ -58,14 +57,13 @@ public class Http2ServerConnection extends Http2ConnectionBase {
   private final ArrayDeque<Push> pendingPushes = new ArrayDeque<>(8);
 
   Http2ServerConnection(
-      Channel channel,
       ContextImpl context,
       String serverOrigin,
       VertxHttp2ConnectionHandler connHandler,
       HttpServerOptions options,
       Handler<HttpServerRequest> requestHandler,
       HttpServerMetrics metrics) {
-    super(channel, context, connHandler);
+    super(context, connHandler);
 
     this.options = options;
     this.serverOrigin = serverOrigin;

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -51,6 +51,8 @@ import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
 
+import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
+
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
@@ -96,7 +98,7 @@ public class Http2ServerRequestImpl extends VertxHttp2Stream<Http2ServerConnecti
       int idx = serverOrigin.indexOf("://");
       host = serverOrigin.substring(idx + 3);
     }
-    Object metric = metrics.isEnabled() ? metrics.requestBegin(conn.metric(), this) : null;
+    Object metric = (METRICS_ENABLED && metrics != null) ? metrics.requestBegin(conn.metric(), this) : null;
     this.response = new Http2ServerResponseImpl(conn, this, metric, false, contentEncoding, host);
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -39,9 +39,9 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.core.net.impl.SSLHelper;
-import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
+import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.streams.ReadStream;
 
 import java.net.MalformedURLException;
@@ -146,8 +146,8 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       }
       creatingContext.addCloseHook(closeHook);
     }
-    HttpClientMetrics metrics = vertx.metricsSPI().createMetrics(this, options);
-    connectionManager = new ConnectionManager(this, metrics);
+    VertxMetrics metrics = vertx.metricsSPI();
+    connectionManager = new ConnectionManager(this, metrics != null ? metrics.createMetrics(this, options) : null);
     proxyType = options.getProxyOptions() != null ? options.getProxyOptions().getType() : null;
   }
 
@@ -859,7 +859,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
 
   @Override
   public boolean isMetricsEnabled() {
-    return getMetrics().isEnabled();
+    return getMetrics() != null;
   }
 
   @Override
@@ -924,10 +924,6 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
 
   SSLHelper getSslHelper() {
     return sslHelper;
-  }
-
-  HttpClientMetrics httpClientMetrics() {
-    return connectionManager.metrics();
   }
 
   private URL parseUrl(String surl) {

--- a/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.http.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.ServerWebSocket;
+
+import java.util.Objects;
+
+/**
+ * HTTP server handlers.
+ *
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class HttpHandlers {
+
+  final Handler<HttpServerRequest> requesthHandler;
+  final Handler<ServerWebSocket> wsHandler;
+  final Handler<HttpConnection> connectionHandler;
+
+  public HttpHandlers(Handler<HttpServerRequest> requesthHandler, Handler<ServerWebSocket> wsHandler, Handler<HttpConnection> connectionHandler) {
+    this.requesthHandler = requesthHandler;
+    this.wsHandler = wsHandler;
+    this.connectionHandler = connectionHandler;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    HttpHandlers that = (HttpHandlers) o;
+
+    if (!Objects.equals(requesthHandler, that.requesthHandler)) return false;
+    if (!Objects.equals(wsHandler, that.wsHandler)) return false;
+    if (!Objects.equals(connectionHandler, that.connectionHandler)) return false;
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 0;
+    if (requesthHandler != null) {
+      result = 31 * result + requesthHandler.hashCode();
+    }
+    if (wsHandler != null) {
+      result = 31 * result + wsHandler.hashCode();
+    }
+    if (connectionHandler != null) {
+      result = 31 * result + connectionHandler.hashCode();
+    }
+    return result;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -586,7 +586,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     }
 
     @Override
-    protected void doMessageReceived(ServerConnection connection, ChannelHandlerContext ctx, Object msg) throws Exception {
+    protected void handleMessage(ServerConnection connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
       if (msg instanceof HttpRequest) {
         final HttpRequest request = (HttpRequest) msg;
 
@@ -609,7 +609,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
           if (wsRequest == null) {
             if (request instanceof FullHttpRequest) {
-              handshake((FullHttpRequest) request, ch, ctx);
+              handshake((FullHttpRequest) request, ch, chctx);
             } else {
               wsRequest = new DefaultFullHttpRequest(request.getProtocolVersion(), request.getMethod(), request.getUri());
               wsRequest.headers().set(request.headers());
@@ -652,7 +652,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
           if (msg instanceof LastHttpContent) {
             FullHttpRequest req = wsRequest;
             wsRequest = null;
-            handshake(req, ch, ctx);
+            handshake(req, ch, chctx);
             return;
           }
         }
@@ -761,12 +761,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     }
 
     @Override
-    protected void channelRead(ServerConnection connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
-      context.executeFromIO(() -> doMessageReceived(conn, chctx, msg));
-    }
-
-    @Override
-    protected void doMessageReceived(ServerConnection conn, ChannelHandlerContext ctx, Object msg) throws Exception {
+    protected void handleMessage(ServerConnection connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
       conn.handleMessage(msg);
     }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -586,6 +586,8 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
     private boolean closeFrameSent;
     private FullHttpRequest wsRequest;
+    private HttpResponseStatus handshakeErrorStatus;
+    private String handshakeErrorMsg;
 
     public ServerHandlerWithWebSockets(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
       super(sslHelper, options, serverOrigin, holder, metrics);
@@ -600,16 +602,19 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
         if (log.isTraceEnabled()) log.trace("Server received request: " + request.getUri());
 
         if (request.headers().contains(io.vertx.core.http.HttpHeaders.UPGRADE, io.vertx.core.http.HttpHeaders.WEBSOCKET, true)) {
+
           // As a fun part, Firefox 6.0.2 supports Websockets protocol '7'. But,
           // it doesn't send a normal 'Connection: Upgrade' header. Instead it
           // sends: 'Connection: keep-alive, Upgrade'. Brilliant.
           String connectionHeader = request.headers().get(io.vertx.core.http.HttpHeaders.CONNECTION);
           if (connectionHeader == null || !connectionHeader.toLowerCase().contains("upgrade")) {
-            sendError("\"Connection\" must be \"Upgrade\".", BAD_REQUEST, ch);
+            handshakeErrorStatus = BAD_REQUEST;
+            handshakeErrorMsg = "\"Connection\" must be \"Upgrade\".";
             return;
           }
 
           if (request.getMethod() != HttpMethod.GET) {
+            handshakeErrorStatus = METHOD_NOT_ALLOWED;
             sendError(null, METHOD_NOT_ALLOWED, ch);
             return;
           }
@@ -662,6 +667,13 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             handshake(conn, req, ch, chctx);
             return;
           }
+        } else if (handshakeErrorStatus != null) {
+          if (msg instanceof LastHttpContent) {
+            sendError(handshakeErrorMsg, handshakeErrorStatus, ch);
+            handshakeErrorMsg = null;
+            handshakeErrorMsg = null;
+          }
+          return;
         }
         conn.handleMessage(msg);
       } else {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -411,7 +411,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       // some casting and a header check
       handler = new ServerHandler(sslHelper, options, serverOrigin, holder, metrics);
     } else {
-      handler = new ServerHandleWithWebSockets(sslHelper, options, serverOrigin, holder, metrics);
+      handler = new ServerHandlerWithWebSockets(sslHelper, options, serverOrigin, holder, metrics);
     }
     handler.addHandler(conn -> {
       connectionMap.put(pipeline.channel(), conn);
@@ -582,12 +582,12 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     }
   }
 
-  public class ServerHandleWithWebSockets extends ServerHandler {
+  public class ServerHandlerWithWebSockets extends ServerHandler {
 
     private boolean closeFrameSent;
     private FullHttpRequest wsRequest;
 
-    public ServerHandleWithWebSockets(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
+    public ServerHandlerWithWebSockets(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
       super(sslHelper, options, serverOrigin, holder, metrics);
     }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -411,9 +411,9 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     if (DISABLE_WEBSOCKETS) {
       // As a performance optimisation you can set a system property to disable websockets altogether which avoids
       // some casting and a header check
-      handler = new ServerHandler(sslHelper, options, serverOrigin, pipeline.channel(), holder, metrics);
+      handler = new ServerHandler(sslHelper, options, serverOrigin, holder, metrics);
     } else {
-      handler = new ServerHandleWithWebSockets(sslHelper, options, serverOrigin, pipeline.channel(), holder, metrics);
+      handler = new ServerHandleWithWebSockets(sslHelper, options, serverOrigin, holder, metrics);
     }
     handler.addHandler(conn -> {
       connectionMap.put(pipeline.channel(), conn);
@@ -589,12 +589,13 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     private boolean closeFrameSent;
     private FullHttpRequest wsRequest;
 
-    public ServerHandleWithWebSockets(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, Channel ch, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
-      super(sslHelper, options, serverOrigin, ch, holder, metrics);
+    public ServerHandleWithWebSockets(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
+      super(sslHelper, options, serverOrigin, holder, metrics);
     }
 
     @Override
     protected void handleMessage(ServerConnection conn, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
+      Channel ch = chctx.channel();
       if (msg instanceof HttpRequest) {
         final HttpRequest request = (HttpRequest) msg;
 
@@ -735,9 +736,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     private final HttpServerMetrics metrics;
     private final HandlerHolder<HttpHandlers> holder;
 
-    public ServerHandler(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, Channel ch, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
-      super(ch);
-
+    public ServerHandler(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
       this.holder = holder;
       this.metrics = metrics;
       this.sslHelper = sslHelper;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -402,7 +402,13 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     if (options.getIdleTimeout() > 0) {
       pipeline.addLast("idle", new IdleStateHandler(0, 0, options.getIdleTimeout()));
     }
-    pipeline.addLast("handler", new ServerHandler(pipeline.channel()));
+    if (DISABLE_WEBSOCKETS) {
+      // As a performance optimisation you can set a system property to disable websockets altogether which avoids
+      // some casting and a header check
+      pipeline.addLast("handler", new ServerHandler(pipeline.channel()));
+    } else {
+      pipeline.addLast("handler", new ServerHandleWithWebSockets(pipeline.channel()));
+    }
   }
 
   public void handleHttp2(Channel ch) {
@@ -583,118 +589,117 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     }
   }
 
-  public class ServerHandler extends VertxHttpHandler<ServerConnection> {
+  public class ServerHandleWithWebSockets extends ServerHandler {
 
     private boolean closeFrameSent;
+    private FullHttpRequest wsRequest;
+
+    public ServerHandleWithWebSockets(Channel ch) {
+      super(ch);
+    }
+
+    @Override
+    protected void doMessageReceived(ServerConnection connection, ChannelHandlerContext ctx, Object msg) throws Exception {
+      if (msg instanceof HttpRequest) {
+        final HttpRequest request = (HttpRequest) msg;
+
+        if (log.isTraceEnabled()) log.trace("Server received request: " + request.getUri());
+
+        if (request.headers().contains(io.vertx.core.http.HttpHeaders.UPGRADE, io.vertx.core.http.HttpHeaders.WEBSOCKET, true)) {
+          // As a fun part, Firefox 6.0.2 supports Websockets protocol '7'. But,
+          // it doesn't send a normal 'Connection: Upgrade' header. Instead it
+          // sends: 'Connection: keep-alive, Upgrade'. Brilliant.
+          String connectionHeader = request.headers().get(io.vertx.core.http.HttpHeaders.CONNECTION);
+          if (connectionHeader == null || !connectionHeader.toLowerCase().contains("upgrade")) {
+            sendError("\"Connection\" must be \"Upgrade\".", BAD_REQUEST, ch);
+            return;
+          }
+
+          if (request.getMethod() != HttpMethod.GET) {
+            sendError(null, METHOD_NOT_ALLOWED, ch);
+            return;
+          }
+
+          if (wsRequest == null) {
+            if (request instanceof FullHttpRequest) {
+              handshake((FullHttpRequest) request, ch, ctx);
+            } else {
+              wsRequest = new DefaultFullHttpRequest(request.getProtocolVersion(), request.getMethod(), request.getUri());
+              wsRequest.headers().set(request.headers());
+            }
+          }
+        } else {
+          //HTTP request
+          if (conn == null) {
+            createConnAndHandle(ctx, ch, msg, null);
+          } else {
+            conn.handleMessage(msg);
+          }
+        }
+      } else if (msg instanceof WebSocketFrameInternal) {
+        //Websocket frame
+        WebSocketFrameInternal wsFrame = (WebSocketFrameInternal) msg;
+        switch (wsFrame.type()) {
+          case BINARY:
+          case CONTINUATION:
+          case TEXT:
+            if (conn != null) {
+              conn.handleMessage(msg);
+            }
+            break;
+          case PING:
+            // Echo back the content of the PING frame as PONG frame as specified in RFC 6455 Section 5.5.2
+            ch.writeAndFlush(new WebSocketFrameImpl(FrameType.PONG, wsFrame.getBinaryData()));
+            break;
+          case PONG:
+            // Just ignore it
+            break;
+          case CLOSE:
+            if (!closeFrameSent) {
+              // Echo back close frame and close the connection once it was written.
+              // This is specified in the WebSockets RFC 6455 Section  5.4.1
+              ch.writeAndFlush(wsFrame).addListener(ChannelFutureListener.CLOSE);
+              closeFrameSent = true;
+            }
+            break;
+          default:
+            throw new IllegalStateException("Invalid type: " + wsFrame.type());
+        }
+      } else if (msg instanceof HttpContent) {
+        if (wsRequest != null) {
+          wsRequest.content().writeBytes(((HttpContent) msg).content());
+          if (msg instanceof LastHttpContent) {
+            FullHttpRequest req = wsRequest;
+            wsRequest = null;
+            handshake(req, ch, ctx);
+            return;
+          }
+        }
+        if (conn != null) {
+          conn.handleMessage(msg);
+        }
+      } else {
+        throw new IllegalStateException("Invalid message " + msg);
+      }
+    }
+  }
+
+  public class ServerHandler extends VertxHttpHandler<ServerConnection> {
 
     public ServerHandler(Channel ch) {
       super(HttpServerImpl.this.connectionMap, ch);
     }
 
-    FullHttpRequest wsRequest;
-
     @Override
     protected void doMessageReceived(ServerConnection conn, ChannelHandlerContext ctx, Object msg) throws Exception {
-
-      // As a performance optimisation you can set a system property to disable websockets altogether which avoids
-      // some casting and a header check
-      if (!DISABLE_WEBSOCKETS) {
-
-        if (msg instanceof HttpRequest) {
-          final HttpRequest request = (HttpRequest) msg;
-
-          if (log.isTraceEnabled()) log.trace("Server received request: " + request.getUri());
-
-          if (request.headers().contains(io.vertx.core.http.HttpHeaders.UPGRADE, io.vertx.core.http.HttpHeaders.WEBSOCKET, true)) {
-            // As a fun part, Firefox 6.0.2 supports Websockets protocol '7'. But,
-            // it doesn't send a normal 'Connection: Upgrade' header. Instead it
-            // sends: 'Connection: keep-alive, Upgrade'. Brilliant.
-            String connectionHeader = request.headers().get(io.vertx.core.http.HttpHeaders.CONNECTION);
-            if (connectionHeader == null || !connectionHeader.toLowerCase().contains("upgrade")) {
-              sendError("\"Connection\" must be \"Upgrade\".", BAD_REQUEST, ch);
-              return;
-            }
-
-            if (request.getMethod() != HttpMethod.GET) {
-              sendError(null, METHOD_NOT_ALLOWED, ch);
-              return;
-            }
-
-            if (wsRequest == null) {
-              if (request instanceof FullHttpRequest) {
-                handshake((FullHttpRequest) request, ch, ctx);
-              } else {
-                wsRequest = new DefaultFullHttpRequest(request.getProtocolVersion(), request.getMethod(), request.getUri());
-                wsRequest.headers().set(request.headers());
-              }
-            }
-          } else {
-            //HTTP request
-            if (conn == null) {
-              createConnAndHandle(ctx, ch, msg, null);
-            } else {
-              conn.handleMessage(msg);
-            }
-          }
-        } else if (msg instanceof WebSocketFrameInternal) {
-          //Websocket frame
-          WebSocketFrameInternal wsFrame = (WebSocketFrameInternal) msg;
-          switch (wsFrame.type()) {
-            case BINARY:
-            case CONTINUATION:
-            case TEXT:
-              if (conn != null) {
-                conn.handleMessage(msg);
-              }
-              break;
-            case PING:
-              // Echo back the content of the PING frame as PONG frame as specified in RFC 6455 Section 5.5.2
-              ch.writeAndFlush(new WebSocketFrameImpl(FrameType.PONG, wsFrame.getBinaryData()));
-              break;
-            case PONG:
-              // Just ignore it
-              break;
-            case CLOSE:
-              if (!closeFrameSent) {
-                // Echo back close frame and close the connection once it was written.
-                // This is specified in the WebSockets RFC 6455 Section  5.4.1
-                ch.writeAndFlush(wsFrame).addListener(ChannelFutureListener.CLOSE);
-                closeFrameSent = true;
-              }
-              break;
-            default:
-              throw new IllegalStateException("Invalid type: " + wsFrame.type());
-          }
-        } else if (msg instanceof HttpContent) {
-          if (wsRequest != null) {
-            wsRequest.content().writeBytes(((HttpContent) msg).content());
-            if (msg instanceof LastHttpContent) {
-              FullHttpRequest req = wsRequest;
-              wsRequest = null;
-              handshake(req, ch, ctx);
-              return;
-            }
-          }
-          if (conn != null) {
-            conn.handleMessage(msg);
-          }
-        } else {
-          throw new IllegalStateException("Invalid message " + msg);
-        }
+      if (conn == null) {
+        createConnAndHandle(ctx, ch, msg, null);
       } else {
-        if (conn == null) {
-
-
-
-          createConnAndHandle(ctx, ch, msg, null);
-        } else {
-          conn.handleMessage(msg);
-        }
+        conn.handleMessage(msg);
       }
     }
 
-
-    private void createConnAndHandle(ChannelHandlerContext ctx, Channel ch, Object msg, WebSocketServerHandshaker shake) {
+    protected void createConnAndHandle(ChannelHandlerContext ctx, Channel ch, Object msg, WebSocketServerHandshaker shake) {
       HandlerHolder<HttpHandler> reqHandler = reqHandlerManager.chooseHandler(ch.eventLoop());
       if (reqHandler != null) {
         if (!DISABLE_HC2 && msg instanceof HttpRequest) {
@@ -780,7 +785,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       }
     }
 
-    private void handshake(FullHttpRequest request, Channel ch, ChannelHandlerContext ctx) throws Exception {
+    protected void handshake(FullHttpRequest request, Channel ch, ChannelHandlerContext ctx) throws Exception {
 
       WebSocketServerHandshaker shake = createHandshaker(ch, request);
       if (shake == null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -30,6 +30,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
@@ -74,7 +75,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   private boolean chunked;
   private boolean closed;
   private ChannelFuture channelFuture;
-  private MultiMap headers;
+  private final VertxHttpHeaders headers;
   private LastHttpContent trailing;
   private MultiMap trailers;
   private String statusMessage;
@@ -84,7 +85,8 @@ public class HttpServerResponseImpl implements HttpServerResponse {
     this.vertx = vertx;
     this.conn = conn;
     this.version = request.getProtocolVersion();
-    this.response = new DefaultHttpResponse(version, HttpResponseStatus.OK, false);
+    this.headers = new VertxHttpHeaders();
+    this.response = new DefaultHttpResponse(version, HttpResponseStatus.OK, headers);
     this.keepAlive = (version == HttpVersion.HTTP_1_1 && !request.headers().contains(io.vertx.core.http.HttpHeaders.CONNECTION, HttpHeaders.CLOSE, true))
       || (version == HttpVersion.HTTP_1_0 && request.headers().contains(io.vertx.core.http.HttpHeaders.CONNECTION, HttpHeaders.KEEP_ALIVE, true));
     this.head = request.method() == io.netty.handler.codec.http.HttpMethod.HEAD;
@@ -92,9 +94,6 @@ public class HttpServerResponseImpl implements HttpServerResponse {
 
   @Override
   public MultiMap headers() {
-    if (headers == null) {
-      headers = new HeadersAdaptor(response.headers());
-    }
     return headers;
   }
 

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -583,9 +583,13 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   private HttpServerResponseImpl write(ByteBuf chunk) {
     synchronized (conn) {
       checkWritten();
-      if (!headWritten && version != HttpVersion.HTTP_1_0 && !chunked && !headers.contentLengthSet()) {
-        throw new IllegalStateException("You must set the Content-Length header to be the total size of the message "
-          + "body BEFORE sending any data if you are not using HTTP chunked encoding.");
+      if (!headWritten && !chunked && !headers.contentLengthSet()) {
+        if (version != HttpVersion.HTTP_1_0) {
+          throw new IllegalStateException("You must set the Content-Length header to be the total size of the message "
+            + "body BEFORE sending any data if you are not using HTTP chunked encoding.");
+        } else {
+          headers.set(HttpHeaders.CONTENT_LENGTH, "0");
+        }
       }
 
       bytesWritten += chunk.readableBytes();

--- a/src/main/java/io/vertx/core/http/impl/PartialHttpResponse.java
+++ b/src/main/java/io/vertx/core/http/impl/PartialHttpResponse.java
@@ -27,19 +27,18 @@ import io.netty.handler.codec.http.HttpVersion;
 
 
 /**
- * Helper wrapper class which allows to assemble a HttpContent and a HttpResponse into one "packet" and so more
+ * Helper wrapper class which allows to assemble an HttpContent and a HttpResponse into one "packet" and so more
  * efficient write it through the pipeline.
  *
- * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-class AssembledHttpResponse implements HttpResponse, HttpContent {
+class PartialHttpResponse extends DefaultHttpResponse implements HttpContent {
 
-  private final HttpResponse response;
-  protected final HttpContent content;
+  protected final ByteBuf content;
 
-  AssembledHttpResponse(HttpResponse response, HttpContent content) {
-    this.response = response;
-    this.content = content;
+  PartialHttpResponse(HttpVersion version, HttpResponseStatus status, HttpHeaders headers, ByteBuf buf) {
+    super(version, status, headers);
+    this.content = buf;
   }
 
   @Override
@@ -63,84 +62,32 @@ class AssembledHttpResponse implements HttpResponse, HttpContent {
   }
 
   @Override
-  public AssembledHttpResponse retain() {
+  public PartialHttpResponse retain() {
     content.retain();
     return this;
   }
 
   @Override
-  public AssembledHttpResponse retain(int increment) {
+  public PartialHttpResponse retain(int increment) {
     content.retain(increment);
     return this;
   }
 
   @Override
-  public HttpResponseStatus getStatus() {
-    return response.getStatus();
-  }
-
-  @Override
-  public AssembledHttpResponse setStatus(HttpResponseStatus status) {
-    response.setStatus(status);
-    return this;
-  }
-
-  @Override
-  public AssembledHttpResponse setProtocolVersion(HttpVersion version) {
-    response.setProtocolVersion(version);
-    return this;
-  }
-
-  @Override
-  public HttpVersion getProtocolVersion() {
-    return response.getProtocolVersion();
-  }
-
-  @Override
-  public HttpVersion protocolVersion() {
-    return response.protocolVersion();
-  }
-
-  @Override
-  public HttpResponseStatus status() {
-    return response.status();
-  }
-
-  @Override
-  public AssembledHttpResponse touch() {
+  public PartialHttpResponse touch() {
     content.touch();
     return this;
   }
 
   @Override
-  public AssembledHttpResponse touch(Object hint) {
+  public PartialHttpResponse touch(Object hint) {
     content.touch(hint);
     return this;
   }
 
   @Override
-  public DecoderResult decoderResult() {
-    return content.decoderResult();
-  }
-
-  @Override
-  public HttpHeaders headers() {
-    return response.headers();
-  }
-
-  @Override
-  public DecoderResult getDecoderResult() {
-    return response.getDecoderResult();
-  }
-
-  @Override
-  public void setDecoderResult(DecoderResult result) {
-    response.setDecoderResult(result);
-  }
-
-  @Override
   public ByteBuf content() {
-    return content.content();
+    return content;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -221,7 +221,7 @@ public class ServerConnection extends Http1xConnectionBase implements HttpConnec
       return ws;
     }
     HttpServerImpl.ServerHandler serverHandler = (HttpServerImpl.ServerHandler) chctx.pipeline().get("handler");
-    handshaker = serverHandler.createHandshaker(chctx.channel(), nettyReq);
+    handshaker = serverHandler.createHandshaker(this, chctx.channel(), nettyReq);
     if (handshaker == null) {
       throw new IllegalStateException("Can't upgrade this request");
     }

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -220,7 +220,7 @@ public class ServerConnection extends Http1xConnectionBase implements HttpConnec
     if (ws != null) {
       return ws;
     }
-    HttpServerImpl.ServerHandler serverHandler = (HttpServerImpl.ServerHandler) chctx.pipeline().get("handler");
+    ServerHandler serverHandler = (ServerHandler) chctx.pipeline().get("handler");
     handshaker = serverHandler.createHandshaker(this, chctx.channel(), nettyReq);
     if (handshaker == null) {
       throw new IllegalStateException("Can't upgrade this request");

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -293,9 +293,9 @@ public class ServerConnection extends Http1xConnectionBase implements HttpConnec
       }
 
       @Override
-      protected void handleMsgReceived(NetSocketImpl conn, Object msg) {
+      protected void handleMessage(NetSocketImpl connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
         ByteBuf buf = (ByteBuf) msg;
-        conn.handleDataReceived(Buffer.buffer(buf));
+        connection.handleDataReceived(Buffer.buffer(buf));
       }
     });
 

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -120,7 +120,7 @@ public class ServerConnection extends ConnectionBase implements HttpConnection {
   public ServerConnection(VertxInternal vertx,
                    SSLHelper sslHelper,
                    HttpServerOptions options,
-                   Channel channel,
+                   ChannelHandlerContext channel,
                    ContextImpl context,
                    String serverOrigin,
                    HttpServerMetrics metrics) {
@@ -255,7 +255,7 @@ public class ServerConnection extends ConnectionBase implements HttpConnection {
   }
 
   NetSocket createNetSocket() {
-    NetSocketImpl socket = new NetSocketImpl(vertx, channel, context, sslHelper, metrics);
+    NetSocketImpl socket = new NetSocketImpl(vertx, chctx, context, sslHelper, metrics);
     socket.metric(metric());
     Map<Channel, NetSocketImpl> connectionMap = new HashMap<>(1);
     connectionMap.put(channel, socket);

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -156,6 +156,7 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
 
   private void enqueue(Object msg) {
     //We queue requests if paused or a request is in progress to prevent responses being written in the wrong order
+    queueing = true;
     pending.add(msg);
     if (pending.size() == CHANNEL_PAUSE_QUEUE_SIZE) {
       //We pause the channel too, to prevent the queue growing too large, but we don't do this
@@ -435,7 +436,6 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
   private void processMessage(Object msg) {
     if (msg instanceof HttpRequest) {
       if (pendingResponse != null) {
-        queueing = true;
         enqueue(msg);
         return;
       }
@@ -494,6 +494,9 @@ class ServerConnection extends ConnectionBase implements HttpConnection {
     } else {
       // Requeue
       // paused = true => queueing = true
+      // todo : this should be added first if pending.size() > 0
+      // case : user call resume on the last http content and then call pause
+      // it will be added at the wrong place and create a bug
       pending.add(LastHttpContent.EMPTY_LAST_CONTENT);
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -294,7 +294,6 @@ public class ServerConnection extends Http1xConnectionBase implements HttpConnec
     if (METRICS_ENABLED && metrics != null) {
       bytesRead += chunk.length();
     }
-//    System.out.println("handling chunk " + chunk);
     currentRequest.handleData(chunk);
   }
 

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -17,10 +17,8 @@
 package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -42,13 +40,10 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.handler.stream.ChunkedFile;
 import io.netty.util.ReferenceCountUtil;
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.GoAway;
-import io.vertx.core.http.Http2Settings;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
@@ -60,7 +55,6 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.NetSocketImpl;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.net.impl.VertxNetHandler;
@@ -551,78 +545,5 @@ public class ServerConnection extends Http1xConnectionBase implements HttpConnec
     } else {
       return -1;
     }
-  }
-
-  //
-
-
-  @Override
-  public synchronized ServerConnection closeHandler(Handler<Void> handler) {
-    return (ServerConnection) super.closeHandler(handler);
-  }
-
-  @Override
-  public synchronized ServerConnection exceptionHandler(Handler<Throwable> handler) {
-    return (ServerConnection) super.exceptionHandler(handler);
-  }
-
-  @Override
-  public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection goAwayHandler(@Nullable Handler<GoAway> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection shutdown() {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public HttpConnection shutdown(long timeoutMs) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support GOAWAY");
-  }
-
-  @Override
-  public Http2Settings settings() {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection updateSettings(Http2Settings settings) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection updateSettings(Http2Settings settings, Handler<AsyncResult<Void>> completionHandler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public Http2Settings remoteSettings() {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support SETTINGS");
-  }
-
-  @Override
-  public HttpConnection ping(Buffer data, Handler<AsyncResult<Buffer>> pongHandler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
-  }
-
-  @Override
-  public HttpConnection pingHandler(@Nullable Handler<Buffer> handler) {
-    throw new UnsupportedOperationException("HTTP/1.x connections don't support PING");
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/ServerHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerHandler.java
@@ -1,0 +1,104 @@
+package io.vertx.core.http.impl;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
+import io.vertx.core.Handler;
+import io.vertx.core.VertxException;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.net.impl.HandlerHolder;
+import io.vertx.core.net.impl.SSLHelper;
+import io.vertx.core.spi.metrics.HttpServerMetrics;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class ServerHandler extends VertxHttpHandler<ServerConnection> {
+
+  private static final Logger log = LoggerFactory.getLogger(ServerHandler.class);
+
+  private final SSLHelper sslHelper;
+  private final HttpServerOptions options;
+  private final String serverOrigin;
+  private final HttpServerMetrics metrics;
+  private final HandlerHolder<HttpHandlers> holder;
+
+  public ServerHandler(SSLHelper sslHelper, HttpServerOptions options, String serverOrigin, HandlerHolder<HttpHandlers> holder, HttpServerMetrics metrics) {
+    this.holder = holder;
+    this.metrics = metrics;
+    this.sslHelper = sslHelper;
+    this.options = options;
+    this.serverOrigin = serverOrigin;
+  }
+
+  @Override
+  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    super.handlerAdded(ctx);
+    ServerConnection conn = new ServerConnection(holder.context.owner(),
+      sslHelper,
+      options,
+      ctx,
+      holder.context,
+      serverOrigin,
+      metrics);
+    setConnection(conn);
+    conn.requestHandler(holder.handler.requesthHandler);
+    holder.context.executeFromIO(() -> {
+      if (metrics != null) {
+        conn.metric(metrics.connected(conn.remoteAddress(), conn.remoteName()));
+      }
+      Handler<HttpConnection> connHandler = holder.handler.connectionHandler;
+      if (connHandler != null) {
+        connHandler.handle(conn);
+      }
+    });
+  }
+
+  @Override
+  protected void handleMessage(ServerConnection conn, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
+    conn.handleMessage(msg);
+  }
+
+  WebSocketServerHandshaker createHandshaker(ServerConnection conn, Channel ch, HttpRequest request) {
+    // As a fun part, Firefox 6.0.2 supports Websockets protocol '7'. But,
+    // it doesn't send a normal 'Connection: Upgrade' header. Instead it
+    // sends: 'Connection: keep-alive, Upgrade'. Brilliant.
+    String connectionHeader = request.headers().get(io.vertx.core.http.HttpHeaders.CONNECTION);
+    if (connectionHeader == null || !connectionHeader.toLowerCase().contains("upgrade")) {
+      HttpServerImpl.sendError("\"Connection\" must be \"Upgrade\".", BAD_REQUEST, ch);
+      return null;
+    }
+
+    if (request.getMethod() != HttpMethod.GET) {
+      HttpServerImpl.sendError(null, METHOD_NOT_ALLOWED, ch);
+      return null;
+    }
+
+    try {
+
+      WebSocketServerHandshakerFactory factory =
+        new WebSocketServerHandshakerFactory(HttpServerImpl.getWebSocketLocation(ch.pipeline(), request), conn.options.getWebsocketSubProtocols(), false,
+          conn.options.getMaxWebsocketFrameSize(), conn.options.isAcceptUnmaskedFrames());
+      WebSocketServerHandshaker shake = factory.newHandshaker(request);
+
+      if (shake == null) {
+        log.error("Unrecognised websockets handshake");
+        WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ch);
+      }
+
+      return shake;
+    } catch (Exception e) {
+      throw new VertxException(e);
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2ConnectionHandlerBuilder.java
@@ -16,15 +16,19 @@
 
 package io.vertx.core.http.impl;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.CompressorHttp2ConnectionEncoder;
-import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Flags;
+import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2FrameLogger;
-import io.netty.handler.codec.http2.Http2LocalFlowController;
+import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.logging.LogLevel;
 import io.vertx.core.http.HttpServerOptions;
@@ -33,10 +37,13 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
+ * Todo : don't use the parent builder that is too complicated and restrictive
+ *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends AbstractHttp2ConnectionHandlerBuilder<VertxHttp2ConnectionHandler<C>, VertxHttp2ConnectionHandlerBuilder<C>> {
 
+  private final Channel channel;
   private Map<Channel, ? super C> connectionMap;
   private boolean useCompression;
   private boolean useDecompression;
@@ -44,8 +51,10 @@ class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends 
   private io.vertx.core.http.Http2Settings initialSettings;
   private Function<VertxHttp2ConnectionHandler<C>, C> connectionFactory;
   private boolean logEnabled;
+  private boolean upgrade;
 
-  VertxHttp2ConnectionHandlerBuilder() {
+  VertxHttp2ConnectionHandlerBuilder(Channel channel) {
+    this.channel = channel;
   }
 
   protected VertxHttp2ConnectionHandlerBuilder<C> server(boolean isServer) {
@@ -66,8 +75,13 @@ class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends 
     this.useCompression = useCompression;
     return this;
   }
-  
-  /** 
+
+  public VertxHttp2ConnectionHandlerBuilder<C> upgrade(boolean upgrade) {
+    this.upgrade = upgrade;
+    return this;
+  }
+
+  /**
    * This method allows to set the compression level to be used in the http/2 connection encoder 
    * (for data sent to client) when compression support is turned on (@see useCompression) and 
    * the client advertises to support deflate/gizip compression in the Accept-Encoding header
@@ -114,6 +128,61 @@ class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends 
     if (logEnabled) {
       frameLogger(new Http2FrameLogger(LogLevel.DEBUG));
     }
+    // Make this damn builder happy
+    frameListener(new Http2FrameListener() {
+      @Override
+      public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding, boolean endOfStream) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency, short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight, boolean exclusive) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+      @Override
+      public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, ByteBuf payload) throws Http2Exception {
+        throw new UnsupportedOperationException();
+      }
+    });
     return super.build();
   }
 
@@ -123,19 +192,29 @@ class VertxHttp2ConnectionHandlerBuilder<C extends Http2ConnectionBase> extends 
       if (useCompression) {
         encoder = new CompressorHttp2ConnectionEncoder(encoder,compressionLevel,CompressorHttp2ConnectionEncoder.DEFAULT_WINDOW_BITS,CompressorHttp2ConnectionEncoder.DEFAULT_MEM_LEVEL);
       }
-      VertxHttp2ConnectionHandler<C> handler = new VertxHttp2ConnectionHandler<>(connectionMap, decoder, encoder, initialSettings, connectionFactory);
+      VertxHttp2ConnectionHandler<C> handler = new VertxHttp2ConnectionHandler<>(connectionMap, decoder, encoder, initialSettings);
+      if (upgrade) {
+        handler.onHttpClientUpgrade();
+      }
+      channel.pipeline().addLast(handler);
+      handler.init(connectionFactory.apply(handler));
       if (useDecompression) {
-        frameListener(new DelegatingDecompressorFrameListener(decoder.connection(), handler.connection));
+        decoder.frameListener(new DelegatingDecompressorFrameListener(decoder.connection(), handler.connection));
       } else {
-        frameListener(handler.connection);
+        decoder.frameListener(handler.connection);
       }
       return handler;
     } else {
-      VertxHttp2ConnectionHandler<C> handler = new VertxHttp2ConnectionHandler<>(connectionMap, decoder, encoder, initialSettings, connectionFactory);
+      VertxHttp2ConnectionHandler<C> handler = new VertxHttp2ConnectionHandler<>(connectionMap, decoder, encoder, initialSettings);
+      if (upgrade) {
+        handler.onHttpClientUpgrade();
+      }
+      channel.pipeline().addLast(handler);
+      handler.init(connectionFactory.apply(handler));
       if (useCompression) {
-        frameListener(new DelegatingDecompressorFrameListener(decoder.connection(), handler.connection));
+        decoder.frameListener(new DelegatingDecompressorFrameListener(decoder.connection(), handler.connection));
       } else {
-        frameListener(handler.connection);
+        decoder.frameListener(handler.connection);
       }
       return handler;
     }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -64,21 +64,7 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
   }
 
   @Override
-  public void channelRead(ChannelHandlerContext chctx, Object msg) throws Exception {
-    ContextImpl context = getContext(conn);
-    context.executeFromIO(() -> {
-      conn.startRead();
-      doMessageReceived(conn, chctx, safeObject(msg, chctx.alloc()));
-    });
-  }
-
-  @Override
-  protected void channelRead(final C connection, final ContextImpl context, final ChannelHandlerContext chctx, final Object msg) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+  protected Object decode(Object msg, ByteBufAllocator allocator) throws Exception {
     if (msg instanceof HttpContent) {
       HttpContent content = (HttpContent) msg;
       ByteBuf buf = content.content();
@@ -114,7 +100,5 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
     }
     return msg;
   }
-
-  protected abstract void doMessageReceived(C connection, ChannelHandlerContext ctx, Object msg) throws Exception;
 
 }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -64,8 +64,17 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
   }
 
   @Override
+  public void channelRead(ChannelHandlerContext chctx, Object msg) throws Exception {
+    ContextImpl context = getContext(conn);
+    context.executeFromIO(() -> {
+      conn.startRead();
+      doMessageReceived(conn, chctx, safeObject(msg, chctx.alloc()));
+    });
+  }
+
+  @Override
   protected void channelRead(final C connection, final ContextImpl context, final ChannelHandlerContext chctx, final Object msg) throws Exception {
-    context.executeFromIO(() -> doMessageReceived(connection, chctx, msg));
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -115,41 +115,6 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
     return msg;
   }
 
-
-  @Override
-  public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-    if (msg instanceof WebSocketFrameInternal) {
-      WebSocketFrameInternal frame = (WebSocketFrameInternal) msg;
-      ByteBuf buf = frame.getBinaryData();
-      if (buf != Unpooled.EMPTY_BUFFER) {
-         buf = safeBuffer(buf, ctx.alloc());
-      }
-      switch (frame.type()) {
-        case BINARY:
-          msg = new BinaryWebSocketFrame(frame.isFinal(), 0, buf);
-          break;
-        case TEXT:
-          msg = new TextWebSocketFrame(frame.isFinal(), 0, buf);
-          break;
-        case CLOSE:
-          msg = new CloseWebSocketFrame(true, 0, buf);
-          break;
-        case CONTINUATION:
-          msg = new ContinuationWebSocketFrame(frame.isFinal(), 0, buf);
-          break;
-        case PONG:
-          msg = new PongWebSocketFrame(buf);
-          break;
-        case PING:
-          msg = new PingWebSocketFrame(buf);
-          break;
-        default:
-          throw new IllegalStateException("Unsupported websocket msg " + msg);
-      }
-    }
-    ctx.write(msg, promise);
-  }
-
   protected abstract void doMessageReceived(C connection, ChannelHandlerContext ctx, Object msg) throws Exception;
 
 }

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -45,7 +45,6 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
 
   protected Map<Channel, C> connectionMap;
   protected final Channel ch;
-  protected C conn;
 
   protected VertxHttpHandler(Map<Channel, C> connectionMap, Channel ch) {
     this.connectionMap = connectionMap;
@@ -53,14 +52,8 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
   }
 
   @Override
-  protected C getConnection() {
-    return conn;
-  }
-
-  @Override
-  protected C removeConnection() {
+  protected void removeConnection() {
     connectionMap.remove(ch);
-    return conn;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -43,17 +43,10 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
     return safeBuffer(holder.content(), allocator);
   }
 
-  protected Map<Channel, C> connectionMap;
   protected final Channel ch;
 
-  protected VertxHttpHandler(Map<Channel, C> connectionMap, Channel ch) {
-    this.connectionMap = connectionMap;
+  protected VertxHttpHandler(Channel ch) {
     this.ch = ch;
-  }
-
-  @Override
-  protected void removeConnection() {
-    connectionMap.remove(ch);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -60,24 +60,12 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
   @Override
   protected C removeConnection() {
     connectionMap.remove(ch);
-    C conn = this.conn;
-    this.conn = null;
     return conn;
   }
 
   @Override
   protected void channelRead(final C connection, final ContextImpl context, final ChannelHandlerContext chctx, final Object msg) throws Exception {
-    if (connection != null) {
-      context.executeFromIO(() -> doMessageReceived(connection, chctx, msg));
-    } else {
-      // We execute this directly as we don't have a context yet, the context will have to be set manually
-      // inside doMessageReceived();
-      try {
-        doMessageReceived(null, chctx, msg);
-      } catch (Throwable t) {
-        chctx.pipeline().fireExceptionCaught(t);
-      }
-    }
+    context.executeFromIO(() -> doMessageReceived(connection, chctx, msg));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -43,12 +43,6 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
     return safeBuffer(holder.content(), allocator);
   }
 
-  protected final Channel ch;
-
-  protected VertxHttpHandler(Channel ch) {
-    this.ch = ch;
-  }
-
   @Override
   protected Object decode(Object msg, ByteBufAllocator allocator) throws Exception {
     if (msg instanceof HttpContent) {

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImpl.java
@@ -19,6 +19,7 @@ package io.vertx.core.http.impl;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.spi.metrics.HttpClientMetrics;
 
 /**
  * This class is optimised for performance when used on the same event loop. However it can be used safely from other threads.
@@ -40,7 +41,10 @@ public class WebSocketImpl extends WebSocketImplBase<WebSocket> implements WebSo
   @Override
   void handleClosed() {
     synchronized (conn) {
-      ((ClientConnection) conn).metrics().disconnected(getMetric());
+      HttpClientMetrics metrics = ((ClientConnection) conn).metrics();
+      if (metrics != null) {
+        metrics.disconnected(getMetric());
+      }
       super.handleClosed();
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -216,9 +216,7 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public String get(final String name) {
-    Objects.requireNonNull(name, "name");
-    CharSequence ret = get0(name);
-    return ret != null ? ret.toString() : null;
+    return get((CharSequence) name);
   }
 
   private CharSequence get0(CharSequence name) {
@@ -304,7 +302,9 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public String get(CharSequence name) {
-    return get(name.toString());
+    Objects.requireNonNull(name, "name");
+    CharSequence ret = get0(name);
+    return ret != null ? ret.toString() : null;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -20,6 +20,7 @@ import io.netty.util.AsciiString;
 import io.vertx.core.MultiMap;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -138,7 +139,7 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     return this;
   }
 
-  private void remove0(int h, int i, String name) {
+  private void remove0(int h, int i, CharSequence name) {
     VertxHttpHeaders.MapEntry e = entries[i];
     if (e == null) {
       return;
@@ -179,7 +180,7 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     return set0(name, strVal);
   }
 
-  private VertxHttpHeaders set0(final String name, final CharSequence strVal) {
+  private VertxHttpHeaders set0(final CharSequence name, final CharSequence strVal) {
     int h = AsciiString.hashCode(name);
     int i = index(h);
     remove0(h, i, name);
@@ -234,20 +235,7 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public List<String> getAll(final String name) {
-    Objects.requireNonNull(name, "name");
-
-    LinkedList<String> values = new LinkedList<>();
-
-    int h = AsciiString.hashCode(name);
-    int i = index(h);
-    VertxHttpHeaders.MapEntry e = entries[i];
-    while (e != null) {
-      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        values.addFirst(e.getValue().toString());
-      }
-      e = e.next;
-    }
-    return values;
+    return getAll((CharSequence) name);
   }
 
   @Override
@@ -261,9 +249,7 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public List<Map.Entry<String, String>> entries() {
-    List<Map.Entry<String, String>> all =
-        new LinkedList<>();
-
+    List<Map.Entry<String, String>> all = new ArrayList<>(size());
     VertxHttpHeaders.MapEntry e = head.after;
     while (e != head) {
       all.add(new AbstractMap.SimpleEntry<>(e.key.toString(), e.value.toString()));
@@ -289,9 +275,7 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public Set<String> names() {
-
     Set<String> names = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-
     VertxHttpHeaders.MapEntry e = head.after;
     while (e != head) {
       names.add(e.getKey().toString());
@@ -309,7 +293,20 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public List<String> getAll(CharSequence name) {
-    return getAll(name.toString());
+    Objects.requireNonNull(name, "name");
+
+    LinkedList<String> values = new LinkedList<>();
+
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        values.addFirst(e.getValue().toString());
+      }
+      e = e.next;
+    }
+    return values;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -68,6 +68,14 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     head.before = head.after = head;
   }
 
+  public boolean contentLengthSet() {
+    return contains(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH);
+  }
+
+  public boolean contentTypeSet() {
+    return contains(io.vertx.core.http.HttpHeaders.CONTENT_TYPE);
+  }
+
   @Override
   public VertxHttpHeaders add(CharSequence name, Object value) {
     int h = AsciiString.hashCode(name);

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -252,7 +252,25 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     List<Map.Entry<String, String>> all = new ArrayList<>(size());
     VertxHttpHeaders.MapEntry e = head.after;
     while (e != head) {
-      all.add(new AbstractMap.SimpleEntry<>(e.key.toString(), e.value.toString()));
+      final MapEntry f = e;
+      all.add(new Map.Entry<String, String>() {
+        @Override
+        public String getKey() {
+          return f.key.toString();
+        }
+        @Override
+        public String getValue() {
+          return f.value.toString();
+        }
+        @Override
+        public String setValue(String value) {
+          return f.setValue(value).toString();
+        }
+        @Override
+        public String toString() {
+          return getKey() + ": " + getValue();
+        }
+      });
       e = e.after;
     }
     return all;

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -1,0 +1,479 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.http.impl.headers;
+
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.util.AsciiString;
+import io.vertx.core.MultiMap;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
+
+  private MultiMap set0(Iterable<Map.Entry<String, String>> map) {
+    clear();
+    for (Map.Entry<String, String> entry: map) {
+      add(entry.getKey(), entry.getValue());
+    }
+    return this;
+  }
+
+  @Override
+  public MultiMap setAll(MultiMap headers) {
+    return set0(headers);
+  }
+
+  @Override
+  public MultiMap setAll(Map<String, String> headers) {
+    return set0(headers.entrySet());
+  }
+
+  @Override
+  public int size() {
+    return names().size();
+  }
+
+  private static int index(int hash) {
+    return hash & 0x0000000F;
+  }
+
+  private final VertxHttpHeaders.MapEntry[] entries = new VertxHttpHeaders.MapEntry[16];
+  private final VertxHttpHeaders.MapEntry head = new VertxHttpHeaders.MapEntry(-1, null, null);
+
+  public VertxHttpHeaders() {
+    head.before = head.after = head;
+  }
+
+  @Override
+  public VertxHttpHeaders add(CharSequence name, Object value) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    add0(h, i, name, (CharSequence) value);
+    return this;
+  }
+
+  @Override
+  public VertxHttpHeaders add(final String name, final String strVal) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    add0(h, i, name, strVal);
+    return this;
+  }
+
+  @Override
+  public VertxHttpHeaders add(String name, Iterable values) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    for (Object vstr: values) {
+      add0(h, i, name, (String) vstr);
+    }
+    return this;
+  }
+
+  @Override
+  public MultiMap addAll(MultiMap headers) {
+    for (Map.Entry<String, String> entry: headers.entries()) {
+      add(entry.getKey(), entry.getValue());
+    }
+    return this;
+  }
+
+  @Override
+  public MultiMap addAll(Map<String, String> map) {
+    for (Map.Entry<String, String> entry: map.entrySet()) {
+      add(entry.getKey(), entry.getValue());
+    }
+    return this;
+  }
+
+  private void add0(int h, int i, final CharSequence name, final CharSequence value) {
+    // Update the hash table.
+    VertxHttpHeaders.MapEntry e = entries[i];
+    VertxHttpHeaders.MapEntry newEntry;
+    entries[i] = newEntry = new VertxHttpHeaders.MapEntry(h, name, value);
+    newEntry.next = e;
+
+    // Update the linked list.
+    newEntry.addBefore(head);
+  }
+
+  @Override
+  public VertxHttpHeaders remove(final String name) {
+    Objects.requireNonNull(name, "name");
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    remove0(h, i, name);
+    return this;
+  }
+
+  private void remove0(int h, int i, String name) {
+    VertxHttpHeaders.MapEntry e = entries[i];
+    if (e == null) {
+      return;
+    }
+
+    for (;;) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        e.remove();
+        VertxHttpHeaders.MapEntry next = e.next;
+        if (next != null) {
+          entries[i] = next;
+          e = next;
+        } else {
+          entries[i] = null;
+          return;
+        }
+      } else {
+        break;
+      }
+    }
+
+    for (;;) {
+      VertxHttpHeaders.MapEntry next = e.next;
+      if (next == null) {
+        break;
+      }
+      if (next.hash == h && AsciiString.contentEqualsIgnoreCase(name, next.key)) {
+        e.next = next.next;
+        next.remove();
+      } else {
+        e = next;
+      }
+    }
+  }
+
+  @Override
+  public VertxHttpHeaders set(final String name, final String strVal) {
+    return set0(name, strVal);
+  }
+
+  private VertxHttpHeaders set0(final String name, final CharSequence strVal) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    remove0(h, i, name);
+    add0(h, i, name, strVal);
+    return this;
+  }
+
+  @Override
+  public VertxHttpHeaders set(final String name, final Iterable values) {
+    Objects.requireNonNull(values, "values");
+
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+
+    remove0(h, i, name);
+    for (Object v: values) {
+      if (v == null) {
+        break;
+      }
+      add0(h, i, name, (String) v);
+    }
+
+    return this;
+  }
+
+  @Override
+  public VertxHttpHeaders clear() {
+    for (int i = 0; i < entries.length; i ++) {
+      entries[i] = null;
+    }
+    head.before = head.after = head;
+    return this;
+  }
+
+  @Override
+  public String get(final String name) {
+    Objects.requireNonNull(name, "name");
+    CharSequence ret = get0(name);
+    return ret != null ? ret.toString() : null;
+  }
+
+  private CharSequence get0(CharSequence name) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        return e.getValue();
+      }
+      e = e.next;
+    }
+    return null;
+  }
+
+  @Override
+  public List<String> getAll(final String name) {
+    Objects.requireNonNull(name, "name");
+
+    LinkedList<String> values = new LinkedList<>();
+
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        values.addFirst(e.getValue().toString());
+      }
+      e = e.next;
+    }
+    return values;
+  }
+
+  @Override
+  public void forEach(Consumer<? super Map.Entry<String, String>> action) {
+    VertxHttpHeaders.MapEntry e = head.after;
+    while (e != head) {
+      action.accept(new AbstractMap.SimpleEntry<>(e.key.toString(), e.value.toString()));
+      e = e.after;
+    }
+  }
+
+  @Override
+  public List<Map.Entry<String, String>> entries() {
+    List<Map.Entry<String, String>> all =
+        new LinkedList<>();
+
+    VertxHttpHeaders.MapEntry e = head.after;
+    while (e != head) {
+      all.add(new AbstractMap.SimpleEntry<>(e.key.toString(), e.value.toString()));
+      e = e.after;
+    }
+    return all;
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return entries().iterator();
+  }
+
+  @Override
+  public boolean contains(String name) {
+    return contains((CharSequence) name);
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return head == head.after;
+  }
+
+  @Override
+  public Set<String> names() {
+
+    Set<String> names = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+    VertxHttpHeaders.MapEntry e = head.after;
+    while (e != head) {
+      names.add(e.getKey().toString());
+      e = e.after;
+    }
+    return names;
+  }
+
+  @Override
+  public String get(CharSequence name) {
+    return get(name.toString());
+  }
+
+  @Override
+  public List<String> getAll(CharSequence name) {
+    return getAll(name.toString());
+  }
+
+  @Override
+  public boolean contains(CharSequence name) {
+    return get0(name) != null;
+  }
+
+  @Override
+  public VertxHttpHeaders add(CharSequence name, CharSequence value) {
+    return add(name.toString(), value.toString());
+  }
+
+  @Override
+  public VertxHttpHeaders add(CharSequence name, Iterable values) {
+    String n = name.toString();
+    for (Object seq: values) {
+      add(n, seq.toString());
+    }
+    return this;
+  }
+
+  @Override
+  public MultiMap set(CharSequence name, CharSequence value) {
+    return set(name.toString(), value.toString());
+  }
+
+  @Override
+  public VertxHttpHeaders set(CharSequence name, Iterable values) {
+    remove(name);
+    String n = name.toString();
+    for (Object seq: values) {
+      add(n, seq.toString());
+    }
+    return this;
+  }
+
+  @Override
+  public VertxHttpHeaders remove(CharSequence name) {
+    return remove(name.toString());
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, String> entry: this) {
+      sb.append(entry).append('\n');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public Integer getInt(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(CharSequence name, int defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Short getShort(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShort(CharSequence name, short defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Long getTimeMillis(CharSequence name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getTimeMillis(CharSequence name, long defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Iterator<Map.Entry<CharSequence, CharSequence>> iteratorCharSequence() {
+    return new Iterator<Map.Entry<CharSequence, CharSequence>>() {
+      VertxHttpHeaders.MapEntry current = head.after;
+      @Override
+      public boolean hasNext() {
+        return current != head;
+      }
+      @Override
+      public Map.Entry<CharSequence, CharSequence> next() {
+        Map.Entry<CharSequence, CharSequence> next = current;
+        current = current.after;
+        return next;
+      }
+    };
+  }
+
+  @Override
+  public HttpHeaders add(String name, Object value) {
+    return add((CharSequence) name, (CharSequence) value);
+  }
+
+  @Override
+  public HttpHeaders addInt(CharSequence name, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HttpHeaders addShort(CharSequence name, short value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HttpHeaders set(String name, Object value) {
+    return set0(name, (CharSequence) value);
+  }
+
+  @Override
+  public HttpHeaders setInt(CharSequence name, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HttpHeaders setShort(CharSequence name, short value) {
+    throw new UnsupportedOperationException();
+  }
+
+  private static final class MapEntry implements Map.Entry<CharSequence, CharSequence> {
+    final int hash;
+    final CharSequence key;
+    CharSequence value;
+    VertxHttpHeaders.MapEntry next;
+    VertxHttpHeaders.MapEntry before, after;
+
+    MapEntry(int hash, CharSequence key, CharSequence value) {
+      this.hash = hash;
+      this.key = key;
+      this.value = value;
+    }
+
+    void remove() {
+      before.after = after;
+      after.before = before;
+    }
+
+    void addBefore(VertxHttpHeaders.MapEntry e) {
+      after  = e;
+      before = e.before;
+      before.after = this;
+      after.before = this;
+    }
+
+    @Override
+    public CharSequence getKey() {
+      return key;
+    }
+
+    @Override
+    public CharSequence getValue() {
+      return value;
+    }
+
+    @Override
+    public CharSequence setValue(CharSequence value) {
+      Objects.requireNonNull(value, "value");
+      CharSequence oldValue = this.value;
+      this.value = value;
+      return oldValue;
+    }
+
+    @Override
+    public String toString() {
+      return getKey() + ": " + getValue();
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -25,7 +25,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Starter;
 import io.vertx.core.Vertx;
-import io.vertx.core.WorkerExecutor;
 import io.vertx.core.impl.launcher.VertxCommandLauncher;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -42,6 +41,15 @@ import java.util.concurrent.RejectedExecutionException;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public abstract class ContextImpl implements ContextInternal {
+
+  private static EventLoop getEventLoop(VertxInternal vertx) {
+    EventLoopGroup group = vertx.getEventLoopGroup();
+    if (group != null) {
+      return group.next();
+    } else {
+      return null;
+    }
+  }
 
   private static final Logger log = LoggerFactory.getLogger(ContextImpl.class);
 
@@ -69,17 +77,17 @@ public abstract class ContextImpl implements ContextInternal {
 
   protected ContextImpl(VertxInternal vertx, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID, JsonObject config,
                         ClassLoader tccl) {
+    this(vertx, getEventLoop(vertx), internalBlockingPool, workerPool, deploymentID, config, tccl);
+  }
+
+  protected ContextImpl(VertxInternal vertx, EventLoop eventLoop, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID, JsonObject config,
+                        ClassLoader tccl) {
     if (DISABLE_TCCL && !tccl.getClass().getName().equals("sun.misc.Launcher$AppClassLoader")) {
       log.warn("You have disabled TCCL checks but you have a custom TCCL to set.");
     }
     this.deploymentID = deploymentID;
     this.config = config;
-    EventLoopGroup group = vertx.getEventLoopGroup();
-    if (group != null) {
-      this.eventLoop = group.next();
-    } else {
-      this.eventLoop = null;
-    }
+    this.eventLoop = eventLoop;
     this.tccl = tccl;
     this.owner = vertx;
     this.workerPool = workerPool;

--- a/src/main/java/io/vertx/core/impl/ContextImpl.java
+++ b/src/main/java/io/vertx/core/impl/ContextImpl.java
@@ -234,7 +234,7 @@ public abstract class ContextImpl implements ContextInternal {
     return eventLoop;
   }
 
-  public Vertx owner() {
+  public VertxInternal owner() {
     return owner;
   }
 

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -21,6 +21,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.spi.VerticleFactory;
+import io.vertx.core.spi.metrics.VertxMetrics;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -438,7 +439,10 @@ public class DeploymentManager {
                 parent.addChild(deployment);
                 deployment.child = true;
               }
-              vertx.metricsSPI().verticleDeployed(verticle);
+              VertxMetrics metrics = vertx.metricsSPI();
+              if (metrics != null) {
+                metrics.verticleDeployed(verticle);
+              }
               deployments.put(deploymentID, deployment);
               if (deployCount.incrementAndGet() == verticles.length) {
                 reportSuccess(deploymentID, callingContext, completionHandler);
@@ -528,7 +532,10 @@ public class DeploymentManager {
             AtomicBoolean failureReported = new AtomicBoolean();
             stopFuture.setHandler(ar -> {
               deployments.remove(deploymentID);
-              vertx.metricsSPI().verticleUndeployed(verticleHolder.verticle);
+              VertxMetrics metrics = vertx.metricsSPI();
+              if (metrics != null) {
+                metrics.verticleUndeployed(verticleHolder.verticle);
+              }
               context.runCloseHooks(ar2 -> {
 
                 if (ar2.failed()) {

--- a/src/main/java/io/vertx/core/impl/EventLoopContext.java
+++ b/src/main/java/io/vertx/core/impl/EventLoopContext.java
@@ -16,6 +16,7 @@
 
 package io.vertx.core.impl;
 
+import io.netty.channel.EventLoop;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -31,6 +32,11 @@ public class EventLoopContext extends ContextImpl {
   public EventLoopContext(VertxInternal vertx, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID, JsonObject config,
                           ClassLoader tccl) {
     super(vertx, internalBlockingPool, workerPool, deploymentID, config, tccl);
+  }
+
+  public EventLoopContext(VertxInternal vertx, EventLoop eventLoop, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID, JsonObject config,
+                          ClassLoader tccl) {
+    super(vertx, eventLoop, internalBlockingPool, workerPool, deploymentID, config, tccl);
   }
 
   public void executeAsync(Handler<Void> task) {

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -53,7 +53,6 @@ import io.vertx.core.http.impl.HttpServerImpl;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.metrics.impl.DummyVertxMetrics;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServer;
@@ -163,10 +162,10 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     ExecutorService workerExec = Executors.newFixedThreadPool(options.getWorkerPoolSize(),
         new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime()));
-    PoolMetrics workerPoolMetrics = isMetricsEnabled() ? metrics.createMetrics(workerExec, "worker", "vert.x-worker-thread", options.getWorkerPoolSize()) : null;
+    PoolMetrics workerPoolMetrics = metrics != null ? metrics.createMetrics(workerExec, "worker", "vert.x-worker-thread", options.getWorkerPoolSize()) : null;
     ExecutorService internalBlockingExec = Executors.newFixedThreadPool(options.getInternalBlockingPoolSize(),
         new VertxThreadFactory("vert.x-internal-blocking-", checker, true, options.getMaxWorkerExecuteTime()));
-    PoolMetrics internalBlockingPoolMetrics = isMetricsEnabled() ? metrics.createMetrics(internalBlockingExec, "worker", "vert.x-internal-blocking", options.getInternalBlockingPoolSize()) : null;
+    PoolMetrics internalBlockingPoolMetrics = metrics != null ? metrics.createMetrics(internalBlockingExec, "worker", "vert.x-internal-blocking", options.getInternalBlockingPoolSize()) : null;
     internalBlockingPool = new WorkerPool(internalBlockingExec, internalBlockingPoolMetrics);
     namedWorkerPools = new HashMap<>();
     workerPool = new WorkerPool(workerExec, workerPoolMetrics);
@@ -208,9 +207,11 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     }
     eventBus.start(ar2 -> {
       if (ar2.succeeded()) {
-        // If the metric provider wants to use the event bus, it cannot use it in its constructor as the event bus
-        // may not be initialized yet. We invokes the eventBusInitialized so it can starts using the event bus.
-        metrics.eventBusInitialized(eventBus);
+        if (metrics != null) {
+          // If the metric provider wants to use the event bus, it cannot use it in its constructor as the event bus
+          // may not be initialized yet. We invokes the eventBusInitialized so it can starts using the event bus.
+          metrics.eventBusInitialized(eventBus);
+        }
 
         if (resultHandler != null) {
           resultHandler.handle(Future.succeededFuture(this));
@@ -348,7 +349,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public boolean isMetricsEnabled() {
-    return metrics != null && metrics.isEnabled();
+    return metrics != null;
   }
 
   @Override
@@ -402,7 +403,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
         return metrics;
       }
     }
-    return DummyVertxMetrics.INSTANCE;
+    return null;
   }
 
   private ClusterManager getClusterManager(VertxOptions options) {
@@ -782,7 +783,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     boolean cancel() {
       if (cancelled.compareAndSet(false, true)) {
-        metrics.timerEnded(timerID, true);
+        if (metrics != null) {
+          metrics.timerEnded(timerID, true);
+        }
         future.cancel(false);
         return true;
       } else {
@@ -803,7 +806,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
       } else {
         future = el.schedule(toRun, delay, TimeUnit.MILLISECONDS);
       }
-      metrics.timerCreated(timerID);
+      if (metrics != null) {
+        metrics.timerCreated(timerID);
+      }
     }
 
     public void handle(Void v) {
@@ -821,7 +826,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     private void cleanupNonPeriodic() {
       VertxImpl.this.timeouts.remove(timerID);
-      metrics.timerEnded(timerID, false);
+      if (metrics != null) {
+        metrics.timerEnded(timerID, false);
+      }
       ContextImpl context = getContext();
       if (context != null) {
         context.removeCloseHook(this);
@@ -970,7 +977,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
     SharedWorkerPool sharedWorkerPool = namedWorkerPools.get(name);
     if (sharedWorkerPool == null) {
       ExecutorService workerExec = Executors.newFixedThreadPool(poolSize, new VertxThreadFactory(name + "-", checker, true, maxExecuteTime));
-      PoolMetrics workerMetrics = isMetricsEnabled() ? metrics.createMetrics(workerExec, "worker", name, poolSize) : null;
+      PoolMetrics workerMetrics = metrics != null ? metrics.createMetrics(workerExec, "worker", name, poolSize) : null;
       namedWorkerPools.put(name, sharedWorkerPool = new SharedWorkerPool(name, workerExec, workerMetrics));
     } else {
       sharedWorkerPool.refCount++;

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -117,8 +117,8 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
   private final FileResolver fileResolver;
   private final Map<ServerID, HttpServerImpl> sharedHttpServers = new HashMap<>();
   private final Map<ServerID, NetServerBase> sharedNetServers = new HashMap<>();
-  private final WorkerPool workerPool;
-  private final WorkerPool internalBlockingPool;
+  final WorkerPool workerPool;
+  final WorkerPool internalBlockingPool;
   private final ThreadFactory eventLoopThreadFactory;
   private final NioEventLoopGroup eventLoopGroup;
   private final NioEventLoopGroup acceptorEventLoopGroup;

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -231,7 +231,7 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
   @Override
   public DatagramSocket createDatagramSocket(DatagramSocketOptions options) {
-    return new DatagramSocketImpl(this, options);
+    return DatagramSocketImpl.create(this, options);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/impl/VertxThread.java
+++ b/src/main/java/io/vertx/core/impl/VertxThread.java
@@ -21,7 +21,7 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-final class VertxThread extends FastThreadLocalThread {
+public final class VertxThread extends FastThreadLocalThread {
 
   private final boolean worker;
   private final long maxExecTime;

--- a/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
+++ b/src/main/java/io/vertx/core/impl/WorkerExecutorImpl.java
@@ -49,7 +49,7 @@ class WorkerExecutorImpl implements Closeable, MetricsProvider, WorkerExecutorIn
   @Override
   public boolean isMetricsEnabled() {
     PoolMetrics metrics = pool.metrics();
-    return metrics != null && metrics.isEnabled();
+    return metrics != null;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -180,7 +180,10 @@ public abstract class ConnectionBase {
   public abstract NetworkMetrics metrics();
 
   protected synchronized void handleException(Throwable t) {
-    metrics().exceptionOccurred(metric(), remoteAddress(), t);
+    NetworkMetrics metrics = metrics();
+    if (metrics != null) {
+      metrics.exceptionOccurred(metric, remoteAddress(), t);
+    }
     if (exceptionHandler != null) {
       exceptionHandler.handle(t);
     } else {
@@ -190,7 +193,7 @@ public abstract class ConnectionBase {
 
   protected synchronized void handleClosed() {
     NetworkMetrics metrics = metrics();
-    if (metrics instanceof TCPMetrics) {
+    if (metrics != null && metrics instanceof TCPMetrics) {
       ((TCPMetrics) metrics).disconnected(metric(), remoteAddress());
     }
     if (closeHandler != null) {
@@ -222,14 +225,14 @@ public abstract class ConnectionBase {
 
   public void reportBytesRead(long numberOfBytes) {
     NetworkMetrics metrics = metrics();
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       metrics.bytesRead(metric(), remoteAddress(), numberOfBytes);
     }
   }
 
   public void reportBytesWritten(long numberOfBytes) {
     NetworkMetrics metrics = metrics();
-    if (metrics.isEnabled()) {
+    if (metrics != null) {
       metrics.bytesWritten(metric(), remoteAddress(), numberOfBytes);
     }
   }

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -179,6 +179,12 @@ public abstract class ConnectionBase {
     }
   }
 
+  /**
+   * @return the Netty channel - for internal usage only
+   */
+  public Channel channel() {
+    return chctx.channel();
+  }
 
   public ContextImpl getContext() {
     return context;

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -237,7 +237,7 @@ public abstract class ConnectionBase {
     }
   }
 
-  private boolean isSSL() {
+  public boolean isSSL() {
     return channel.pipeline().get(SslHandler.class) != null;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -50,6 +50,7 @@ public abstract class ConnectionBase {
 
   protected final VertxInternal vertx;
   protected final Channel channel;
+  protected final ChannelHandlerContext chctx;
   protected final ContextImpl context;
   private Handler<Throwable> exceptionHandler;
   private Handler<Void> closeHandler;
@@ -59,9 +60,10 @@ public abstract class ConnectionBase {
   private boolean needsAsyncFlush;
   private Object metric;
 
-  protected ConnectionBase(VertxInternal vertx, Channel channel, ContextImpl context) {
+  protected ConnectionBase(VertxInternal vertx, ChannelHandlerContext channel, ContextImpl context) {
     this.vertx = vertx;
-    this.channel = channel;
+    this.chctx = channel;
+    this.channel = channel.channel();
     this.context = context;
   }
 

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -65,7 +65,7 @@ public abstract class ConnectionBase {
     this.context = context;
   }
 
-  protected synchronized final void startRead() {
+  public synchronized final void startRead() {
     checkContext();
     read = true;
     if (ctxThread == null) {

--- a/src/main/java/io/vertx/core/net/impl/NetClientBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientBase.java
@@ -230,17 +230,15 @@ public abstract class NetClientBase<C extends ConnectionBase> implements Metrics
     ContextImpl.setContext(context);
     VertxNetHandler<C> handler = new VertxNetHandler<C>(ch, ctx -> createConnection(vertx, ctx, host, port, context, sslHelper, metrics), socketMap) {
       @Override
-      protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+      protected Object decode(Object msg, ByteBufAllocator allocator) throws Exception {
         return NetClientBase.this.safeObject(msg, allocator);
       }
-
       @Override
-      protected void handleMsgReceived(C conn, Object msg) {
-        NetClientBase.this.handleMsgReceived(conn, msg);
+      protected void handleMessage(C connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
+        NetClientBase.this.handleMsgReceived(connection, msg);
       }
     };
     ch.pipeline().addLast("handler", handler);
-
 
     // Need to set context before constructor is called as writehandler registration needs this
     C sock = handler.getConnection();

--- a/src/main/java/io/vertx/core/net/impl/NetClientBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientBase.java
@@ -36,6 +36,7 @@ import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
 
 import java.util.Map;
 import java.util.Objects;
@@ -79,7 +80,8 @@ public abstract class NetClientBase<C extends ConnectionBase> implements Metrics
     } else {
       creatingContext = null;
     }
-    this.metrics = vertx.metricsSPI().createMetrics(options);
+    VertxMetrics metrics = vertx.metricsSPI();
+    this.metrics = metrics != null ? metrics.createMetrics(options) : null;
   }
 
   /**
@@ -105,7 +107,9 @@ public abstract class NetClientBase<C extends ConnectionBase> implements Metrics
         creatingContext.removeCloseHook(closeHook);
       }
       closed = true;
-      metrics.close();
+      if (metrics != null) {
+        metrics.close();
+      }
     }
   }
 
@@ -238,7 +242,9 @@ public abstract class NetClientBase<C extends ConnectionBase> implements Metrics
     handler.conn = sock;
     socketMap.put(ch, sock);
     context.executeFromIO(() -> {
-      sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
+      if (metrics != null) {
+        sock.metric(metrics.connected(sock.remoteAddress(), sock.remoteName()));
+      }
       connectHandler.handle(Future.succeededFuture(sock));
     });
   }

--- a/src/main/java/io/vertx/core/net/impl/NetClientBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientBase.java
@@ -19,6 +19,7 @@ package io.vertx.core.net.impl;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.FixedRecvByteBufAllocator;
@@ -89,7 +90,7 @@ public abstract class NetClientBase<C extends ConnectionBase> implements Metrics
    *
    * @return the created connection
    */
-  protected abstract C createConnection(VertxInternal vertx, Channel channel, String host, int port,
+  protected abstract C createConnection(VertxInternal vertx, ChannelHandlerContext chctx, String host, int port,
                                         ContextImpl context, SSLHelper helper, TCPMetrics metrics);
 
   protected abstract void handleMsgReceived(C conn, Object msg);
@@ -237,8 +238,8 @@ public abstract class NetClientBase<C extends ConnectionBase> implements Metrics
   private void connected(ContextImpl context, Channel ch, Handler<AsyncResult<C>> connectHandler, String host, int port) {
     // Need to set context before constructor is called as writehandler registration needs this
     ContextImpl.setContext(context);
-    C sock = createConnection(vertx, ch, host, port, context, sslHelper, metrics);
     VertxNetHandler handler = ch.pipeline().get(VertxNetHandler.class);
+    C sock = createConnection(vertx, handler.context(), host, port, context, sslHelper, metrics);
     handler.conn = sock;
     socketMap.put(ch, sock);
     context.executeFromIO(() -> {

--- a/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetClientImpl.java
@@ -19,6 +19,7 @@ package io.vertx.core.net.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -91,8 +92,8 @@ public class NetClientImpl extends NetClientBase<NetSocketImpl> implements NetCl
   }
 
   @Override
-  protected NetSocketImpl createConnection(VertxInternal vertx, Channel channel, String host, int port, ContextImpl context, SSLHelper helper, TCPMetrics metrics) {
-    return new NetSocketImpl(vertx, channel, host, port, context, helper, metrics);
+  protected NetSocketImpl createConnection(VertxInternal vertx, ChannelHandlerContext chctx, String host, int port, ContextImpl context, SSLHelper helper, TCPMetrics metrics) {
+    return new NetSocketImpl(vertx, chctx, host, port, context, helper, metrics);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/NetServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerBase.java
@@ -356,9 +356,9 @@ public abstract class NetServerBase<C extends ConnectionBase> implements Closeab
     private void connected(Channel ch, HandlerHolder<Handler<? super C>> handler) {
       // Need to set context before constructor is called as writehandler registration needs this
       ContextImpl.setContext(handler.context);
-      C sock = createConnection(vertx, ch, handler.context, sslHelper, metrics);
-      socketMap.put(ch, sock);
       VertxNetHandler netHandler = ch.pipeline().get(VertxNetHandler.class);
+      C sock = createConnection(vertx, netHandler.context(), handler.context, sslHelper, metrics);
+      socketMap.put(ch, sock);
       netHandler.conn = sock;
       handler.context.executeFromIO(() -> {
         if (metrics != null) {
@@ -378,7 +378,7 @@ public abstract class NetServerBase<C extends ConnectionBase> implements Closeab
    *
    * @return the created connection
    */
-  protected abstract C createConnection(VertxInternal vertx, Channel channel, ContextImpl context,
+  protected abstract C createConnection(VertxInternal vertx, ChannelHandlerContext chctx, ContextImpl context,
                                         SSLHelper helper, TCPMetrics metrics);
 
   /**

--- a/src/main/java/io/vertx/core/net/impl/NetServerBase.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerBase.java
@@ -328,11 +328,11 @@ public abstract class NetServerBase<C extends ConnectionBase> implements Closeab
     ContextImpl.setContext(handler.context);
     VertxNetHandler<C> nh = new VertxNetHandler<C>(ch, ctx -> createConnection(vertx, ctx, handler.context, sslHelper, metrics), socketMap) {
       @Override
-      protected void handleMsgReceived(C conn, Object msg) {
-        NetServerBase.this.handleMsgReceived(conn, msg);
+      protected void handleMessage(C connection, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
+        NetServerBase.this.handleMsgReceived(connection, msg);
       }
       @Override
-      protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+      protected Object decode(Object msg, ByteBufAllocator allocator) throws Exception {
         return NetServerBase.this.safeObject(msg, allocator);
       }
     };

--- a/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetServerImpl.java
@@ -155,8 +155,8 @@ public class NetServerImpl extends NetServerBase<NetSocketImpl> implements NetSe
   }
 
   @Override
-  protected NetSocketImpl createConnection(VertxInternal vertx, Channel channel, ContextImpl context, SSLHelper helper, TCPMetrics metrics) {
-    return new NetSocketImpl(vertx, channel, context, helper, metrics);
+  protected NetSocketImpl createConnection(VertxInternal vertx, ChannelHandlerContext chctx, ContextImpl context, SSLHelper helper, TCPMetrics metrics) {
+    return new NetSocketImpl(vertx, chctx, context, helper, metrics);
   }
 
   /*

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -21,6 +21,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.CharsetUtil;
@@ -72,12 +73,12 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   private Buffer pendingData;
   private boolean paused = false;
 
-  public NetSocketImpl(VertxInternal vertx, Channel channel, ContextImpl context,
+  public NetSocketImpl(VertxInternal vertx, ChannelHandlerContext channel, ContextImpl context,
                        SSLHelper helper, TCPMetrics metrics) {
     this(vertx, channel, null, 0, context, helper, metrics);
   }
 
-  public NetSocketImpl(VertxInternal vertx, Channel channel, String host, int port, ContextImpl context,
+  public NetSocketImpl(VertxInternal vertx, ChannelHandlerContext channel, String host, int port, ContextImpl context,
                        SSLHelper helper, TCPMetrics metrics) {
     super(vertx, channel, context);
     this.helper = helper;

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -239,8 +239,8 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
   @Override
   public synchronized void close() {
     // Close after all data is written
-    channel.write(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
-    channel.flush();
+    chctx.write(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+    chctx.flush();
   }
 
   @Override
@@ -250,7 +250,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
 
   @Override
   public NetSocket upgradeToSsl(String serverName, Handler<Void> handler) {
-    ChannelOutboundHandler sslHandler = (ChannelOutboundHandler) channel.pipeline().get("ssl");
+    ChannelOutboundHandler sslHandler = (ChannelOutboundHandler) chctx.pipeline().get("ssl");
     if (sslHandler == null) {
       if (host != null) {
         sslHandler = new SslHandler(helper.createEngine(vertx, host, port, serverName));
@@ -261,7 +261,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocket {
           sslHandler = new SslHandler(helper.createEngine(vertx));
         }
       }
-      channel.pipeline().addFirst("ssl", sslHandler);
+      chctx.pipeline().addFirst("ssl", sslHandler);
     }
     io.netty.util.concurrent.Future<Channel> handshakeFuture;
     if (sslHandler instanceof SslHandler) {

--- a/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -31,7 +31,7 @@ import io.vertx.core.impl.ContextTask;
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDuplexHandler {
+public abstract class   VertxHandler<C extends ConnectionBase> extends ChannelDuplexHandler {
 
   private C conn;
   private ContextTask endReadAndFlush;

--- a/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -31,9 +31,17 @@ import io.vertx.core.impl.ContextImpl;
  */
 public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDuplexHandler {
 
-  protected abstract C getConnection();
+  private C conn;
 
-  protected abstract C removeConnection();
+  protected void setConnection(C connection) {
+    conn = connection;
+  }
+
+  public C getConnection() {
+    return conn;
+  }
+
+  protected abstract void removeConnection();
 
   protected ContextImpl getContext(C connection) {
     return connection.getContext();
@@ -89,9 +97,9 @@ public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDupl
 
   @Override
   public void channelInactive(ChannelHandlerContext chctx) throws Exception {
-    C connection = removeConnection();
-    ContextImpl context = getContext(connection);
-    context.executeFromIO(connection::handleClosed);
+    removeConnection();
+    ContextImpl context = getContext(conn);
+    context.executeFromIO(conn::handleClosed);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/VertxHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxHandler.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.ContextTask;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
@@ -32,9 +33,11 @@ import io.vertx.core.impl.ContextImpl;
 public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDuplexHandler {
 
   private C conn;
+  private ContextTask endReadAndFlush;
 
   protected void setConnection(C connection) {
     conn = connection;
+    endReadAndFlush = conn::endReadAndFlush;
   }
 
   public C getConnection() {
@@ -101,7 +104,7 @@ public abstract class VertxHandler<C extends ConnectionBase> extends ChannelDupl
   @Override
   public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
     ContextImpl context = conn.getContext();
-    context.executeFromIO(conn::endReadAndFlush);
+    context.executeFromIO(endReadAndFlush);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
@@ -31,6 +31,7 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
 
   private final Channel ch;
   private final Map<Channel, C> connectionMap;
+  private ChannelHandlerContext chctx;
   C conn; // We should try to make this private
 
   public VertxNetHandler(Channel ch, Map<Channel, C> connectionMap) {
@@ -42,6 +43,15 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
     this.ch = ch;
     this.connectionMap = connectionMap;
     this.conn = conn;
+  }
+
+  @Override
+  public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    chctx = ctx;
+  }
+
+  ChannelHandlerContext context() {
+    return chctx;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
@@ -31,17 +31,15 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
 
   private final Function<ChannelHandlerContext, C> connectionFactory;
   private final Channel ch;
-  private final Map<Channel, C> connectionMap;
   private ChannelHandlerContext chctx;
 
-  public VertxNetHandler(Channel ch, Function<ChannelHandlerContext, C> connectionFactory, Map<Channel, C> connectionMap) {
+  public VertxNetHandler(Channel ch, Function<ChannelHandlerContext, C> connectionFactory) {
     this.ch = ch;
-    this.connectionMap = connectionMap;
     this.connectionFactory = connectionFactory;
   }
 
-  public VertxNetHandler(Channel ch, C conn, Map<Channel, C> connectionMap) {
-    this(ch, ctx -> conn, connectionMap);
+  public VertxNetHandler(Channel ch, C conn) {
+    this(ch, ctx -> conn);
   }
 
   @Override
@@ -52,11 +50,6 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
 
   ChannelHandlerContext context() {
     return chctx;
-  }
-
-  @Override
-  protected void removeConnection() {
-    connectionMap.remove(ch);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
@@ -20,9 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import io.vertx.core.impl.ContextImpl;
-import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.spi.metrics.TCPMetrics;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -36,7 +33,6 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
   private final Channel ch;
   private final Map<Channel, C> connectionMap;
   private ChannelHandlerContext chctx;
-  private C conn;
 
   public VertxNetHandler(Channel ch, Function<ChannelHandlerContext, C> connectionFactory, Map<Channel, C> connectionMap) {
     this.ch = ch;
@@ -51,7 +47,7 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     chctx = ctx;
-    conn = connectionFactory.apply(ctx);
+    setConnection(connectionFactory.apply(ctx));
   }
 
   ChannelHandlerContext context() {
@@ -59,16 +55,8 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
   }
 
   @Override
-  protected C getConnection() {
-    return conn;
-  }
-
-  @Override
-  protected C removeConnection() {
+  protected void removeConnection() {
     connectionMap.remove(ch);
-    C conn = this.conn;
-    this.conn = null;
-    return conn;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
+++ b/src/main/java/io/vertx/core/net/impl/VertxNetHandler.java
@@ -72,18 +72,7 @@ public abstract class VertxNetHandler<C extends ConnectionBase> extends VertxHan
   }
 
   @Override
-  protected void channelRead(C conn, ContextImpl context, ChannelHandlerContext chctx, Object msg) throws Exception {
-    if (conn != null) {
-      context.executeFromIO(() -> handleMsgReceived(conn, msg));
-    } else {
-      // just discard
-    }
-  }
-
-  protected abstract void handleMsgReceived(C conn, Object msg);
-
-  @Override
-  protected Object safeObject(Object msg, ByteBufAllocator allocator) throws Exception {
+  protected Object decode(Object msg, ByteBufAllocator allocator) throws Exception {
     if (msg instanceof ByteBuf) {
       return safeBuffer((ByteBuf) msg, allocator);
     }

--- a/src/main/java/io/vertx/core/spi/metrics/Metrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/Metrics.java
@@ -24,7 +24,7 @@ package io.vertx.core.spi.metrics;
  */
 public interface Metrics {
 
-  String DISABLE_METRICS_PROPERTY_NAME = "vertx.disabledMetrics";
+  String DISABLE_METRICS_PROPERTY_NAME = "vertx.disableMetrics";
 
   boolean METRICS_ENABLED = !Boolean.getBoolean(DISABLE_METRICS_PROPERTY_NAME);
 

--- a/src/main/java/io/vertx/core/spi/metrics/Metrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/Metrics.java
@@ -32,6 +32,7 @@ public interface Metrics {
    * Whether the metrics are enabled.
    *
    * @return true if the metrics are enabled.
+   * @deprecated the SPI metrics should instead return a {@code null} object to signal that metrics is not provided
    */
   @Deprecated
   boolean isEnabled();

--- a/src/main/java/io/vertx/core/spi/metrics/Metrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/Metrics.java
@@ -24,11 +24,16 @@ package io.vertx.core.spi.metrics;
  */
 public interface Metrics {
 
+  String DISABLE_METRICS_PROPERTY_NAME = "vertx.disabledMetrics";
+
+  boolean METRICS_ENABLED = !Boolean.getBoolean(DISABLE_METRICS_PROPERTY_NAME);
+
   /**
    * Whether the metrics are enabled.
    *
    * @return true if the metrics are enabled.
    */
+  @Deprecated
   boolean isEnabled();
 
   /**

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -84,7 +84,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * This method should be called only once.
    *
    * @param eventBus the Vert.x event bus
-   * @return the event bus metrics SPI
+   * @return the event bus metrics SPI or {@code null} when metrics are disabled
    */
   EventBusMetrics createMetrics(EventBus eventBus);
 
@@ -101,7 +101,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * @param server       the Vert.x http server
    * @param localAddress localAddress the local address the net socket is listening on
    * @param options      the options used to create the {@link io.vertx.core.http.HttpServer}
-   * @return the http server metrics SPI or null when metrics are disabled
+   * @return the http server metrics SPI or {@code null} when metrics are disabled
    */
   HttpServerMetrics<?, ?, ?> createMetrics(HttpServer server, SocketAddress localAddress, HttpServerOptions options);
 
@@ -112,7 +112,7 @@ public interface VertxMetrics extends Metrics, Measured {
    *
    * @param client  the Vert.x http client
    * @param options the options used to create the {@link io.vertx.core.http.HttpClient}
-   * @return the http client metrics SPI or null when metrics are disabled
+   * @return the http client metrics SPI or {@code null} when metrics are disabled
    */
   HttpClientMetrics<?, ?, ?, ?, ?> createMetrics(HttpClient client, HttpClientOptions options);
 
@@ -128,7 +128,7 @@ public interface VertxMetrics extends Metrics, Measured {
    *
    * @param localAddress localAddress the local address the net socket is listening on
    * @param options      the options used to create the {@link NetServer}
-   * @return the net server metrics SPI or null when metrics are disabled
+   * @return the net server metrics SPI or {@code null} when metrics are disabled
    */
   TCPMetrics<?> createMetrics(SocketAddress localAddress, NetServerOptions options);
 
@@ -138,7 +138,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * No specific thread and context can be expected when this method is called.
    *
    * @param options the options used to create the {@link NetClient}
-   * @return the net client metrics SPI or null when metrics are disabled
+   * @return the net client metrics SPI or {@code null} when metrics are disabled
    */
   TCPMetrics<?> createMetrics(NetClientOptions options);
 
@@ -149,7 +149,7 @@ public interface VertxMetrics extends Metrics, Measured {
    *
    * @param socket  the Vert.x datagram socket
    * @param options the options used to create the {@link io.vertx.core.datagram.DatagramSocket}
-   * @return the datagram metrics SPI
+   * @return the datagram metrics SPI or {@code null} when metrics are disabled
    */
   DatagramSocketMetrics createMetrics(DatagramSocket socket, DatagramSocketOptions options);
 
@@ -171,7 +171,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * @param poolType the type of the pool e.g worker, datasource, etc..
    * @param poolName the name of the pool
    * @param maxPoolSize the pool max size, or -1 if the number cannot be determined
-   * @return the thread pool metrics SPI  or null when metrics are disabled
+   * @return the thread pool metrics SPI or {@code null} when metrics are disabled
    */
   <P> PoolMetrics<?> createMetrics(P pool, String poolType, String poolName, int maxPoolSize);
 }

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -101,7 +101,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * @param server       the Vert.x http server
    * @param localAddress localAddress the local address the net socket is listening on
    * @param options      the options used to create the {@link io.vertx.core.http.HttpServer}
-   * @return the http server metrics SPI
+   * @return the http server metrics SPI or null when metrics are disabled
    */
   HttpServerMetrics<?, ?, ?> createMetrics(HttpServer server, SocketAddress localAddress, HttpServerOptions options);
 
@@ -112,7 +112,7 @@ public interface VertxMetrics extends Metrics, Measured {
    *
    * @param client  the Vert.x http client
    * @param options the options used to create the {@link io.vertx.core.http.HttpClient}
-   * @return the http client metrics SPI
+   * @return the http client metrics SPI or null when metrics are disabled
    */
   HttpClientMetrics<?, ?, ?, ?, ?> createMetrics(HttpClient client, HttpClientOptions options);
 
@@ -128,7 +128,7 @@ public interface VertxMetrics extends Metrics, Measured {
    *
    * @param localAddress localAddress the local address the net socket is listening on
    * @param options      the options used to create the {@link NetServer}
-   * @return the net server metrics SPI
+   * @return the net server metrics SPI or null when metrics are disabled
    */
   TCPMetrics<?> createMetrics(SocketAddress localAddress, NetServerOptions options);
 
@@ -138,7 +138,7 @@ public interface VertxMetrics extends Metrics, Measured {
    * No specific thread and context can be expected when this method is called.
    *
    * @param options the options used to create the {@link NetClient}
-   * @return the net client metrics SPI
+   * @return the net client metrics SPI or null when metrics are disabled
    */
   TCPMetrics<?> createMetrics(NetClientOptions options);
 
@@ -170,7 +170,8 @@ public interface VertxMetrics extends Metrics, Measured {
    * @param pool the pool of resource, it can be used by the metrics implementation to gather extra statistics
    * @param poolType the type of the pool e.g worker, datasource, etc..
    * @param poolName the name of the pool
-   * @param maxPoolSize the pool max size, or -1 if the number cannot be determined   @return the thread pool metrics SPI
+   * @param maxPoolSize the pool max size, or -1 if the number cannot be determined
+   * @return the thread pool metrics SPI  or null when metrics are disabled
    */
   <P> PoolMetrics<?> createMetrics(P pool, String poolType, String poolName, int maxPoolSize);
 }

--- a/src/test/assembly/benchmarks.xml
+++ b/src/test/assembly/benchmarks.xml
@@ -1,0 +1,22 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.1 http://maven.apache.org/xsd/assembly-1.1.1.xsd">
+  <id>benchmarks</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.testOutputDirectory}</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <unpack>true</unpack>
+      <scope>test</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Threads(1)
+@BenchmarkMode(Mode.Throughput)
+@Fork(value = 3, jvmArgs = { "-XX:+UseBiasedLocking", "-XX:BiasedLockingStartupDelay=0", "-XX:+AggressiveOpts"})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public abstract class BenchmarkBase {
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
 @Threads(1)
 @BenchmarkMode(Mode.Throughput)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "-XX:+UseBiasedLocking",
     "-XX:BiasedLockingStartupDelay=0",
     "-XX:+AggressiveOpts",

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -28,11 +28,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
 @Threads(1)
 @BenchmarkMode(Mode.Throughput)
-@Fork(value = 3, jvmArgs = { "-XX:+UseBiasedLocking", "-XX:BiasedLockingStartupDelay=0", "-XX:+AggressiveOpts"})
+@Fork(value = 1, jvmArgs = { "-XX:+UseBiasedLocking", "-XX:BiasedLockingStartupDelay=0", "-XX:+AggressiveOpts"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class BenchmarkBase {
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -32,7 +32,13 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
 @Threads(1)
 @BenchmarkMode(Mode.Throughput)
-@Fork(value = 1, jvmArgs = { "-XX:+UseBiasedLocking", "-XX:BiasedLockingStartupDelay=0", "-XX:+AggressiveOpts"})
+@Fork(value = 1, jvmArgs = {
+    "-XX:+UseBiasedLocking",
+    "-XX:BiasedLockingStartupDelay=0",
+    "-XX:+AggressiveOpts",
+    "-Djmh.executor=CUSTOM",
+    "-Djmh.executor.class=io.vertx.core.impl.VertxExecutorService"
+})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public abstract class BenchmarkBase {
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -28,11 +28,11 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
-@Threads(1)
+@Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@Threads(16)
 @BenchmarkMode(Mode.Throughput)
-@Fork(value = 1, jvmArgs = {
+@Fork(value = 1, jvmArgsAppend = {
     "-XX:+UseBiasedLocking",
     "-XX:BiasedLockingStartupDelay=0",
     "-XX:+AggressiveOpts",

--- a/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/BenchmarkBase.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Warmup(iterations = 20, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
-@Threads(16)
+@Threads(1)
 @BenchmarkMode(Mode.Throughput)
 @Fork(value = 1, jvmArgsAppend = {
     "-XX:+UseBiasedLocking",

--- a/src/test/benchmarks/io/vertx/benchmarks/EmptyBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/EmptyBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@State(Scope.Thread)
+public class EmptyBenchmark {
+
+  @Benchmark
+  public void baseline(Blackhole blackhole) {
+    blackhole.consume("whatever");
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
@@ -22,7 +22,6 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
 
 import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
 
@@ -44,14 +43,12 @@ public class HeadersContainsBenchmark extends BenchmarkBase {
   }
 
   @Benchmark
-  public void nettySmall(Blackhole blackhole) throws Exception {
-    boolean result = nettySmallHeaders.contains(HeadersUtils.CONTENT_LENGTH_HEADER);
-    blackhole.consume(result);
+  public boolean nettySmall() throws Exception {
+    return nettySmallHeaders.contains(HeadersUtils.CONTENT_LENGTH_HEADER);
   }
 
   @Benchmark
-  public void vertxSmall(Blackhole blackhole) throws Exception {
-    boolean result = vertxSmallHeaders.contains(HeadersUtils.CONTENT_LENGTH_HEADER);
-    blackhole.consume(result);
+  public boolean vertxSmall() throws Exception {
+    return vertxSmallHeaders.contains(HeadersUtils.CONTENT_LENGTH_HEADER);
   }
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersContainsBenchmark.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@State(Scope.Thread)
+public class HeadersContainsBenchmark extends BenchmarkBase {
+
+  private HttpHeaders nettySmallHeaders;
+  private VertxHttpHeaders vertxSmallHeaders;
+
+  @Setup
+  public void setup() {
+    nettySmallHeaders = new DefaultHttpHeaders();
+    vertxSmallHeaders = new VertxHttpHeaders();
+    setBaseHeaders(nettySmallHeaders);
+    setBaseHeaders(vertxSmallHeaders);
+  }
+
+  @Benchmark
+  public void nettySmall(Blackhole blackhole) throws Exception {
+    boolean result = nettySmallHeaders.contains(HeadersUtils.CONTENT_LENGTH_HEADER);
+    blackhole.consume(result);
+  }
+
+  @Benchmark
+  public void vertxSmall(Blackhole blackhole) throws Exception {
+    boolean result = vertxSmallHeaders.contains(HeadersUtils.CONTENT_LENGTH_HEADER);
+    blackhole.consume(result);
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@State(Scope.Thread)
+public class HeadersEncodeBenchmark extends BenchmarkBase {
+
+  static class PublicEncoder extends HttpResponseEncoder {
+
+    // Make it public
+    @Override
+    public void encodeHeaders(HttpHeaders headers, ByteBuf buf) throws Exception {
+      super.encodeHeaders(headers, buf);
+    }
+  }
+
+  private PublicEncoder encoder;
+  private ByteBuf byteBuf;
+  private HttpHeaders emptyHeaders;
+  private HttpHeaders nettySmallHeaders;
+  private HttpHeaders vertxSmallHeaders;
+
+  @Setup
+  public void setup() {
+    byteBuf = Unpooled.buffer(1024);
+    encoder = new PublicEncoder();
+    emptyHeaders = EmptyHttpHeaders.INSTANCE;
+    nettySmallHeaders = new DefaultHttpHeaders();
+    vertxSmallHeaders = new VertxHttpHeaders();
+    setBaseHeaders(nettySmallHeaders);
+    setBaseHeaders(vertxSmallHeaders);
+  }
+
+  @Benchmark
+  public void baseline(Blackhole blackhole) throws Exception {
+    byteBuf.resetWriterIndex();
+    encoder.encodeHeaders(emptyHeaders, byteBuf);
+    blackhole.consume(byteBuf);
+  }
+
+  @Benchmark
+  public void nettySmall(Blackhole blackhole) throws Exception {
+    byteBuf.resetWriterIndex();
+    encoder.encodeHeaders(nettySmallHeaders, byteBuf);
+    blackhole.consume(byteBuf);
+  }
+
+  @Benchmark
+  public void vertxSmall(Blackhole blackhole) throws Exception {
+    byteBuf.resetWriterIndex();
+    encoder.encodeHeaders(vertxSmallHeaders, byteBuf);
+    blackhole.consume(byteBuf);
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersEncodeBenchmark.java
@@ -23,10 +23,10 @@ import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
 
 import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
 
@@ -35,6 +35,10 @@ import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
  */
 @State(Scope.Thread)
 public class HeadersEncodeBenchmark extends BenchmarkBase {
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void consume(final ByteBuf buf) {
+  }
 
   static class PublicEncoder extends HttpResponseEncoder {
 
@@ -63,23 +67,23 @@ public class HeadersEncodeBenchmark extends BenchmarkBase {
   }
 
   @Benchmark
-  public void baseline(Blackhole blackhole) throws Exception {
+  public void baseline() throws Exception {
     byteBuf.resetWriterIndex();
     encoder.encodeHeaders(emptyHeaders, byteBuf);
-    blackhole.consume(byteBuf);
+    consume(byteBuf);
   }
 
   @Benchmark
-  public void nettySmall(Blackhole blackhole) throws Exception {
+  public void nettySmall() throws Exception {
     byteBuf.resetWriterIndex();
     encoder.encodeHeaders(nettySmallHeaders, byteBuf);
-    blackhole.consume(byteBuf);
+    consume(byteBuf);
   }
 
   @Benchmark
-  public void vertxSmall(Blackhole blackhole) throws Exception {
+  public void vertxSmall() throws Exception {
     byteBuf.resetWriterIndex();
     encoder.encodeHeaders(vertxSmallHeaders, byteBuf);
-    blackhole.consume(byteBuf);
+    consume(byteBuf);
   }
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersSetBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersSetBenchmark.java
@@ -15,19 +15,43 @@
  */
 package io.vertx.benchmarks;
 
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
+
+import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @State(Scope.Thread)
-public class EmptyBenchmark {
+public class HeadersSetBenchmark extends BenchmarkBase {
+
+  private HttpHeaders nettySmallHeaders;
+  private VertxHttpHeaders vertxSmallHeaders;
+
+  @Setup
+  public void setup() {
+    nettySmallHeaders = new DefaultHttpHeaders();
+    vertxSmallHeaders = new VertxHttpHeaders();
+  }
 
   @Benchmark
-  public void baseline(Blackhole blackhole) {
-    blackhole.consume("whatever");
+  public void nettySmall(Blackhole blackhole) throws Exception {
+    nettySmallHeaders.clear();
+    setBaseHeaders(nettySmallHeaders);
+    blackhole.consume(nettySmallHeaders);
+  }
+
+  @Benchmark
+  public void vertxSmall(Blackhole blackhole) throws Exception {
+    vertxSmallHeaders.clear();
+    setBaseHeaders(vertxSmallHeaders);
+    blackhole.consume(vertxSmallHeaders);
   }
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersSetBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersSetBenchmark.java
@@ -19,10 +19,10 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
 
 import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
 
@@ -31,6 +31,10 @@ import static io.vertx.benchmarks.HeadersUtils.setBaseHeaders;
  */
 @State(Scope.Thread)
 public class HeadersSetBenchmark extends BenchmarkBase {
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void consume(final HttpHeaders headers) {
+  }
 
   private HttpHeaders nettySmallHeaders;
   private VertxHttpHeaders vertxSmallHeaders;
@@ -42,16 +46,16 @@ public class HeadersSetBenchmark extends BenchmarkBase {
   }
 
   @Benchmark
-  public void nettySmall(Blackhole blackhole) throws Exception {
+  public void nettySmall() throws Exception {
     nettySmallHeaders.clear();
     setBaseHeaders(nettySmallHeaders);
-    blackhole.consume(nettySmallHeaders);
+    consume(nettySmallHeaders);
   }
 
   @Benchmark
-  public void vertxSmall(Blackhole blackhole) throws Exception {
+  public void vertxSmall() throws Exception {
     vertxSmallHeaders.clear();
     setBaseHeaders(vertxSmallHeaders);
-    blackhole.consume(vertxSmallHeaders);
+    consume(vertxSmallHeaders);
   }
 }

--- a/src/test/benchmarks/io/vertx/benchmarks/HeadersUtils.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HeadersUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.netty.handler.codec.http.HttpHeaders;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public abstract class HeadersUtils {
+
+  public static final DateFormat DATE_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyyy HH:mm:ss z");
+  public static final CharSequence VERTX_HEADER = io.vertx.core.http.HttpHeaders.createOptimized("vert.x");
+  public static final CharSequence TEXT_PLAIN_HEADER = io.vertx.core.http.HttpHeaders.createOptimized("text/plain");
+  public static final CharSequence CONTENT_LENGTH_HEADER = io.vertx.core.http.HttpHeaders.createOptimized("20");
+  public static final CharSequence DATE_HEADER = io.vertx.core.http.HttpHeaders.createOptimized(DATE_FORMAT.format(new Date()));
+
+  public static void setBaseHeaders(HttpHeaders headers) {
+    headers.add(io.vertx.core.http.HttpHeaders.CONTENT_TYPE, TEXT_PLAIN_HEADER);
+    headers.add(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH, CONTENT_LENGTH_HEADER);
+    headers.add(io.vertx.core.http.HttpHeaders.SERVER, VERTX_HEADER);
+    headers.add(io.vertx.core.http.HttpHeaders.DATE, DATE_HEADER);
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AsciiString;
+import io.netty.util.CharsetUtil;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.HttpServerImpl;
+import io.vertx.core.http.impl.ServerConnection;
+import io.vertx.core.impl.ContextImpl;
+import io.vertx.core.impl.EventLoopContext;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.impl.HandlerHolder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@State(Scope.Thread)
+public class HttpServerBenchmark extends BenchmarkBase {
+
+  VertxInternal vertx;
+  EmbeddedChannel vertxChannel;
+  EmbeddedChannel nettyChannel;
+  ByteBuf GET;
+
+  private static final CharSequence RESPONSE_TYPE_PLAIN = io.vertx.core.http.HttpHeaders.createOptimized("text/plain");
+
+  private static final String HELLO_WORLD = "Hello, world!";
+  private static final Buffer HELLO_WORLD_BUFFER = Buffer.buffer(HELLO_WORLD);
+
+  private static final CharSequence HEADER_SERVER = io.vertx.core.http.HttpHeaders.createOptimized("server");
+  private static final CharSequence HEADER_DATE = io.vertx.core.http.HttpHeaders.createOptimized("date");
+  private static final CharSequence HEADER_CONTENT_TYPE = io.vertx.core.http.HttpHeaders.createOptimized("content-type");
+  private static final CharSequence HEADER_CONTENT_LENGTH = io.vertx.core.http.HttpHeaders.createOptimized("content-length");
+
+  private static final CharSequence HELLO_WORLD_LENGTH = io.vertx.core.http.HttpHeaders.createOptimized("" + HELLO_WORLD.length());
+  private static final CharSequence SERVER = io.vertx.core.http.HttpHeaders.createOptimized("vert.x");
+  private static final CharSequence DATE_STRING = io.vertx.core.http.HttpHeaders.createOptimized(java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME.format(java.time.ZonedDateTime.now()));
+
+  @Setup
+  public void setup() {
+    vertx = (VertxInternal) Vertx.vertx();
+    HttpServerOptions options = new HttpServerOptions();
+    Map<Channel, ServerConnection> connectionMap = new HashMap<>();
+    vertxChannel = new EmbeddedChannel(
+        new HttpRequestDecoder(
+            options.getMaxInitialLineLength(),
+            options.getMaxHeaderSize(),
+            options.getMaxChunkSize(),
+            false,
+            options.getDecoderInitialBufferSize()),
+        new HttpResponseEncoder()
+    );
+    ContextImpl context = new EventLoopContext(vertx, vertxChannel.eventLoop(), null, null, null, new JsonObject(), Thread.currentThread().getContextClassLoader());
+    ServerConnection connection = new ServerConnection(vertx, null, new HttpServerOptions(), vertxChannel, context, "localhost", null);
+    Handler<HttpServerRequest> app = request -> {
+      HttpServerResponse response = request.response();
+      MultiMap headers = response.headers();
+      headers
+          .add(HEADER_CONTENT_TYPE, RESPONSE_TYPE_PLAIN)
+          .add(HEADER_SERVER, SERVER)
+          .add(HEADER_DATE, DATE_STRING)
+          .add(HEADER_CONTENT_LENGTH, HELLO_WORLD_LENGTH);
+      response.end(HELLO_WORLD_BUFFER);
+    };
+    HandlerHolder<HttpServerImpl.Handlers> holder = new HandlerHolder<>(context, new HttpServerImpl.Handlers(app, null, null));
+    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(connectionMap, vertxChannel, holder, connection, null);
+    vertxChannel.pipeline().addLast("handler", handler);
+    GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
+        "GET / HTTP/1.1\r\n" +
+            "\r\n").getBytes()));
+
+    nettyChannel = new EmbeddedChannel(new HttpRequestDecoder(
+        options.getMaxInitialLineLength(),
+        options.getMaxHeaderSize(),
+        options.getMaxChunkSize(),
+        false,
+        options.getDecoderInitialBufferSize()),
+        new HttpResponseEncoder(), new SimpleChannelInboundHandler<HttpRequest>() {
+
+      private final byte[] STATIC_PLAINTEXT = "Hello, World!".getBytes(CharsetUtil.UTF_8);
+      private final int STATIC_PLAINTEXT_LEN = STATIC_PLAINTEXT.length;
+      private final ByteBuf PLAINTEXT_CONTENT_BUFFER = Unpooled.unreleasableBuffer(Unpooled.directBuffer().writeBytes(STATIC_PLAINTEXT));
+      private final CharSequence PLAINTEXT_CLHEADER_VALUE = new AsciiString(String.valueOf(STATIC_PLAINTEXT_LEN));
+
+      private final CharSequence TYPE_PLAIN = new AsciiString("text/plain");
+      private final CharSequence SERVER_NAME = new AsciiString("Netty");
+      private final CharSequence CONTENT_TYPE_ENTITY = HttpHeaderNames.CONTENT_TYPE;
+      private final CharSequence DATE_ENTITY = HttpHeaderNames.DATE;
+      private final CharSequence CONTENT_LENGTH_ENTITY = HttpHeaderNames.CONTENT_LENGTH;
+      private final CharSequence SERVER_ENTITY = HttpHeaderNames.SERVER;
+
+      private final DateFormat FORMAT = new SimpleDateFormat("E, dd MMM yyyy HH:mm:ss z");
+      private final CharSequence date = new AsciiString(FORMAT.format(new Date()));
+
+      @Override
+      protected void channelRead0(ChannelHandlerContext ctx, HttpRequest msg) throws Exception {
+        writeResponse(ctx, msg, PLAINTEXT_CONTENT_BUFFER.duplicate(), TYPE_PLAIN, PLAINTEXT_CLHEADER_VALUE);
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND, Unpooled.EMPTY_BUFFER, false);
+        ctx.write(response).addListener(ChannelFutureListener.CLOSE);
+      }
+
+      private void writeResponse(ChannelHandlerContext ctx, HttpRequest request, ByteBuf buf, CharSequence contentType, CharSequence contentLength) {
+
+        // Build the response object.
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, buf, false);
+        HttpHeaders headers = response.headers();
+        headers.set(CONTENT_TYPE_ENTITY, contentType);
+        headers.set(SERVER_ENTITY, SERVER_NAME);
+        headers.set(DATE_ENTITY, date);
+        headers.set(CONTENT_LENGTH_ENTITY, contentLength);
+
+        // Close the non-keep-alive connection after the write operation is done.
+        ctx.write(response, ctx.voidPromise());
+      }
+    });
+  }
+
+  @Benchmark
+  public void vertx(Blackhole blackhole) {
+    vertxChannel.writeInbound(GET);
+    Object result = vertxChannel.outboundMessages().poll();
+    blackhole.consume(result);
+  }
+
+  @Fork(value = 1, jvmArgsAppend = {
+      "-XX:+UseBiasedLocking",
+      "-XX:BiasedLockingStartupDelay=0",
+      "-Dvertx.threadChecks=false",
+      "-Dvertx.disableContextTimings=true",
+      "-Dvertx.disableTCCL=true ",
+      "-XX:+AggressiveOpts",
+      "-Djmh.executor=CUSTOM",
+      "-Djmh.executor.class=io.vertx.core.impl.VertxExecutorService"
+  })
+  @Benchmark
+  public void vertxOpt(Blackhole blackhole) {
+    vertxChannel.writeInbound(GET);
+    Object result = vertxChannel.outboundMessages().poll();
+    blackhole.consume(result);
+  }
+
+  @Benchmark
+  public void netty(Blackhole blackhole) {
+    nettyChannel.writeInbound(GET);
+    Object result = nettyChannel.outboundMessages().poll();
+    blackhole.consume(result);
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -111,7 +111,7 @@ public class HttpServerBenchmark extends BenchmarkBase {
       response.end(HELLO_WORLD_BUFFER);
     };
     HandlerHolder<HttpHandlers> holder = new HandlerHolder<>(context, new HttpHandlers(app, null, null));
-    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", vertxChannel, holder, null);
+    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", holder, null);
     vertxChannel.pipeline().addLast("handler", handler);
     GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
         "GET / HTTP/1.1\r\n" +

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -40,6 +40,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.impl.HttpHandlers;
 import io.vertx.core.http.impl.HttpServerImpl;
 import io.vertx.core.http.impl.ServerConnection;
 import io.vertx.core.impl.ContextImpl;
@@ -110,7 +111,7 @@ public class HttpServerBenchmark extends BenchmarkBase {
           .add(HEADER_CONTENT_LENGTH, HELLO_WORLD_LENGTH);
       response.end(HELLO_WORLD_BUFFER);
     };
-    HandlerHolder<HttpServerImpl.Handlers> holder = new HandlerHolder<>(context, new HttpServerImpl.Handlers(app, null, null));
+    HandlerHolder<HttpHandlers> holder = new HandlerHolder<>(context, new HttpHandlers(app, null, null));
     HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", connectionMap, vertxChannel, holder, null);
     vertxChannel.pipeline().addLast("handler", handler);
     GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -17,7 +17,6 @@ package io.vertx.benchmarks;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -41,8 +40,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.HttpHandlers;
-import io.vertx.core.http.impl.HttpServerImpl;
-import io.vertx.core.http.impl.ServerConnection;
+import io.vertx.core.http.impl.ServerHandler;
 import io.vertx.core.impl.ContextImpl;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.VertxInternal;
@@ -58,8 +56,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -111,7 +107,7 @@ public class HttpServerBenchmark extends BenchmarkBase {
       response.end(HELLO_WORLD_BUFFER);
     };
     HandlerHolder<HttpHandlers> holder = new HandlerHolder<>(context, new HttpHandlers(app, null, null));
-    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", holder, null);
+    ServerHandler handler = new ServerHandler(null, new HttpServerOptions(), "localhost", holder, null);
     vertxChannel.pipeline().addLast("handler", handler);
     GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
         "GET / HTTP/1.1\r\n" +

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -100,7 +100,6 @@ public class HttpServerBenchmark extends BenchmarkBase {
         new HttpResponseEncoder()
     );
     ContextImpl context = new EventLoopContext(vertx, vertxChannel.eventLoop(), null, null, null, new JsonObject(), Thread.currentThread().getContextClassLoader());
-    ServerConnection connection = new ServerConnection(vertx, null, new HttpServerOptions(), vertxChannel, context, "localhost", null);
     Handler<HttpServerRequest> app = request -> {
       HttpServerResponse response = request.response();
       MultiMap headers = response.headers();
@@ -112,7 +111,7 @@ public class HttpServerBenchmark extends BenchmarkBase {
       response.end(HELLO_WORLD_BUFFER);
     };
     HandlerHolder<HttpServerImpl.Handlers> holder = new HandlerHolder<>(context, new HttpServerImpl.Handlers(app, null, null));
-    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(connectionMap, vertxChannel, holder, connection, null);
+    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", connectionMap, vertxChannel, holder, null);
     vertxChannel.pipeline().addLast("handler", handler);
     GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
         "GET / HTTP/1.1\r\n" +

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -90,7 +90,6 @@ public class HttpServerBenchmark extends BenchmarkBase {
   public void setup() {
     vertx = (VertxInternal) Vertx.vertx();
     HttpServerOptions options = new HttpServerOptions();
-    Map<Channel, ServerConnection> connectionMap = new HashMap<>();
     vertxChannel = new EmbeddedChannel(
         new HttpRequestDecoder(
             options.getMaxInitialLineLength(),
@@ -112,7 +111,7 @@ public class HttpServerBenchmark extends BenchmarkBase {
       response.end(HELLO_WORLD_BUFFER);
     };
     HandlerHolder<HttpHandlers> holder = new HandlerHolder<>(context, new HttpHandlers(app, null, null));
-    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", connectionMap, vertxChannel, holder, null);
+    HttpServerImpl.ServerHandler handler = new HttpServerImpl.ServerHandler(null, new HttpServerOptions(), "localhost", vertxChannel, holder, null);
     vertxChannel.pipeline().addLast("handler", handler);
     GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
         "GET / HTTP/1.1\r\n" +

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerBenchmark.java
@@ -51,6 +51,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.text.DateFormat;
@@ -61,6 +62,7 @@ import java.util.Date;
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @State(Scope.Thread)
+@Threads(16)
 public class HttpServerBenchmark extends BenchmarkBase {
 
   VertxInternal vertx;

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -63,7 +63,7 @@ import java.util.Date;
  */
 @State(Scope.Thread)
 @Threads(16)
-public class HttpServerBenchmark extends BenchmarkBase {
+public class HttpServerHandlerBenchmark extends BenchmarkBase {
 
   private static final ByteBuf GET = Unpooled.unreleasableBuffer(Unpooled.copiedBuffer((
     "GET / HTTP/1.1\r\n" +

--- a/src/test/benchmarks/io/vertx/benchmarks/RunOnContextBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/RunOnContextBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.BenchmarkContext;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+@State(Scope.Thread)
+public class RunOnContextBenchmark extends BenchmarkBase {
+
+  @State(Scope.Thread)
+  public static class BaselineState {
+
+    Vertx vertx;
+    BenchmarkContext context;
+    Handler<Void> task;
+
+    @Setup
+    public void setup(Blackhole hole) {
+      vertx = Vertx.vertx();
+      context = BenchmarkContext.create(vertx);
+      task = v -> {
+        hole.consume("the-string");
+      };
+    }
+  }
+
+  @Benchmark
+  public void baseline(BaselineState state) {
+    state.context.runDirect(state.task);
+  }
+
+  @Benchmark
+  @Fork(jvmArgsAppend = { "-Dvertx.threadChecks=false", "-Dvertx.disableContextTimings=true", "-Dvertx.disableTCCL=true" })
+  public void noChecks(BaselineState state) {
+    state.context.runDirect(state.task);
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/RunOnContextBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/RunOnContextBenchmark.java
@@ -19,17 +19,21 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.BenchmarkContext;
 import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.infra.Blackhole;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
 @State(Scope.Thread)
 public class RunOnContextBenchmark extends BenchmarkBase {
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void consume(final String buf) {
+  }
 
   @State(Scope.Thread)
   public static class BaselineState {
@@ -39,12 +43,10 @@ public class RunOnContextBenchmark extends BenchmarkBase {
     Handler<Void> task;
 
     @Setup
-    public void setup(Blackhole hole) {
+    public void setup() {
       vertx = Vertx.vertx();
       context = BenchmarkContext.create(vertx);
-      task = v -> {
-        hole.consume("the-string");
-      };
+      task = v -> consume("the-string");
     }
   }
 

--- a/src/test/benchmarks/io/vertx/core/impl/BenchmarkContext.java
+++ b/src/test/benchmarks/io/vertx/core/impl/BenchmarkContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class BenchmarkContext extends ContextImpl {
+
+  public static BenchmarkContext create(Vertx vertx) {
+    VertxImpl impl = (VertxImpl) vertx;
+    return new BenchmarkContext(impl, impl.internalBlockingPool, impl.workerPool, null, null, Thread.currentThread().getContextClassLoader());
+  }
+
+  public BenchmarkContext(VertxInternal vertx, WorkerPool internalBlockingPool, WorkerPool workerPool, String deploymentID, JsonObject config, ClassLoader tccl) {
+    super(vertx, internalBlockingPool, workerPool, deploymentID, config, tccl);
+  }
+
+  @Override
+  protected void executeAsync(Handler<Void> task) {
+    wrapTask(null, task, true, null).run();
+  }
+
+  public void runDirect(Handler<Void> task) {
+    wrapTask(null, task, true, null).run();
+  }
+
+  @Override
+  public boolean isEventLoopContext() {
+    return false;
+  }
+
+  @Override
+  public boolean isMultiThreadedWorkerContext() {
+    return false;
+  }
+
+  @Override
+  protected void checkCorrectThread() {
+  }
+}

--- a/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
+++ b/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2011-2013 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.impl;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VertxExecutorService extends ThreadPoolExecutor {
+
+  public VertxExecutorService(int maxThreads, String prefix) {
+    super(maxThreads, maxThreads,
+        0L, TimeUnit.MILLISECONDS,
+        new LinkedBlockingQueue<>(),
+        new VertxThreadFactory(prefix, new BlockedThreadChecker(10000, 10000), false, 10000));
+  }
+}

--- a/src/test/java/io/vertx/test/core/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/test/core/CaseInsensitiveHeadersTest.java
@@ -16,11 +16,15 @@ import static org.junit.Assert.*;
 
 public class CaseInsensitiveHeadersTest {
 
+  protected MultiMap newMultiMap() {
+    return new CaseInsensitiveHeaders();
+  }
+
   @Test
   public void testCaseInsensitiveHeaders()
       throws Exception {
 
-    MultiMap result = new CaseInsensitiveHeaders();
+    MultiMap result = newMultiMap();
 
     assertNotNull(result);
     assertTrue(result.isEmpty());
@@ -31,7 +35,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     HashMap<String, String> map = new HashMap<String, String>();
     map.put("a", "b");
 
@@ -46,7 +50,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     HashMap<String, String> map = new HashMap<String, String>();
     map.put("a", "b");
     map.put("c", "d");
@@ -57,7 +61,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest3()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     HashMap<String, String> map = new HashMap<String, String>();
     map.put("a", "b");
 
@@ -67,7 +71,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest4()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     Map<String, String> map = new HashMap<String, String>();
 
     assertEquals("", mmap.addAll(map).toString());
@@ -76,8 +80,8 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest5()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
-    MultiMap headers = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
+    MultiMap headers = newMultiMap();
 
     assertEquals("", mmap.addAll(headers).toString());
   }
@@ -85,7 +89,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest7()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = "name";
     CharSequence value = "value";
 
@@ -95,7 +99,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest8()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = "name";
     ArrayList<CharSequence> values = new ArrayList<CharSequence>();
     values.add("somevalue");
@@ -106,7 +110,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest9()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
     ArrayList<CharSequence> values = new ArrayList<CharSequence>();
     values.add("somevalue");
@@ -117,7 +121,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest10()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "a";
     ArrayList<CharSequence> values = new ArrayList<CharSequence>();
     values.add("somevalue");
@@ -128,7 +132,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest11()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
     String strVal = "";
 
@@ -138,7 +142,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest12()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "a";
     String strVal = "b";
 
@@ -148,7 +152,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest13()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "aaa";
     String strVal = "";
 
@@ -158,7 +162,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddTest14()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
     String strVal = "aaa";
 
@@ -168,7 +172,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddIterable()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "name";
     List<String> values = new ArrayList<String>();
     values.add("value1");
@@ -183,9 +187,9 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testAddMultiMap()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
-    MultiMap mm = new CaseInsensitiveHeaders();
+    MultiMap mm = newMultiMap();
     mm.add("Header1", "value1");
     mm.add("Header2", "value2");
 
@@ -198,7 +202,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testClearTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     MultiMap result = mmap.clear();
 
@@ -211,7 +215,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testContainsTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = String.valueOf(new Object());
 
     assertFalse(mmap.contains(name));
@@ -220,7 +224,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testContainsTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
 
     assertFalse(mmap.contains(name));
@@ -229,7 +233,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testContainsTest3()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "0123456789";
 
     boolean result = mmap.contains(name);
@@ -243,7 +247,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testEntriesTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     List<Map.Entry<String, String>> result = mmap.entries();
 
@@ -254,7 +258,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = String.valueOf(new Object());
 
     assertNull(mmap.get(name));
@@ -263,7 +267,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "1";
 
     assertNull(mmap.get(name));
@@ -272,7 +276,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetTest3()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "name";
 
     String result = mmap.get(name);
@@ -290,7 +294,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetAllTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = String.valueOf(new Object());
 
     List<String> result = mmap.getAll(name);
@@ -302,7 +306,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetAllTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "1";
 
     List<String> result = mmap.getAll(name);
@@ -314,7 +318,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetAllTest3()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "name";
 
     List<String> result = mmap.getAll(name);
@@ -326,7 +330,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testGetAll()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "name";
     mmap.add(name, "value1");
     mmap.add(name, "value2");
@@ -347,7 +351,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testIsEmptyTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     assertTrue(mmap.isEmpty());
   }
@@ -355,7 +359,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testIsEmptyTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     mmap.add("a", "b");
 
     assertFalse(mmap.isEmpty());
@@ -364,7 +368,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testIteratorTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     Iterator<Map.Entry<String, String>> result = mmap.iterator();
 
@@ -375,7 +379,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testIteratorTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     mmap.add("a", "b");
 
     Iterator<Map.Entry<String, String>> result = mmap.iterator();
@@ -387,7 +391,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testNamesTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     Set<String> result = mmap.names();
 
@@ -398,7 +402,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testRemoveTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = String.valueOf(new Object());
 
     MultiMap result = mmap.remove(name);
@@ -417,7 +421,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testRemoveTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "1";
 
     MultiMap result = mmap.remove(name);
@@ -430,7 +434,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testRemoveTest3()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "name";
 
     MultiMap result = mmap.remove(name);
@@ -443,7 +447,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testRemoveTest4()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "name";
     String value = "value";
     mmap.add(name, value);
@@ -458,7 +462,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest1()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     HashMap<String, String> headers = new HashMap<String, String>();
     headers.put("", "");
 
@@ -473,7 +477,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest2()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     HashMap<String, String> headers = new HashMap<String, String>();
     headers.put("", "");
     headers.put("aaa", "bbb");
@@ -489,7 +493,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest3()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     HashMap<String, String> headers = new HashMap<String, String>();
     headers.put("aaa", "bbb");
 
@@ -504,7 +508,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest4()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     Map<String, String> headers = new HashMap<String, String>();
 
     MultiMap result = mmap.setAll(headers);
@@ -518,8 +522,8 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest5()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
-    MultiMap headers = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
+    MultiMap headers = newMultiMap();
 
     MultiMap result = mmap.setAll(headers);
 
@@ -532,7 +536,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest7()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = "name";
     CharSequence value = "value";
 
@@ -547,7 +551,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest8()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     CharSequence name = "name";
     ArrayList<CharSequence> values = new ArrayList<CharSequence>();
     values.add("somevalue");
@@ -558,7 +562,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest9()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
     ArrayList<CharSequence> values = new ArrayList<CharSequence>();
     values.add("somevalue");
@@ -569,7 +573,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest10()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "aaa";
     ArrayList<CharSequence> values = new ArrayList<CharSequence>();
     values.add("somevalue");
@@ -580,7 +584,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest11()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
     String strVal = "";
 
@@ -595,7 +599,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest12()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "aaa";
     String strVal = "bbb";
 
@@ -610,7 +614,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest13()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "aaa";
     String strVal = "";
 
@@ -625,7 +629,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetTest14()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
     String name = "";
     String strVal = "bbb";
 
@@ -646,7 +650,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetIterableEmpty()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     String name = "name";
     List<String> values = new ArrayList<String>();
@@ -662,7 +666,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSetIterable()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     String name = "name";
     List<String> values = new ArrayList<String>();
@@ -680,7 +684,7 @@ public class CaseInsensitiveHeadersTest {
   @Test
   public void testSize()
       throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     assertEquals(0, mmap.size());
     mmap.add("header", "value");
@@ -693,7 +697,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test
   public void testGetHashColl() {
-    MultiMap mm = new CaseInsensitiveHeaders();
+    MultiMap mm = newMultiMap();
     String name1 = "!~AZ";
     String name2 = "!~\u0080Y";
     mm.add(name1, "value1");
@@ -754,7 +758,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test
   public void testGetAllHashColl() {
-    MultiMap mm = new CaseInsensitiveHeaders();
+    MultiMap mm = newMultiMap();
     String name1 = "AZ";
     String name2 = "\u0080Y";
     assertTrue("hash error", hash(name1) == hash(name2));
@@ -777,7 +781,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test
   public void testRemoveHashColl() {
-    MultiMap mm = new CaseInsensitiveHeaders();
+    MultiMap mm = newMultiMap();
     String name1 = "AZ";
     String name2 = "\u0080Y";
     String name3 = "RZ";
@@ -836,7 +840,7 @@ public class CaseInsensitiveHeadersTest {
   // MIN_VALUE in int representation
   @Test
   public void testHashMININT() {
-    CaseInsensitiveHeaders mm = new CaseInsensitiveHeaders();
+    MultiMap mm = newMultiMap();
     String name1 = "";
     long value = Integer.MAX_VALUE;
     value++;
@@ -872,7 +876,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test
   public void testToString() {
-    MultiMap mm = new CaseInsensitiveHeaders();
+    MultiMap mm = newMultiMap();
     assertEquals("", mm.toString());
     mm.add("Header1", "Value1");
     assertEquals("Header1: Value1\n",
@@ -901,7 +905,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test
   public void testMapEntrySetValue() throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     mmap.add("Header", "oldvalue");
 
@@ -913,7 +917,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test
   public void testMapEntryToString() throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     mmap.add("Header", "value");
 
@@ -922,7 +926,7 @@ public class CaseInsensitiveHeadersTest {
 
   @Test(expected = NullPointerException.class)
   public void testMapEntrySetValueNull() throws Exception {
-    MultiMap mmap = new CaseInsensitiveHeaders();
+    MultiMap mmap = newMultiMap();
 
     mmap.add("Header", "oldvalue");
 

--- a/src/test/java/io/vertx/test/core/DatagramTest.java
+++ b/src/test/java/io/vertx/test/core/DatagramTest.java
@@ -207,6 +207,7 @@ public class DatagramTest extends VertxTestBase {
       WriteStream<Buffer> sender1 = peer1.sender(1234, "127.0.0.1");
       sender1.write(buffer);
     });
+    await();
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -1169,6 +1169,7 @@ public class Http1xTest extends HttpTest {
     AtomicInteger reqCount = new AtomicInteger(0);
     server.requestHandler(req -> {
       int theCount = reqCount.get();
+//      System.out.println("begin " + theCount);
       assertEquals(theCount, Integer.parseInt(req.headers().get("count")));
       reqCount.incrementAndGet();
       req.response().setChunked(true);
@@ -1180,6 +1181,7 @@ public class Http1xTest extends HttpTest {
           req.response().headers().set("count", String.valueOf(theCount));
           req.response().write(buff);
           req.response().end();
+//          System.out.println("end " + theCount);
         });
       });
     });

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -3681,6 +3681,21 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
+  public void testUnknownContentLengthIsSetToZeroWithHTTP_1_0() throws Exception {
+    server.requestHandler(req -> {
+      req.response().write("Some-String").end();
+    });
+    startServer();
+    client.close();
+    client = vertx.createHttpClient(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_1_0));
+    client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+      assertEquals("0", resp.getHeader("Content-Length"));
+      testComplete();
+    });
+    await();
+  }
+
+  @Test
   public void testPartialH2CAmbiguousRequest() throws Exception {
     server.requestHandler(req -> {
       assertEquals("POST", req.rawMethod());

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -1169,7 +1169,6 @@ public class Http1xTest extends HttpTest {
     AtomicInteger reqCount = new AtomicInteger(0);
     server.requestHandler(req -> {
       int theCount = reqCount.get();
-//      System.out.println("begin " + theCount);
       assertEquals(theCount, Integer.parseInt(req.headers().get("count")));
       reqCount.incrementAndGet();
       req.response().setChunked(true);
@@ -1181,7 +1180,6 @@ public class Http1xTest extends HttpTest {
           req.response().headers().set("count", String.valueOf(theCount));
           req.response().write(buff);
           req.response().end();
-//          System.out.println("end " + theCount);
         });
       });
     });

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -3689,7 +3689,7 @@ public class Http1xTest extends HttpTest {
     client.close();
     client = vertx.createHttpClient(new HttpClientOptions().setProtocolVersion(HttpVersion.HTTP_1_0));
     client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
-      assertEquals("0", resp.getHeader("Content-Length"));
+      assertNull(resp.getHeader("Content-Length"));
       testComplete();
     });
     await();

--- a/src/test/java/io/vertx/test/core/MetricsOptionsTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsOptionsTest.java
@@ -81,8 +81,7 @@ public class MetricsOptionsTest extends VertxTestBase {
     vertx.close();
     vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(new MetricsOptions().setEnabled(true)));
     VertxMetrics metrics = ((VertxInternal) vertx).metricsSPI();
-    assertNotNull(metrics);
-    assertTrue(metrics instanceof DummyVertxMetrics);
+    assertNull(metrics);
   }
 
   @Test

--- a/src/test/java/io/vertx/test/core/VertxHttpHeadersTest.java
+++ b/src/test/java/io/vertx/test/core/VertxHttpHeadersTest.java
@@ -1,0 +1,15 @@
+package io.vertx.test.core;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class VertxHttpHeadersTest extends CaseInsensitiveHeadersTest {
+
+  @Override
+  protected MultiMap newMultiMap() {
+    return new VertxHttpHeaders();
+  }
+}

--- a/src/test/java/io/vertx/test/core/WebsocketTest.java
+++ b/src/test/java/io/vertx/test/core/WebsocketTest.java
@@ -973,6 +973,38 @@ public class WebsocketTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  public void testInvalidMissingConnectionHeader() throws Exception {
+    String path = "/some/path";
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(HttpTestBase.DEFAULT_HTTP_PORT).setWebsocketSubProtocols("invalid")).websocketHandler(ws -> {
+    });
+    server.listen(onSuccess(ar -> {
+      client.get(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTPS_HOST, path, resp -> {
+        assertEquals(400, resp.statusCode());
+        resp.endHandler(v -> {
+          testComplete();
+        });
+      }).putHeader("Upgrade", "Websocket").end();
+    }));
+    await();
+  }
+
+  @Test
+  public void testInvalidMethod() throws Exception {
+    String path = "/some/path";
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(HttpTestBase.DEFAULT_HTTP_PORT).setWebsocketSubProtocols("invalid")).websocketHandler(ws -> {
+    });
+    server.listen(onSuccess(ar -> {
+      client.head(HttpTestBase.DEFAULT_HTTP_PORT, HttpTestBase.DEFAULT_HTTPS_HOST, path, resp -> {
+        assertEquals(405, resp.statusCode());
+        resp.endHandler(v -> {
+          testComplete();
+        });
+      }).putHeader("Upgrade", "Websocket").putHeader("Connection", "Upgrade").end();
+    }));
+    await();
+  }
+
   private void testReject(WebsocketVersion version) throws Exception {
 
     String path = "/some/path";


### PR DESCRIPTION
Performance improvements for `HttpServer`, the improvements have been tested in a real environment (provided by Red Hat). Here are results of the Techempower plaintext benchmark:

|                     |3.4.0    |   3.5.0-SNAPSHOT|
|---|---|---|
|plain/256     | 3489111 | 3624167 |
|plain/1024   | 3571519 | 4027825 |
|plain/4096  | 3468908  | 3955497 |
|plain/16384 | 3296358  | 3779672 |

- Simplified the `HttpServer` handlers to combine the request and websocket handlers context that helps to simplify the internal code and anyway one would not use two different event loops for these.
- Decouple the Vert.x Netty handler that handles the `HttpRequest`/`HttpResponse` events so it can be created independantly of an HttpServer instance and can be benchmarked with a Netty embedded event loop to measure the overhead of Vert.x
- set the `ConnectionBase` on `VertxHandler` when the handler is added to the pipeline avoiding to handle the null case in the read pipeline.
- now the various server handlers write through the `ChannelHandlerContext` instead of the `Channel` to bypass the `Channel`->`ChannelHandlerContext` that is not necessary (http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#29.0)
- use a `VoidPromise` in pipeline write operations when possible (http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#8.0)
- metrics SPI instances are considered as disabled when null is returned from the SPI. Previously it was checking for null / enabled boolean
- use optimized `HttpHeaders` for `HttpServerResponse` that implements `Multimap`
- in `HttpServerResponse` avoid to double check the response headers like _content-length_
- `ServerConnection` has been made JIT friendly when possible
- JMH micro benchmarks : a few JMH micro benchmarks have been added that helps to measure the impact of changes on the `HttpServer` request handler. Note that these benchmarks have been added to quickly see the impact of changes but do not replace real benchmarking done in a lab.

The JMH benchmarks results:

```
Benchmark                             Mode  Cnt       Score       Error   Units
HeadersContainsBenchmark.nettySmall  thrpt   10  211541.865 ± 15864.149  ops/ms
HeadersContainsBenchmark.vertxSmall  thrpt   10  279507.048 ± 28970.228  ops/ms
HeadersEncodeBenchmark.baseline      thrpt   10  254731.860 ±  6419.979  ops/ms
HeadersEncodeBenchmark.nettySmall    thrpt   10    8159.088 ±    72.889  ops/ms
HeadersEncodeBenchmark.vertxSmall    thrpt   10    9804.617 ±   199.194  ops/ms
HeadersSetBenchmark.nettySmall       thrpt   10    4883.103 ±    96.648  ops/ms
HeadersSetBenchmark.vertxSmall       thrpt   10   23627.110 ±   327.857  ops/ms
HttpServerHandlerBenchmark.netty     thrpt    10  916.701 ± 1338.710  ops/ms
HttpServerHandlerBenchmark.vertx     thrpt    10  613.475 ±   68.536  ops/ms
HttpServerHandlerBenchmark.vertxOpt  thrpt    10  678.481 ±  467.255  ops/ms
RunOnContextBenchmark.baseline       thrpt   10   24237.869 ±   648.594  ops/ms
RunOnContextBenchmark.noChecks       thrpt   10  193615.947 ± 15562.721  ops/ms
```