### PR TITLE
Improve the CPU core detection on linux when executed in cgroups (Doc…

### DIFF
--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -19,6 +19,7 @@ package io.vertx.core;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.dns.AddressResolverOptions;
 import io.vertx.core.eventbus.EventBusOptions;
+import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.spi.cluster.ClusterManager;
@@ -38,7 +39,7 @@ public class VertxOptions {
   /**
    * The default number of event loop threads to be used  = 2 * number of cores on the machine
    */
-  public static final int DEFAULT_EVENT_LOOP_POOL_SIZE = 2 * Runtime.getRuntime().availableProcessors();
+  public static final int DEFAULT_EVENT_LOOP_POOL_SIZE = 2 * CpuCoreSensor.availableProcessors();
 
   /**
    * The default number of threads in the worker pool = 20

--- a/src/main/java/io/vertx/core/impl/cpu/CpuCoreSensor.java
+++ b/src/main/java/io/vertx/core/impl/cpu/CpuCoreSensor.java
@@ -31,7 +31,7 @@ import java.util.Locale;
  *
  * @author Jason T. Greene
  */
-public class ProcessorInfo {
+public class CpuCoreSensor {
 
     private static final String CPUS_ALLOWED = "Cpus_allowed:";
     private static final byte[] BITS = new byte[]{0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};

--- a/src/main/java/io/vertx/core/impl/cpu/CpuCoreSensor.java
+++ b/src/main/java/io/vertx/core/impl/cpu/CpuCoreSensor.java
@@ -1,109 +1,98 @@
 package io.vertx.core.impl.cpu;
-/*
- * JBoss, Home of Professional Open Source.
- * Copyright 2015 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import io.vertx.core.impl.launcher.commands.ExecUtils;
+
+import java.io.*;
 import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Locale;
 
 /**
- * Provides general information about the processors on this host.
+ * Utility class providing the number of CPU cores available. On Linux, to handle CGroups, it reads and
+ * parses the /proc/self/status file.
+ * <p>
+ * This class derives from https://github.com/wildfly/wildfly-common/blob/master/src/main/java/org/wildfly/common/cpu/ProcessorInfo.java
+ * licensed under the Apache Software License 2.0.
  *
  * @author Jason T. Greene
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
 public class CpuCoreSensor {
 
-    private static final String CPUS_ALLOWED = "Cpus_allowed:";
-    private static final byte[] BITS = new byte[]{0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
-    private static final Charset ASCII = Charset.forName("US-ASCII");
+  private static final String CPUS_ALLOWED = "Cpus_allowed:";
+  private static final byte[] BITS = new byte[]{0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
+  private static final Charset ASCII = Charset.forName("US-ASCII");
 
-    /**
-     * Returns the number of processors available to this process. On most operating systems this method
-     * simply delegates to {@link Runtime#availableProcessors()}. However, on Linux, this strategy
-     * is insufficient, since the JVM does not take into consideration the process' CPU set affinity
-     * which is employed by cgroups and numactl. Therefore this method will analyze the Linux proc filesystem
-     * to make the determination. Since the CPU affinity of a process can be change at any time, this method does
-     * not cache the result. Calls should be limited accordingly.
-     * <br>
-     * Note tha on Linux, both SMT units (Hyper-Threading) and CPU cores are counted as a processor.
-     *
-     * @return the available processors on this system.
-     */
-    public static int availableProcessors() {
-        if (System.getSecurityManager() != null) {
-            return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.valueOf(determineProcessors())).intValue();
-        }
-
-        return determineProcessors();
+  /**
+   * Returns the number of processors available to this process.
+   * <p>
+   * On most operating systems this method simply delegates to {@link Runtime#availableProcessors()}. However, on
+   * Linux, this strategy is insufficient, since the JVM does not take into consideration the process' CPU set affinity
+   * which is employed by cgroups and numactl. Therefore this method will analyze the Linux proc filesystem
+   * to make the determination.
+   * <p>
+   * Since the CPU affinity of a process can be change at any time, this method does not cache the result.
+   * <p>
+   * Note that on Linux, both SMT units (Hyper-Threading) and CPU cores are counted as a processor.
+   * <p>
+   * This method is used to configure the default number of event loops. This settings can be overridden by the user.
+   *
+   * @return the available processors on this system.
+   */
+  public static int availableProcessors() {
+    if (System.getSecurityManager() != null) {
+      return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> (determineProcessors()));
     }
 
-    private static int determineProcessors() {
-        int javaProcs = Runtime.getRuntime().availableProcessors();
-        if (!isLinux()) {
-            return javaProcs;
-        }
+    return determineProcessors();
+  }
 
-        int maskProcs = 0;
+  private static int determineProcessors() {
+    int fromJava = Runtime.getRuntime().availableProcessors();
+    int fromProcFile = 0;
 
-        try {
-            maskProcs = readCPUMask();
-        } catch (Exception e) {
-            // yum
-        }
-
-        return maskProcs > 0 ? Math.min(javaProcs, maskProcs) : javaProcs;
+    if (!ExecUtils.isLinux()) {
+      return fromJava;
     }
 
-    private static int readCPUMask() throws IOException {
-        final FileInputStream stream = new FileInputStream("/proc/self/status");
-        final InputStreamReader inputReader = new InputStreamReader(stream, ASCII);
-
-        try (BufferedReader reader = new BufferedReader(inputReader)) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                if (line.startsWith(CPUS_ALLOWED)) {
-                    int count = 0;
-                    int start = CPUS_ALLOWED.length();
-                    for (int i = start; i < line.length(); i++) {
-                         char ch = line.charAt(i);
-                         if (ch >= '0' && ch <= '9') {
-                             count += BITS[ch - '0'];
-                         } else if (ch >= 'a' && ch <= 'f') {
-                             count += BITS[ch - 'a' + 10];
-                         } else if (ch >= 'A' && ch <= 'F') {
-                             count += BITS[ch - 'A' + 10];
-                         }
-                     }
-                     return count;
-                 }
-             }
-         }
-
-         return -1;
-     }
-
-    private static boolean isLinux() {
-        String osArch = System.getProperty("os.name", "unknown").toLowerCase(Locale.US);
-        return (osArch.contains("linux"));
+    try {
+      fromProcFile = readCPUMask(new File("/proc/self/status"));
+    } catch (Exception e) {
+      // We can't do much at this point, we are on linux but using a different /proc format.
     }
+
+    return fromProcFile > 0 ? Math.min(fromJava, fromProcFile) : fromJava;
+  }
+
+  protected static int readCPUMask(File file) throws IOException {
+    if (file == null  || ! file.exists()) {
+      return -1;
+    }
+
+    final FileInputStream stream = new FileInputStream(file);
+    final InputStreamReader inputReader = new InputStreamReader(stream, ASCII);
+
+    try (BufferedReader reader = new BufferedReader(inputReader)) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.startsWith(CPUS_ALLOWED)) {
+          int count = 0;
+          int start = CPUS_ALLOWED.length();
+          for (int i = start; i < line.length(); i++) {
+            char ch = line.charAt(i);
+            if (ch >= '0' && ch <= '9') {
+              count += BITS[ch - '0'];
+            } else if (ch >= 'a' && ch <= 'f') {
+              count += BITS[ch - 'a' + 10];
+            } else if (ch >= 'A' && ch <= 'F') {
+              count += BITS[ch - 'A' + 10];
+            }
+          }
+          return count;
+        }
+      }
+    }
+
+    return -1;
+  }
 }

