### PR TITLE
BufferImpl should have a public noarg constructor to be used in AsyncMap

### DIFF
--- a/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
+++ b/src/main/java/io/vertx/core/buffer/impl/BufferImpl.java
@@ -36,7 +36,7 @@ public class BufferImpl implements Buffer {
 
   private ByteBuf buffer;
 
-  BufferImpl() {
+  public BufferImpl() {
     this(0);
   }
 

--- a/src/main/java/io/vertx/core/shareddata/impl/ClusterSerializable.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/ClusterSerializable.java
@@ -21,6 +21,8 @@ import io.vertx.core.buffer.Buffer;
 /**
  * Objects implementing this interface will be write to and read from a {@link Buffer} when respectively
  * stored and read from an {@link io.vertx.core.shareddata.AsyncMap}.
+ * <p>
+ * Implementations must have a public no-argument constructor.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */


### PR DESCRIPTION
Otherwise cluster managers can't create an instance after deserializing.

Follows up on #2019 and fixes build issues