### PR TITLE
A few improvements in websocket rejection: the ServerWebSocket#reject…

### DIFF
--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -107,11 +107,16 @@ public interface ServerWebSocket extends WebSocketBase {
    * <p>
    * Calling this method from the websocket handler when it is first passed to you gives you the opportunity to reject
    * the websocket, which will cause the websocket handshake to fail by returning
-   * a 404 response code.
+   * a {@literal 502} response code.
    * <p>
    * You might use this method, if for example you only want to accept WebSockets with a particular path.
    */
   void reject();
+
+  /**
+   * Like {@link #reject()} but with a {@code status}.
+   */
+  void reject(int status);
 
   /**
    * @return an array of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
+++ b/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2014 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.core.http;
+
+import io.vertx.core.VertxException;
+
+/**
+ * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
+ */
+public class WebsocketRejectedException extends VertxException {
+
+  private final int status;
+
+  WebsocketRejectedException(int status) {
+    super("Websocket connection attempt returned HTTP status code " + status);
+    this.status = status;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
+++ b/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
@@ -29,6 +29,9 @@ public class WebsocketRejectedException extends VertxException {
     this.status = status;
   }
 
+  /**
+   * @return the status code of the response that rejected the upgrade
+   */
   public int getStatus() {
     return status;
   }

--- a/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
+++ b/src/main/java/io/vertx/core/http/WebsocketRejectedException.java
@@ -24,7 +24,7 @@ public class WebsocketRejectedException extends VertxException {
 
   private final int status;
 
-  WebsocketRejectedException(int status) {
+  public WebsocketRejectedException(int status) {
     super("Websocket connection attempt returned HTTP status code " + status);
     this.status = status;
   }

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -177,13 +177,14 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
       if (handshaker != null && handshaking) {
         if (msg instanceof HttpResponse) {
           HttpResponse resp = (HttpResponse) msg;
-          if (resp.getStatus().code() != 101) {
+          HttpResponseStatus status = resp.status();
+          if (status.code() != 101) {
             handshaker = null;
             close();
-            handleException(new WebSocketHandshakeException("Websocket connection attempt returned HTTP status code " + resp.getStatus().code()));
+            handleException(new WebsocketRejectedException(status.code()));
             return;
           }
-          response = new DefaultFullHttpResponse(resp.getProtocolVersion(), resp.getStatus());
+          response = new DefaultFullHttpResponse(resp.protocolVersion(), status);
           response.headers().add(resp.headers());
         }
 
@@ -214,7 +215,7 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
       }
     }
 
-    private void handleException(WebSocketHandshakeException e) {
+    private void handleException(Exception e) {
       handshaking = false;
       buffered.clear();
       Handler<Throwable> handler = exceptionHandler();

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -731,7 +731,11 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             }
             ws.connectNow();
           } else {
-            ch.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, BAD_GATEWAY));
+            HttpResponseStatus status = ws.getRejectedStatus();
+            if (status == null) {
+              status = BAD_GATEWAY;
+            }
+            ch.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, status));
           }
         });
       }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -731,11 +731,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             }
             ws.connectNow();
           } else {
-            HttpResponseStatus status = ws.getRejectedStatus();
-            if (status == null) {
-              status = BAD_GATEWAY;
-            }
-            ch.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, status));
+            ch.writeAndFlush(new DefaultFullHttpResponse(HTTP_1_1, ws.getRejectedStatus()));
           }
         });
       }

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.core.http.impl;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
@@ -24,6 +25,8 @@ import io.vertx.core.net.impl.ConnectionBase;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.security.cert.X509Certificate;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
 
 /**
  * This class is optimised for performance when used on the same event loop. However it can be used safely from other threads.
@@ -44,6 +47,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
 
   private boolean connected;
   private boolean rejected;
+  private HttpResponseStatus rejectedStatus;
 
   public ServerWebSocketImpl(VertxInternal vertx, String uri, String path, String query, MultiMap headers,
                              ConnectionBase conn, boolean supportsContinuation, Runnable connectRunnable,
@@ -78,6 +82,15 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
 
   @Override
   public void reject() {
+    reject(BAD_GATEWAY);
+  }
+
+  @Override
+  public void reject(int status) {
+    reject(HttpResponseStatus.valueOf(status));
+  }
+
+  private void reject(HttpResponseStatus status) {
     synchronized (conn) {
       checkClosed();
       if (connectRunnable == null) {
@@ -87,6 +100,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
         throw new IllegalStateException("Cannot reject websocket, it has already been written to");
       }
       rejected = true;
+      rejectedStatus = status;
     }
   }
 
@@ -101,7 +115,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
       checkClosed();
       if (connectRunnable != null) {
         // Server side
-        if (rejected) {
+        if (isRejected()) {
           throw new IllegalStateException("Cannot close websocket, it has been rejected");
         }
         if (!connected && !closed) {
@@ -116,7 +130,7 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
   public ServerWebSocket writeFrame(WebSocketFrame frame) {
     synchronized (conn) {
       if (connectRunnable != null) {
-        if (rejected) {
+        if (isRejected()) {
           throw new IllegalStateException("Cannot write to websocket, it has been rejected");
         }
         if (!connected && !closed) {
@@ -135,15 +149,18 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
   // Connect if not already connected
   void connectNow() {
     synchronized (conn) {
-      if (!connected && !rejected) {
+      if (!connected && !isRejected()) {
         connect();
       }
     }
   }
 
-  boolean isRejected() {
-    synchronized (conn) {
-      return rejected;
-    }
+  synchronized boolean isRejected() {
+    return rejected;
   }
+
+  synchronized HttpResponseStatus getRejectedStatus() {
+    return rejectedStatus;
+  }
+
 }

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -156,11 +156,15 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
   }
 
   synchronized boolean isRejected() {
-    return rejected;
+    synchronized (conn) {
+      return rejected;
+    }
   }
 
   synchronized HttpResponseStatus getRejectedStatus() {
-    return rejectedStatus;
+    synchronized (conn) {
+      return rejectedStatus;
+    }
   }
 
 }


### PR DESCRIPTION
…() is overloaded to provide a specific status code, the reject() method is documented that it will send 502 by default and not 404, the client can be aware of the rejection status with the new WebsocketRejectedException. fixes #1996