### PR TITLE
Call the MessageConsumer end handler on explicit unregistration

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -516,7 +516,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
     // Unregister all handlers explicitly - don't rely on context hooks
     for (Handlers handlers: handlerMap.values()) {
       for (HandlerHolder holder: handlers.list) {
-        holder.getHandler().unregister(true);
+        holder.getHandler().unregister();
       }
     }
   }

--- a/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/HandlerRegistration.java
@@ -102,17 +102,13 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
 
   @Override
   public synchronized void unregister() {
-    unregister(false);
+    doUnregister(null);
   }
 
   @Override
   public synchronized void unregister(Handler<AsyncResult<Void>> completionHandler) {
     Objects.requireNonNull(completionHandler);
-    doUnregister(completionHandler, false);
-  }
-
-  public void unregister(boolean callEndHandler) {
-    doUnregister(null, callEndHandler);
+    doUnregister(completionHandler);
   }
 
   public void sendAsyncResultFailure(ReplyFailure failure, String msg) {
@@ -120,11 +116,11 @@ public class HandlerRegistration<T> implements MessageConsumer<T>, Handler<Messa
     asyncResultHandler.handle(Future.failedFuture(new ReplyException(failure, msg)));
   }
 
-  private void doUnregister(Handler<AsyncResult<Void>> completionHandler, boolean callEndHandler) {
+  private void doUnregister(Handler<AsyncResult<Void>> completionHandler) {
     if (timeoutID != -1) {
       vertx.cancelTimer(timeoutID);
     }
-    if (endHandler != null && callEndHandler) {
+    if (endHandler != null) {
       Handler<Void> theEndHandler = endHandler;
       Handler<AsyncResult<Void>> handler = completionHandler;
       completionHandler = ar -> {

--- a/src/test/java/io/vertx/test/core/LocalEventBusTest.java
+++ b/src/test/java/io/vertx/test/core/LocalEventBusTest.java
@@ -744,7 +744,7 @@ public class LocalEventBusTest extends EventBusTestBase {
     awaitLatch(latch);
     assertEquals(2, contexts.size());
   }
-  
+
   @Test
   public void testContextsPublish() throws Exception {
     Set<ContextImpl> contexts = new ConcurrentHashSet<>();
@@ -1121,13 +1121,8 @@ public class LocalEventBusTest extends EventBusTestBase {
 
   private void testUnregisterationOfRegisteredConsumerCallsEndHandler(MessageConsumer<String> consumer, ReadStream<?> readStream) {
     consumer.handler(msg -> {});
-    consumer.endHandler(v -> {
-      fail();
-    });
+    consumer.endHandler(v -> testComplete());
     consumer.unregister();
-    vertx.runOnContext(d -> {
-      testComplete();
-    });
     await();
   }
 


### PR DESCRIPTION
motivation: currently the MessageConsumer end handler is called only when consumer is unregistered during an event bus close. When the consumer is explicitly unregistered it is not called. This handler is mainly used by RxJava and Kotlin coroutines and it seems it would be best to call the end handler in all case to give an opportunity to end the treatment. In RxJava it would call the complete handler and in Kotlin it would close the underlying channel (so a for-each iteration on the channel would terminate and execute the code after).

change: call the MessageConsumer end handler when the MessageConsumer is unregistered explictly.