### PR TITLE
JSON message codecs creates unnecessary intermediate String

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonArrayMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonArrayMessageCodec.java
@@ -16,7 +16,6 @@
 
 package io.vertx.core.eventbus.impl.codecs;
 
-import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.json.JsonArray;
@@ -28,20 +27,16 @@ public class JsonArrayMessageCodec implements MessageCodec<JsonArray, JsonArray>
 
   @Override
   public void encodeToWire(Buffer buffer, JsonArray jsonArray) {
-    String strJson = jsonArray.encode();
-    byte[] encoded = strJson.getBytes(CharsetUtil.UTF_8);
-    buffer.appendInt(encoded.length);
-    Buffer buff = Buffer.buffer(encoded);
-    buffer.appendBuffer(buff);
+    Buffer encoded = jsonArray.toBuffer();
+    buffer.appendInt(encoded.length());
+    buffer.appendBuffer(encoded);
   }
 
   @Override
   public JsonArray decodeFromWire(int pos, Buffer buffer) {
     int length = buffer.getInt(pos);
     pos += 4;
-    byte[] encoded = buffer.getBytes(pos, pos + length);
-    String str = new String(encoded, CharsetUtil.UTF_8);
-    return new JsonArray(str);
+    return new JsonArray(buffer.slice(pos, pos + length));
   }
 
   @Override

--- a/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonObjectMessageCodec.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/codecs/JsonObjectMessageCodec.java
@@ -16,7 +16,6 @@
 
 package io.vertx.core.eventbus.impl.codecs;
 
-import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.json.JsonObject;
@@ -28,20 +27,16 @@ public class JsonObjectMessageCodec implements MessageCodec<JsonObject, JsonObje
 
   @Override
   public void encodeToWire(Buffer buffer, JsonObject jsonObject) {
-    String strJson = jsonObject.encode();
-    byte[] encoded = strJson.getBytes(CharsetUtil.UTF_8);
-    buffer.appendInt(encoded.length);
-    Buffer buff = Buffer.buffer(encoded);
-    buffer.appendBuffer(buff);
+    Buffer encoded = jsonObject.toBuffer();
+    buffer.appendInt(encoded.length());
+    buffer.appendBuffer(encoded);
   }
 
   @Override
   public JsonObject decodeFromWire(int pos, Buffer buffer) {
     int length = buffer.getInt(pos);
     pos += 4;
-    byte[] encoded = buffer.getBytes(pos, pos + length);
-    String str = new String(encoded, CharsetUtil.UTF_8);
-    return new JsonObject(str);
+    return new JsonObject(buffer.slice(pos, pos + length));
   }
 
   @Override