--- a/src/main/java/io/vertx/core/impl/cpu/LICENSE
+++ b/src/main/java/io/vertx/core/impl/cpu/LICENSE
@@ -1,0 +1,15 @@
+JBoss, Home of Professional Open Source.
+Copyright 2015 Red Hat, Inc., and individual contributors
+as indicated by the @author tags.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/main/java/io/vertx/core/impl/cpu/ProcessorInfo.java
+++ b/src/main/java/io/vertx/core/impl/cpu/ProcessorInfo.java
@@ -1,0 +1,109 @@
+package io.vertx.core.impl.cpu;
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Locale;
+
+/**
+ * Provides general information about the processors on this host.
+ *
+ * @author Jason T. Greene
+ */
+public class ProcessorInfo {
+
+    private static final String CPUS_ALLOWED = "Cpus_allowed:";
+    private static final byte[] BITS = new byte[]{0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4};
+    private static final Charset ASCII = Charset.forName("US-ASCII");
+
+    /**
+     * Returns the number of processors available to this process. On most operating systems this method
+     * simply delegates to {@link Runtime#availableProcessors()}. However, on Linux, this strategy
+     * is insufficient, since the JVM does not take into consideration the process' CPU set affinity
+     * which is employed by cgroups and numactl. Therefore this method will analyze the Linux proc filesystem
+     * to make the determination. Since the CPU affinity of a process can be change at any time, this method does
+     * not cache the result. Calls should be limited accordingly.
+     * <br>
+     * Note tha on Linux, both SMT units (Hyper-Threading) and CPU cores are counted as a processor.
+     *
+     * @return the available processors on this system.
+     */
+    public static int availableProcessors() {
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.valueOf(determineProcessors())).intValue();
+        }
+
+        return determineProcessors();
+    }
+
+    private static int determineProcessors() {
+        int javaProcs = Runtime.getRuntime().availableProcessors();
+        if (!isLinux()) {
+            return javaProcs;
+        }
+
+        int maskProcs = 0;
+
+        try {
+            maskProcs = readCPUMask();
+        } catch (Exception e) {
+            // yum
+        }
+
+        return maskProcs > 0 ? Math.min(javaProcs, maskProcs) : javaProcs;
+    }
+
+    private static int readCPUMask() throws IOException {
+        final FileInputStream stream = new FileInputStream("/proc/self/status");
+        final InputStreamReader inputReader = new InputStreamReader(stream, ASCII);
+
+        try (BufferedReader reader = new BufferedReader(inputReader)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(CPUS_ALLOWED)) {
+                    int count = 0;
+                    int start = CPUS_ALLOWED.length();
+                    for (int i = start; i < line.length(); i++) {
+                         char ch = line.charAt(i);
+                         if (ch >= '0' && ch <= '9') {
+                             count += BITS[ch - '0'];
+                         } else if (ch >= 'a' && ch <= 'f') {
+                             count += BITS[ch - 'a' + 10];
+                         } else if (ch >= 'A' && ch <= 'F') {
+                             count += BITS[ch - 'A' + 10];
+                         }
+                     }
+                     return count;
+                 }
+             }
+         }
+
+         return -1;
+     }
+
+    private static boolean isLinux() {
+        String osArch = System.getProperty("os.name", "unknown").toLowerCase(Locale.US);
+        return (osArch.contains("linux"));
+    }
+}

