### PR TITLE
allow overriding cluster host and post in launcher by beforeStartingVertx()

### DIFF
--- a/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
+++ b/src/main/java/io/vertx/core/impl/launcher/commands/BareCommand.java
@@ -159,6 +159,12 @@ public class BareCommand extends ClasspathHandler {
     Vertx instance;
     if (isClustered()) {
       log.info("Starting clustering...");
+      if (!options.getClusterHost().equals(VertxOptions.DEFAULT_CLUSTER_HOST)) {
+        clusterHost = options.getClusterHost();
+      }
+      if (options.getClusterPort() != VertxOptions.DEFAULT_CLUSTER_PORT) {
+        clusterPort = options.getClusterPort();
+      }
       if (clusterHost == null) {
         clusterHost = getDefaultAddress();
         if (clusterHost == null) {

--- a/src/test/java/io/vertx/test/core/LauncherTest.java
+++ b/src/test/java/io/vertx/test/core/LauncherTest.java
@@ -62,7 +62,7 @@ public class LauncherTest extends VertxTestBase {
       throw new IllegalStateException("Cannot find the vertx-version.txt");
     } else {
       BufferedReader in = new BufferedReader(
-          new InputStreamReader(resource.openStream()));
+        new InputStreamReader(resource.openStream()));
       expectedVersion = in.readLine();
       in.close();
     }
@@ -432,9 +432,9 @@ public class LauncherTest extends VertxTestBase {
     MyLauncher launcher = new MyLauncher();
     String[] args;
     if (clustered) {
-      args = new String[] {"run", "java:" + TestVerticle.class.getCanonicalName(), "-cluster"};
+      args = new String[]{"run", "java:" + TestVerticle.class.getCanonicalName(), "-cluster"};
     } else {
-      args = new String[] {"run", "java:" + TestVerticle.class.getCanonicalName()};
+      args = new String[]{"run", "java:" + TestVerticle.class.getCanonicalName()};
     }
     launcher.dispatch(args);
     assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
@@ -508,7 +508,7 @@ public class LauncherTest extends VertxTestBase {
     // Should be ignored
 
     MyLauncher launcher = new MyLauncher();
-    String[] args =  {"run", "java:" + TestVerticle.class.getCanonicalName()};
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName()};
     launcher.dispatch(args);
     assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
 
@@ -524,23 +524,91 @@ public class LauncherTest extends VertxTestBase {
   public void testWhenPassingTheMainObject() throws Exception {
     MyLauncher launcher = new MyLauncher();
     int instances = 10;
-    launcher.dispatch(launcher, new String[] {"run", "java:" + TestVerticle.class.getCanonicalName(),
-        "-instances", "10"});
+    launcher.dispatch(launcher, new String[]{"run", "java:" + TestVerticle.class.getCanonicalName(),
+      "-instances", "10"});
     assertWaitUntil(() -> TestVerticle.instanceCount.get() == instances);
   }
 
   @Test
   public void testBare() throws Exception {
     MyLauncher launcher = new MyLauncher();
-    launcher.dispatch(new String[] {"bare"});
+    launcher.dispatch(new String[]{"bare"});
     assertWaitUntil(() -> launcher.afterStartingVertxInvoked);
   }
 
   @Test
   public void testBareAlias() throws Exception {
     MyLauncher launcher = new MyLauncher();
-    launcher.dispatch(new String[] {"-ha"});
+    launcher.dispatch(new String[]{"-ha"});
     assertWaitUntil(() -> launcher.afterStartingVertxInvoked);
+  }
+
+  @Test
+  public void testConfigureClusterHostPortFromProperties() throws Exception {
+    int clusterPort = TestUtils.randomHighPortInt();
+    System.setProperty(RunCommand.VERTX_OPTIONS_PROP_PREFIX + "clusterHost", "127.0.0.1");
+    System.setProperty(RunCommand.VERTX_OPTIONS_PROP_PREFIX + "clusterPort", Integer.toString(clusterPort));
+    MyLauncher launcher = new MyLauncher();
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-cluster"};
+    launcher.dispatch(args);
+    assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
+    assertEquals("127.0.0.1", launcher.options.getClusterHost());
+    assertEquals(clusterPort, launcher.options.getClusterPort());
+    assertNull(launcher.options.getClusterPublicHost());
+    assertEquals(-1, launcher.options.getClusterPublicPort());
+  }
+
+  @Test
+  public void testConfigureClusterHostPortFromCommandLine() throws Exception {
+    int clusterPort = TestUtils.randomHighPortInt();
+    MyLauncher launcher = new MyLauncher();
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-cluster", "--cluster-host", "127.0.0.1", "--cluster-port", Integer.toString(clusterPort)};
+    launcher.dispatch(args);
+    assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
+    assertEquals("127.0.0.1", launcher.options.getClusterHost());
+    assertEquals(clusterPort, launcher.options.getClusterPort());
+    assertNull(launcher.options.getClusterPublicHost());
+    assertEquals(-1, launcher.options.getClusterPublicPort());
+  }
+
+  @Test
+  public void testOverrideClusterHostPortFromProperties() throws Exception {
+    int clusterPort = TestUtils.randomHighPortInt();
+    int newClusterPort = TestUtils.randomHighPortInt();
+    int newClusterPublicPort = TestUtils.randomHighPortInt();
+    System.setProperty(RunCommand.VERTX_OPTIONS_PROP_PREFIX + "clusterHost", "127.0.0.2");
+    System.setProperty(RunCommand.VERTX_OPTIONS_PROP_PREFIX + "clusterPort", Integer.toString(clusterPort));
+    MyLauncher launcher = new MyLauncher();
+    launcher.clusterHost = "127.0.0.1";
+    launcher.clusterPort = newClusterPort;
+    launcher.clusterPublicHost = "127.0.0.3";
+    launcher.clusterPublicPort = newClusterPublicPort;
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-cluster"};
+    launcher.dispatch(args);
+    assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
+    assertEquals("127.0.0.1", launcher.options.getClusterHost());
+    assertEquals(newClusterPort, launcher.options.getClusterPort());
+    assertEquals("127.0.0.3", launcher.options.getClusterPublicHost());
+    assertEquals(newClusterPublicPort, launcher.options.getClusterPublicPort());
+  }
+
+  @Test
+  public void testOverrideClusterHostPortFromCommandLine() throws Exception {
+    int clusterPort = TestUtils.randomHighPortInt();
+    int newClusterPort = TestUtils.randomHighPortInt();
+    int newClusterPublicPort = TestUtils.randomHighPortInt();
+    MyLauncher launcher = new MyLauncher();
+    launcher.clusterHost = "127.0.0.1";
+    launcher.clusterPort = newClusterPort;
+    launcher.clusterPublicHost = "127.0.0.3";
+    launcher.clusterPublicPort = newClusterPublicPort;
+    String[] args = {"run", "java:" + TestVerticle.class.getCanonicalName(), "-cluster", "--cluster-host", "127.0.0.2", "--cluster-port", Integer.toString(clusterPort)};
+    launcher.dispatch(args);
+    assertWaitUntil(() -> TestVerticle.instanceCount.get() == 1);
+    assertEquals("127.0.0.1", launcher.options.getClusterHost());
+    assertEquals(newClusterPort, launcher.options.getClusterPort());
+    assertEquals("127.0.0.3", launcher.options.getClusterPublicHost());
+    assertEquals(newClusterPublicPort, launcher.options.getClusterPublicPort());
   }
 
   class MyLauncher extends Launcher {
@@ -552,7 +620,10 @@ public class LauncherTest extends VertxTestBase {
     VertxOptions options;
     DeploymentOptions deploymentOptions;
     JsonObject config;
-
+    String clusterHost;
+    int clusterPort;
+    String clusterPublicHost;
+    int clusterPublicPort;
 
     PrintStream stream = new PrintStream(out);
 
@@ -582,6 +653,13 @@ public class LauncherTest extends VertxTestBase {
     public void beforeStartingVertx(VertxOptions options) {
       beforeStartingVertxInvoked = true;
       this.options = options;
+      if (clusterHost != null) {
+        options.setClusterHost(clusterHost);
+        options.setClusterPort(clusterPort);
+        options.setClusterPublicHost(clusterPublicHost);
+        options.setClusterPublicPort(clusterPublicPort);
+        super.beforeStartingVertx(options);
+      }
     }
 
     @Override

--- a/src/test/java/io/vertx/test/core/TestUtils.java
+++ b/src/test/java/io/vertx/test/core/TestUtils.java
@@ -19,7 +19,6 @@
 
 package io.vertx.test.core;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.vertx.core.buffer.Buffer;
@@ -46,6 +45,7 @@ public class TestUtils {
 
   /**
    * Creates a Buffer of random bytes.
+   *
    * @param length The length of the Buffer
    * @return the Buffer
    */
@@ -55,6 +55,7 @@ public class TestUtils {
 
   /**
    * Create an array of random bytes
+   *
    * @param length The length of the created array
    * @return the byte array
    */
@@ -64,8 +65,9 @@ public class TestUtils {
 
   /**
    * Create an array of random bytes
-   * @param length The length of the created array
-   * @param avoid If true, the resulting array will not contain avoidByte
+   *
+   * @param length    The length of the created array
+   * @param avoid     If true, the resulting array will not contain avoidByte
    * @param avoidByte A byte that is not to be included in the resulting array
    * @return an array of random bytes
    */
@@ -84,8 +86,9 @@ public class TestUtils {
 
   /**
    * Creates a Buffer containing random bytes
-   * @param length the size of the Buffer to create
-   * @param avoid if true, the resulting Buffer will not contain avoidByte
+   *
+   * @param length    the size of the Buffer to create
+   * @param avoid     if true, the resulting Buffer will not contain avoidByte
    * @param avoidByte A byte that is not to be included in the resulting array
    * @return a Buffer of random bytes
    */
@@ -113,6 +116,13 @@ public class TestUtils {
    */
   public static int randomPortInt() {
     return random.nextInt(65536);
+  }
+
+  /**
+   * @return a random port > 1024
+   */
+  public static int randomHighPortInt() {
+    return random.nextInt(65536 - 1024) + 1024;
   }
 
   /**
@@ -157,14 +167,14 @@ public class TestUtils {
    * @return a random char
    */
   public static char randomChar() {
-    return (char)(random.nextInt(16));
+    return (char) (random.nextInt(16));
   }
 
   /**
    * @return a random short
    */
   public static short randomShort() {
-    return (short)(random.nextInt(1 << 15));
+    return (short) (random.nextInt(1 << 15));
   }
 
   /**
@@ -183,6 +193,7 @@ public class TestUtils {
 
   /**
    * Creates a String containing random unicode characters
+   *
    * @param length The length of the string to create
    * @return a String of random unicode characters
    */
@@ -200,6 +211,7 @@ public class TestUtils {
 
   /**
    * Creates a random string of ascii alpha characters
+   *
    * @param length the length of the string to create
    * @return a String of random ascii alpha characters
    */
@@ -214,6 +226,7 @@ public class TestUtils {
 
   /**
    * Create random {@link Http2Settings} with valid values.
+   *
    * @return the random settings
    */
   public static Http2Settings randomHttp2Settings() {
@@ -250,6 +263,7 @@ public class TestUtils {
 
   /**
    * Determine if two byte arrays are equal
+   *
    * @param b1 The first byte array to compare
    * @param b2 The second byte array to compare
    * @return true if the byte arrays are equal
@@ -264,6 +278,7 @@ public class TestUtils {
 
   /**
    * Asserts that an IllegalArgumentException is thrown by the code block.
+   *
    * @param runnable code block to execute
    */
   public static void assertIllegalArgumentException(Runnable runnable) {
@@ -277,6 +292,7 @@ public class TestUtils {
 
   /**
    * Asserts that a NullPointerException is thrown by the code block.
+   *
    * @param runnable code block to execute
    */
   public static void assertNullPointerException(Runnable runnable) {
@@ -290,6 +306,7 @@ public class TestUtils {
 
   /**
    * Asserts that an IllegalStateException is thrown by the code block.
+   *
    * @param runnable code block to execute
    */
   public static void assertIllegalStateException(Runnable runnable) {
@@ -303,6 +320,7 @@ public class TestUtils {
 
   /**
    * Asserts that an IndexOutOfBoundsException is thrown by the code block.
+   *
    * @param runnable code block to execute
    */
   public static void assertIndexOutOfBoundsException(Runnable runnable) {
@@ -313,7 +331,7 @@ public class TestUtils {
       // OK
     }
   }
-  
+
   /**
    * @param source
    * @return gzipped data
@@ -371,9 +389,9 @@ public class TestUtils {
 
   public static Buffer leftPad(int padding, Buffer buffer) {
     return Buffer.buffer(Unpooled.buffer()
-        .writerIndex(padding)
-        .readerIndex(padding)
-        .writeBytes(buffer.getByteBuf())
+      .writerIndex(padding)
+      .readerIndex(padding)
+      .writeBytes(buffer.getByteBuf())
     );
   }
 


### PR DESCRIPTION
should work on osx as well (by only binding to 127.0.0.1)