--- a/src/test/benchmarks/io/vertx/benchmarks/JsonDecodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/JsonDecodeBenchmark.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * @author Thomas Segismont
+ */
+@State(Scope.Thread)
+public class JsonDecodeBenchmark extends BenchmarkBase {
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void consume(final JsonObject jsonObject) {
+  }
+
+  private Buffer small;
+  private Buffer large;
+
+  @Setup
+  public void setup() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    small = loadJsonAsBuffer(classLoader.getResource("small.json"));
+    large = loadJsonAsBuffer(classLoader.getResource("large.json"));
+  }
+
+  private Buffer loadJsonAsBuffer(URL url) {
+    try {
+      Buffer encoded = new JsonObject(Json.mapper.readValue(url, Map.class)).toBuffer();
+      return Buffer.buffer().appendInt(encoded.length()).appendBuffer(encoded);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Benchmark
+  public void viaStringSmall() throws Exception {
+    viaString(small);
+  }
+
+  @Benchmark
+  public void viaStringLarge() throws Exception {
+    viaString(large);
+  }
+
+  private void viaString(Buffer buffer) throws Exception {
+    int pos = 0;
+    int length = buffer.getInt(pos);
+    pos += 4;
+    byte[] encoded = buffer.getBytes(pos, pos + length);
+    String str = new String(encoded, CharsetUtil.UTF_8);
+    consume(new JsonObject(str));
+  }
+
+  @Benchmark
+  public void directSmall() throws Exception {
+    direct(small);
+  }
+
+  @Benchmark
+  public void directLarge() throws Exception {
+    direct(large);
+  }
+
+  private void direct(Buffer buffer) throws Exception {
+    int pos = 0;
+    int length = buffer.getInt(pos);
+    pos += 4;
+    consume(new JsonObject(buffer.slice(pos, pos + length)));
+  }
+}

--- a/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/JsonEncodeBenchmark.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.benchmarks;
+
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * @author Thomas Segismont
+ */
+@State(Scope.Thread)
+public class JsonEncodeBenchmark extends BenchmarkBase {
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public static void consume(final Buffer buffer) {
+  }
+
+  private JsonObject small;
+  private JsonObject large;
+
+  @Setup
+  public void setup() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    small = loadJson(classLoader.getResource("small.json"));
+    large = loadJson(classLoader.getResource("large.json"));
+  }
+
+  private JsonObject loadJson(URL url) {
+    try {
+      return new JsonObject(Json.mapper.readValue(url, Map.class));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Benchmark
+  public void viaStringSmall() throws Exception {
+    viaString(small);
+  }
+
+  @Benchmark
+  public void viaStringLarge() throws Exception {
+    viaString(large);
+  }
+
+  private void viaString(JsonObject jsonObject) throws Exception {
+    Buffer buffer = Buffer.buffer();
+    String strJson = jsonObject.encode();
+    byte[] encoded = strJson.getBytes(CharsetUtil.UTF_8);
+    buffer.appendInt(encoded.length);
+    Buffer buff = Buffer.buffer(encoded);
+    buffer.appendBuffer(buff);
+    consume(buffer);
+  }
+
+  @Benchmark
+  public void directSmall() throws Exception {
+    direct(small);
+  }
+
+  @Benchmark
+  public void directLarge() throws Exception {
+    direct(large);
+  }
+
+  private void direct(JsonObject jsonObject) throws Exception {
+    Buffer buffer = Buffer.buffer();
+    Buffer encoded = jsonObject.toBuffer();
+    buffer.appendInt(encoded.length());
+    buffer.appendBuffer(encoded);
+    consume(buffer);
+  }
+}

--- a/src/test/resources/large.json
+++ b/src/test/resources/large.json
@@ -1,0 +1,100 @@
+{
+  "web-app": {
+    "servlet": [
+      {
+        "servlet-name": "cofaxCDS",
+        "servlet-class": "org.cofax.cds.CDSServlet",
+        "init-param": {
+          "configGlossary:installationAt": "Philadelphia, PA",
+          "configGlossary:adminEmail": "ksm@pobox.com",
+          "configGlossary:poweredBy": "Cofax",
+          "configGlossary:poweredByIcon": "/images/cofax.gif",
+          "configGlossary:staticPath": "/content/static",
+          "templateProcessorClass": "org.cofax.WysiwygTemplate",
+          "templateLoaderClass": "org.cofax.FilesTemplateLoader",
+          "templatePath": "templates",
+          "templateOverridePath": "",
+          "defaultListTemplate": "listTemplate.htm",
+          "defaultFileTemplate": "articleTemplate.htm",
+          "useJSP": false,
+          "jspListTemplate": "listTemplate.jsp",
+          "jspFileTemplate": "articleTemplate.jsp",
+          "cachePackageTagsTrack": 200,
+          "cachePackageTagsStore": 200,
+          "cachePackageTagsRefresh": 60,
+          "cacheTemplatesTrack": 100,
+          "cacheTemplatesStore": 50,
+          "cacheTemplatesRefresh": 15,
+          "cachePagesTrack": 200,
+          "cachePagesStore": 100,
+          "cachePagesRefresh": 10,
+          "cachePagesDirtyRead": 10,
+          "searchEngineListTemplate": "forSearchEnginesList.htm",
+          "searchEngineFileTemplate": "forSearchEngines.htm",
+          "searchEngineRobotsDb": "WEB-INF/robots.db",
+          "useDataStore": true,
+          "dataStoreClass": "org.cofax.SqlDataStore",
+          "redirectionClass": "org.cofax.SqlRedirection",
+          "dataStoreName": "cofax",
+          "dataStoreDriver": "com.microsoft.jdbc.sqlserver.SQLServerDriver",
+          "dataStoreUrl": "jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
+          "dataStoreUser": "sa",
+          "dataStorePassword": "dataStoreTestQuery",
+          "dataStoreTestQuery": "SET NOCOUNT ON;select test='test';",
+          "dataStoreLogFile": "/usr/local/tomcat/logs/datastore.log",
+          "dataStoreInitConns": 10,
+          "dataStoreMaxConns": 100,
+          "dataStoreConnUsageLimit": 100,
+          "dataStoreLogLevel": "debug",
+          "maxUrlLength": 500
+        }
+      },
+      {
+        "servlet-name": "cofaxEmail",
+        "servlet-class": "org.cofax.cds.EmailServlet",
+        "init-param": {
+          "mailHost": "mail1",
+          "mailHostOverride": "mail2"
+        }
+      },
+      {
+        "servlet-name": "cofaxAdmin",
+        "servlet-class": "org.cofax.cds.AdminServlet"
+      },
+      {
+        "servlet-name": "fileServlet",
+        "servlet-class": "org.cofax.cds.FileServlet"
+      },
+      {
+        "servlet-name": "cofaxTools",
+        "servlet-class": "org.cofax.cms.CofaxToolsServlet",
+        "init-param": {
+          "templatePath": "toolstemplates/",
+          "log": 1,
+          "logLocation": "/usr/local/tomcat/logs/CofaxTools.log",
+          "logMaxSize": "",
+          "dataLog": 1,
+          "dataLogLocation": "/usr/local/tomcat/logs/dataLog.log",
+          "dataLogMaxSize": "",
+          "removePageCache": "/content/admin/remove?cache=pages&id=",
+          "removeTemplateCache": "/content/admin/remove?cache=templates&id=",
+          "fileTransferFolder": "/usr/local/tomcat/webapps/content/fileTransferFolder",
+          "lookInContext": 1,
+          "adminGroupID": 4,
+          "betaServer": true
+        }
+      }
+    ],
+    "servlet-mapping": {
+      "cofaxCDS": "/",
+      "cofaxEmail": "/cofaxutil/aemail/*",
+      "cofaxAdmin": "/admin/*",
+      "fileServlet": "/static/*",
+      "cofaxTools": "/tools/*"
+    },
+    "taglib": {
+      "taglib-uri": "cofax.tld",
+      "taglib-location": "/WEB-INF/tlds/cofax.tld"
+    }
+  }
+}

--- a/src/test/resources/small.json
+++ b/src/test/resources/small.json
@@ -1,0 +1,25 @@
+{
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {
+        "GlossEntry": {
+          "ID": "SGML",
+          "SortAs": "SGML",
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": [
+              "GML",
+              "XML"
+            ]
+          },
+          "GlossSee": "markup"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2079 

With this change, codecs encode to and decode from Buffer directly.

The benchmark results are the following:

```
Benchmark                            Mode  Cnt    Score    Error   Units
JsonDecodeBenchmark.directLarge     thrpt   10   99,408 ±  0,592  ops/ms
JsonDecodeBenchmark.directSmall     thrpt   10  570,768 ±  3,802  ops/ms
JsonDecodeBenchmark.viaStringLarge  thrpt   10   79,384 ±  0,715  ops/ms
JsonDecodeBenchmark.viaStringSmall  thrpt   10  430,398 ± 13,331  ops/ms
JsonEncodeBenchmark.directLarge     thrpt   10  147,995 ±  1,050  ops/ms
JsonEncodeBenchmark.directSmall     thrpt   10  817,803 ±  5,216  ops/ms
JsonEncodeBenchmark.viaStringLarge  thrpt   10  111,845 ±  1,348  ops/ms
JsonEncodeBenchmark.viaStringSmall  thrpt   10  623,426 ±  4,568  ops/ms
```

Benefits range from +25% to 32%, depending on whether you are encoding/decoding a small/large payload.