### PR TITLE
Override equals and hashCode in PemTrustOptions

### DIFF
--- a/src/main/java/io/vertx/core/net/PemTrustOptions.java
+++ b/src/main/java/io/vertx/core/net/PemTrustOptions.java
@@ -155,4 +155,21 @@ public class PemTrustOptions implements TrustOptions, Cloneable {
     return new PemTrustOptions(this);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    PemTrustOptions that = (PemTrustOptions) o;
+
+    if (!certPaths.equals(that.certPaths)) return false;
+    return certValues.equals(that.certValues);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = certPaths.hashCode();
+    result = 31 * result + certValues.hashCode();
+    return result;
+  }
 }

--- a/src/test/java/io/vertx/test/core/KeyStoreTest.java
+++ b/src/test/java/io/vertx/test/core/KeyStoreTest.java
@@ -39,6 +39,7 @@ import java.util.Enumeration;
 
 import static io.vertx.test.core.TestUtils.assertIllegalArgumentException;
 import static io.vertx.test.core.TestUtils.assertNullPointerException;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -353,6 +354,40 @@ public class KeyStoreTest extends VertxTestBase {
     options = new PemTrustOptions(options.toJson());
     assertEquals(Collections.singletonList(certPath), options.getCertPaths());
     assertEquals(Collections.singletonList(certValue), options.getCertValues());
+  }
+
+  @Test
+  public void testTrustOptionsEquality() {
+    String certPath1 = TestUtils.randomAlphaString(100);
+    String certPath2 = TestUtils.randomAlphaString(100);
+    Buffer certValue1 = Buffer.buffer(TestUtils.randomAlphaString(100));
+    Buffer certValue2 = Buffer.buffer(TestUtils.randomAlphaString(100));
+
+    PemTrustOptions options = new PemTrustOptions();
+    PemTrustOptions otherOptions = new PemTrustOptions();
+    assertEquals(options, otherOptions);
+    assertEquals(options.hashCode(), otherOptions.hashCode());
+
+    options.addCertPath(certPath1);
+    options.addCertPath(certPath2);
+    options.addCertValue(certValue1);
+    options.addCertValue(certValue2);
+    otherOptions.addCertPath(certPath1);
+    otherOptions.addCertPath(certPath2);
+    otherOptions.addCertValue(certValue1);
+    otherOptions.addCertValue(certValue2);
+    assertEquals(options, otherOptions);
+    assertEquals(options.hashCode(), otherOptions.hashCode());
+
+    otherOptions.addCertPath(TestUtils.randomAlphaString(100));
+    assertNotEquals(options, otherOptions);
+
+    PemTrustOptions reverseOrderOptions = new PemTrustOptions();
+    reverseOrderOptions.addCertPath(certPath2);
+    reverseOrderOptions.addCertPath(certPath1);
+    reverseOrderOptions.addCertValue(certValue2);
+    reverseOrderOptions.addCertValue(certValue1);
+    assertNotEquals(options, reverseOrderOptions);
   }
 
   @Test


### PR DESCRIPTION
https://github.com/eclipse/vert.x/issues/2038

Signed-off-by: Andrei Iacob <iacobandrei+sfdc@gmail.com>