--- a/src/test/java/io/vertx/core/impl/CpuCoreSensorTest.java
+++ b/src/test/java/io/vertx/core/impl/CpuCoreSensorTest.java
@@ -1,0 +1,47 @@
+package io.vertx.core.impl;
+
+import io.vertx.core.impl.cpu.CpuCoreSensor;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+/**
+ * Tests that we can read the number of CPUs from /proc/self/status files.
+ *
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+public class CpuCoreSensorTest {
+  @Test
+  public void readRegular() throws Exception {
+    File file = new File("src/test/resources/cpus/status-1.txt");
+    assertThat(CpuCoreSensor.readCPUMask(file), is(1));
+  }
+
+  @Test
+  public void readRegular2() throws Exception {
+    File file = new File("src/test/resources/cpus/status-2.txt");
+    assertThat(CpuCoreSensor.readCPUMask(file), is(2));
+  }
+
+  @Test
+  public void readMissingFile() throws Exception {
+    File file = new File("src/test/resources/cpus/does-not-exist");
+    assertThat(CpuCoreSensor.readCPUMask(file), is(-1));
+  }
+
+  @Test
+  public void readMissingEntry() throws Exception {
+    File file = new File("src/test/resources/cpus/missing.txt");
+    assertThat(CpuCoreSensor.readCPUMask(file), is(-1));
+  }
+
+  @Test
+  public void readCorruptedFile() throws Exception {
+    File file = new File("src/test/resources/cpus/corrupted.txt");
+    assertThat(CpuCoreSensor.readCPUMask(file), is(-1));
+  }
+
+}

--- a/src/test/resources/cpus/corrupted.txt
+++ b/src/test/resources/cpus/corrupted.txt
@@ -1,0 +1,1 @@
+This is not a valid /proc/self/status file.

--- a/src/test/resources/cpus/missing.txt
+++ b/src/test/resources/cpus/missing.txt
@@ -1,0 +1,51 @@
+Name:	cat
+Umask:	0022
+State:	R (running)
+Tgid:	9
+Ngid:	0
+Pid:	9
+PPid:	1
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	256
+Groups:
+NStgid:	9
+NSpid:	9
+NSpgid:	9
+NSsid:	1
+VmPeak:	    4536 kB
+VmSize:	    4536 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	     692 kB
+VmRSS:	     692 kB
+RssAnon:	      76 kB
+RssFile:	     616 kB
+RssShmem:	       0 kB
+VmData:	     324 kB
+VmStk:	     132 kB
+VmExe:	      48 kB
+VmLib:	    1952 kB
+VmPTE:	      32 kB
+VmPMD:	      12 kB
+VmSwap:	       0 kB
+HugetlbPages:	       0 kB
+Threads:	1
+SigQ:	0/7757
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	0000000000000000
+SigIgn:	0000000000000000
+SigCgt:	0000000000000000
+CapInh:	00000000a80425fb
+CapPrm:	00000000a80425fb
+CapEff:	00000000a80425fb
+CapBnd:	00000000a80425fb
+CapAmb:	0000000000000000
+Seccomp:	2
+# no CPU entries
+Mems_allowed:	1
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	0
+nonvoluntary_ctxt_switches:	0

--- a/src/test/resources/cpus/status-1.txt
+++ b/src/test/resources/cpus/status-1.txt
@@ -1,0 +1,52 @@
+Name:	cat
+Umask:	0022
+State:	R (running)
+Tgid:	9
+Ngid:	0
+Pid:	9
+PPid:	1
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	256
+Groups:
+NStgid:	9
+NSpid:	9
+NSpgid:	9
+NSsid:	1
+VmPeak:	    4536 kB
+VmSize:	    4536 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	     692 kB
+VmRSS:	     692 kB
+RssAnon:	      76 kB
+RssFile:	     616 kB
+RssShmem:	       0 kB
+VmData:	     324 kB
+VmStk:	     132 kB
+VmExe:	      48 kB
+VmLib:	    1952 kB
+VmPTE:	      32 kB
+VmPMD:	      12 kB
+VmSwap:	       0 kB
+HugetlbPages:	       0 kB
+Threads:	1
+SigQ:	0/7757
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	0000000000000000
+SigIgn:	0000000000000000
+SigCgt:	0000000000000000
+CapInh:	00000000a80425fb
+CapPrm:	00000000a80425fb
+CapEff:	00000000a80425fb
+CapBnd:	00000000a80425fb
+CapAmb:	0000000000000000
+Seccomp:	2
+Cpus_allowed:	2
+Cpus_allowed_list:	0-1
+Mems_allowed:	1
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	0
+nonvoluntary_ctxt_switches:	0

--- a/src/test/resources/cpus/status-2.txt
+++ b/src/test/resources/cpus/status-2.txt
@@ -1,0 +1,52 @@
+Name:	cat
+Umask:	0022
+State:	R (running)
+Tgid:	9
+Ngid:	0
+Pid:	9
+PPid:	1
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	256
+Groups:
+NStgid:	9
+NSpid:	9
+NSpgid:	9
+NSsid:	1
+VmPeak:	    4536 kB
+VmSize:	    4536 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	     692 kB
+VmRSS:	     692 kB
+RssAnon:	      76 kB
+RssFile:	     616 kB
+RssShmem:	       0 kB
+VmData:	     324 kB
+VmStk:	     132 kB
+VmExe:	      48 kB
+VmLib:	    1952 kB
+VmPTE:	      32 kB
+VmPMD:	      12 kB
+VmSwap:	       0 kB
+HugetlbPages:	       0 kB
+Threads:	1
+SigQ:	0/7757
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	0000000000000000
+SigIgn:	0000000000000000
+SigCgt:	0000000000000000
+CapInh:	00000000a80425fb
+CapPrm:	00000000a80425fb
+CapEff:	00000000a80425fb
+CapBnd:	00000000a80425fb
+CapAmb:	0000000000000000
+Seccomp:	2
+Cpus_allowed:	3
+Cpus_allowed_list:	0-1
+Mems_allowed:	1
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	0
+nonvoluntary_ctxt_switches:	0


### PR DESCRIPTION
…ker container for instance)

This PR replaces the classic call to `availableProcessors` when running on Linux. This is because, when running in a docker environment or on the top of an hypervisor the JVM does not a great job to give us the right answer (returning the number of cores on the host machine instead of the container ones).

This PR proposes to read `/proc/self/status` to find the right number of core. 

On Windows and Mac, we still rely on the JVM method (which give the right answer).