### PR TITLE
add idle timeout for sockets to leak

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -270,6 +270,9 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
                 if (DISABLE_HC2) {
                   configureHttp1(pipeline);
                 } else {
+                  if (options.getIdleTimeout() > 0) {
+                    pipeline.addLast("idle", new IdleStateHandler(0, 0, options.getIdleTimeout()));
+                  }
                   pipeline.addLast(new Http1xOrHttp2Handler());
                 }
               }
@@ -941,6 +944,9 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
     @Override
     protected void configure(ChannelHandlerContext ctx, boolean h2c) {
+      if (options.getIdleTimeout() > 0) {
+        ctx.pipeline().remove("idle");
+      }
       if (h2c) {
         handleHttp2(ctx.channel());
       } else {


### PR DESCRIPTION
Channel missing link in the process of initialization, there may be links to the risk of leakage.