### PR TITLE
Added run context close hooks when verticle deployment fails.

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -490,11 +490,11 @@ public class DeploymentManager {
                 reportSuccess(deploymentID, callingContext, completionHandler);
               }
             } else if (!failureReported.get()) {
-              reportFailure(ar.cause(), callingContext, completionHandler);
+              context.runCloseHooks(closeHookAsyncResult -> reportFailure(ar.cause(), callingContext, completionHandler));
             }
           });
         } catch (Throwable t) {
-          reportFailure(t, callingContext, completionHandler);
+          context.runCloseHooks(closeHookAsyncResult -> reportFailure(t, callingContext, completionHandler));
         }
       });
     }


### PR DESCRIPTION
Only needed to change two lines in source and added a test to ensure close hooks were run when verticle failed to deploy.  If anything else needs to be done for this let me know.