### PR TITLE
Fix #handleEnd to respect paused

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -243,15 +243,20 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
     synchronized (conn) {
       conn.reportBytesRead(bytesRead);
       bytesRead = 0;
-      if (!paused && lastChunk != null) {
-        handleChunk(lastChunk);
-      }
-      // paused can be updated in the #handleChunk call above, check it again
       if (paused) {
         pausedLastChunk = lastChunk;
         hasPausedEnd = true;
         pausedTrailers = trailers;
       } else {
+        if (lastChunk != null) {
+          handleChunk(lastChunk);
+          if (paused) {
+            pausedLastChunk = null;
+            hasPausedEnd = true;
+            pausedTrailers = trailers;
+            return;
+          }
+        }
         this.trailers = trailers;
         if (endHandler != null) {
           try {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -243,14 +243,15 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
     synchronized (conn) {
       conn.reportBytesRead(bytesRead);
       bytesRead = 0;
+      if (!paused && lastChunk != null) {
+        handleChunk(lastChunk);
+      }
+      // paused can be updated in the #handleChunk call above, check it again
       if (paused) {
         pausedLastChunk = lastChunk;
         hasPausedEnd = true;
         pausedTrailers = trailers;
       } else {
-        if (lastChunk != null) {
-          handleChunk(lastChunk);
-        }
         this.trailers = trailers;
         if (endHandler != null) {
           try {


### PR DESCRIPTION
`io.vertx.core.http.impl.HttpClientResponseImpl#handleEnd` calls
`handleChunk` whose handler can pause the response, thus signaling it's
not ready to process further including the end of the response. With the
change the `paused` status is now examined twice.

Signed-off-by: Boris Byk <boris.byk@gmail.com>