### PR TITLE
Added run context close hooks when verticle deployment fails.

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -490,11 +490,11 @@ public class DeploymentManager {
                 reportSuccess(deploymentID, callingContext, completionHandler);
               }
             } else if (!failureReported.get()) {
-              reportFailure(ar.cause(), callingContext, completionHandler);
+              context.runCloseHooks(closeHookAsyncResult -> reportFailure(ar.cause(), callingContext, completionHandler));
             }
           });
         } catch (Throwable t) {
-          reportFailure(t, callingContext, completionHandler);
+          context.runCloseHooks(closeHookAsyncResult -> reportFailure(t, callingContext, completionHandler));
         }
       });
     }

--- a/src/test/java/io/vertx/test/core/DeploymentTest.java
+++ b/src/test/java/io/vertx/test/core/DeploymentTest.java
@@ -1361,8 +1361,10 @@ public class DeploymentTest extends VertxTestBase {
   @Test
   public void testFailedDeployRunsContextShutdownHook() throws Exception {
     CountDownLatch closeCountdownLatch = new CountDownLatch(1);
+    AtomicBoolean closableCalledFirst = new AtomicBoolean(false);
     Closeable closeable = completionHandler -> {
       closeCountdownLatch.countDown();
+      closableCalledFirst.set(true);
       completionHandler.handle(Future.succeededFuture());
     };
     Verticle v = new AbstractVerticle() {
@@ -1373,6 +1375,7 @@ public class DeploymentTest extends VertxTestBase {
       }
     };
     vertx.deployVerticle(v, asyncResult -> {
+      assertTrue(closableCalledFirst.get());    // ensure shutdown hook is called before deploy verticle callback
       assertTrue(asyncResult.failed());
       assertNull(asyncResult.result());
     });


### PR DESCRIPTION
Signed-off-by: Blake <blakehowell2@gmail.com>

Accidentally messed up history a bit so had to modify. Signed ECA and commit this time.