### PR TITLE
SSLSession accessor support to get access to SSL session information

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -267,10 +267,15 @@ public interface HttpConnection {
   SSLSession sslSession();
 
   /**
+   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
+   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
+   * access that method.
+   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
    * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see #sslSession()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -258,9 +258,10 @@ public interface HttpConnection {
   boolean isSsl();
 
   /**
-   * @return an array of the peer certificates. Returns null if connection is
+   * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/HttpConnection.java
+++ b/src/main/java/io/vertx/core/http/HttpConnection.java
@@ -27,6 +27,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -256,6 +257,14 @@ public interface HttpConnection {
    * @return true if this {@link io.vertx.core.http.HttpConnection} is encrypted via SSL/TLS.
    */
   boolean isSsl();
+
+  /**
+   * @return SSLSession associated with the underlying socket. Returns null if connection is
+   *         not SSL.
+   * @see javax.net.ssl.SSLSession
+   */
+  @GenIgnore
+  SSLSession sslSession();
 
   /**
    * @return an ordered array of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -171,10 +171,11 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   SocketAddress localAddress();
 
   /**
-   * @return an array of the peer certificates. Returns null if connection is
+   * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
-  */
+   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;
 

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -29,6 +29,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -169,6 +170,14 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
    */
   @CacheReturn
   SocketAddress localAddress();
+
+  /**
+   * @return SSLSession associated with the underlying socket. Returns null if connection is
+   *         not SSL.
+   * @see javax.net.ssl.SSLSession
+   */
+  @GenIgnore
+  SSLSession sslSession();
 
   /**
    * @return an ordered array of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -180,10 +180,15 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   SSLSession sslSession();
 
   /**
+   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
+   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
+   * access that method.
+   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
    * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see #sslSession()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -119,9 +119,10 @@ public interface ServerWebSocket extends WebSocketBase {
   void reject(int status);
 
   /**
-   * @return an array of the peer certificates. Returns null if connection is
+   * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -25,6 +25,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -117,6 +118,14 @@ public interface ServerWebSocket extends WebSocketBase {
    * Like {@link #reject()} but with a {@code status}.
    */
   void reject(int status);
+
+  /**
+   * @return SSLSession associated with the underlying socket. Returns null if connection is
+   *         not SSL.
+   * @see javax.net.ssl.SSLSession
+   */
+  @GenIgnore
+  SSLSession sslSession();
 
   /**
    * @return an ordered array of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/ServerWebSocket.java
+++ b/src/main/java/io/vertx/core/http/ServerWebSocket.java
@@ -128,10 +128,15 @@ public interface ServerWebSocket extends WebSocketBase {
   SSLSession sslSession();
 
   /**
+   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
+   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
+   * access that method.
+   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
    * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see #sslSession()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -28,6 +28,7 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -200,6 +201,14 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
    * @return true if this {@link io.vertx.core.http.HttpConnection} is encrypted via SSL/TLS.
    */
   boolean isSsl();
+
+  /**
+   * @return SSLSession associated with the underlying socket. Returns null if connection is
+   *         not SSL.
+   * @see javax.net.ssl.SSLSession
+   */
+  @GenIgnore
+  SSLSession sslSession();
 
   /**
    * @return an ordered array of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -202,9 +202,10 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   boolean isSsl();
 
   /**
-   * @return an array of the peer certificates. Returns null if connection is
+   * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/WebSocketBase.java
+++ b/src/main/java/io/vertx/core/http/WebSocketBase.java
@@ -211,10 +211,15 @@ public interface WebSocketBase extends ReadStream<Buffer>, WriteStream<Buffer> {
   SSLSession sslSession();
 
   /**
+   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
+   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
+   * access that method.
+   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
    * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see #sslSession()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -47,6 +47,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
 import java.nio.channels.ClosedChannelException;
@@ -368,6 +369,11 @@ public class Http2ServerRequestImpl extends VertxHttp2Stream<Http2ServerConnecti
   @Override
   public SocketAddress localAddress() {
     return conn.localAddress();
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return conn.sslSession();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -45,6 +45,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.net.URISyntaxException;
 
@@ -267,6 +268,11 @@ public class HttpServerRequestImpl implements HttpServerRequest {
       }
     }
     return absoluteURI;
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return conn.sslSession();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerWebSocketImpl.java
@@ -24,6 +24,7 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.impl.ConnectionBase;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_GATEWAY;
@@ -102,6 +103,11 @@ public class ServerWebSocketImpl extends WebSocketImplBase<ServerWebSocket> impl
       rejected = true;
       rejectedStatus = status;
     }
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return conn.sslSession();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/VertxHttp2NetSocket.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttp2NetSocket.java
@@ -31,6 +31,7 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -281,6 +282,11 @@ class VertxHttp2NetSocket<C extends Http2ConnectionBase> extends VertxHttp2Strea
   @Override
   public boolean isSsl() {
     return conn.isSsl();
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return conn.sslSession();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -30,6 +30,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.ConnectionBase;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.util.UUID;
 
@@ -101,6 +102,11 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   @Override
   public boolean isSsl() {
     return conn.isSsl();
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return conn.sslSession();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -235,9 +235,10 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   boolean isSsl();
 
   /**
-   * @return an array of the peer certificates. Returns null if connection is
+   * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
+   * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -244,10 +244,15 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
   SSLSession sslSession();
 
   /**
+   * Note: Java SE 5+ recommends to use javax.net.ssl.SSLSession#getPeerCertificates() instead of
+   * of javax.net.ssl.SSLSession#getPeerCertificateChain() which this method is based on. Use {@link #sslSession()} to
+   * access that method.
+   *
    * @return an ordered array of the peer certificates. Returns null if connection is
    *         not SSL.
    * @throws javax.net.ssl.SSLPeerUnverifiedException SSL peer's identity has not been verified.
    * @see javax.net.ssl.SSLSession#getPeerCertificateChain()
+   * @see #sslSession()
    */
   @GenIgnore
   X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException;

--- a/src/main/java/io/vertx/core/net/NetSocket.java
+++ b/src/main/java/io/vertx/core/net/NetSocket.java
@@ -28,6 +28,7 @@ import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 /**
@@ -233,6 +234,14 @@ public interface NetSocket extends ReadStream<Buffer>, WriteStream<Buffer> {
    * @return true if this {@link io.vertx.core.net.NetSocket} is encrypted via SSL/TLS.
    */
   boolean isSsl();
+
+  /**
+   * @return SSLSession associated with the underlying socket. Returns null if connection is
+   *         not SSL.
+   * @see javax.net.ssl.SSLSession
+   */
+  @GenIgnore
+  SSLSession sslSession();
 
   /**
    * @return an ordered array of the peer certificates. Returns null if connection is

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -29,6 +29,7 @@ import io.vertx.core.spi.metrics.NetworkMetrics;
 import io.vertx.core.spi.metrics.TCPMetrics;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -283,6 +284,17 @@ public abstract class ConnectionBase {
 
   public boolean isSsl() {
     return chctx.pipeline().get(SslHandler.class) != null;
+  }
+
+  public SSLSession sslSession() {
+    if (isSSL()) {
+      ChannelHandlerContext sslHandlerContext = chctx.pipeline().context("ssl");
+      assert sslHandlerContext != null;
+      SslHandler sslHandler = (SslHandler) sslHandlerContext.handler();
+      return sslHandler.engine().getSession();
+    } else {
+      return null;
+    }
   }
 
   public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {


### PR DESCRIPTION
Java SE 5-8 has deprecated usage of SSLSession#getPeerCertificateChain() as described in here:
https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLSession.html#getPeerCertificateChain--

This PR adds support for SSLSession#getPeerCertificates() which has new accessor peerCertificates() to follow naming convention for peerCertificateChain(). peerCertificateChain() is left there with @deprecated note to transition to peerCertificate().

TLS test cases are adapted to use peerCertificates().