### PR TITLE
Provide an exception handler on HttpServer and NetServer to process uncaught connection errors

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -73,6 +73,16 @@ public interface HttpServer extends Measured {
   HttpServer connectionHandler(Handler<HttpConnection> handler);
 
   /**
+   * Set an exception handler called for socket errors happening before the HTTP connection
+   * is established, e.g during the TLS handshake.
+   *
+   * @param handler the handler to set
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  HttpServer exceptionHandler(Handler<Throwable> handler);
+
+  /**
    * Return the websocket stream for the server. If a websocket connect handshake is successful a
    * new {@link ServerWebSocket} instance will be created and passed to the stream {@link io.vertx.core.streams.ReadStream#handler(io.vertx.core.Handler)}.
    *

--- a/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
@@ -32,11 +32,17 @@ public class HttpHandlers {
   final Handler<HttpServerRequest> requesthHandler;
   final Handler<ServerWebSocket> wsHandler;
   final Handler<HttpConnection> connectionHandler;
+  final Handler<Throwable> exceptionHandler;
 
-  public HttpHandlers(Handler<HttpServerRequest> requesthHandler, Handler<ServerWebSocket> wsHandler, Handler<HttpConnection> connectionHandler) {
+  public HttpHandlers(
+    Handler<HttpServerRequest> requesthHandler,
+    Handler<ServerWebSocket> wsHandler,
+    Handler<HttpConnection> connectionHandler,
+    Handler<Throwable> exceptionHandler) {
     this.requesthHandler = requesthHandler;
     this.wsHandler = wsHandler;
     this.connectionHandler = connectionHandler;
+    this.exceptionHandler = exceptionHandler;
   }
 
   @Override
@@ -49,6 +55,7 @@ public class HttpHandlers {
     if (!Objects.equals(requesthHandler, that.requesthHandler)) return false;
     if (!Objects.equals(wsHandler, that.wsHandler)) return false;
     if (!Objects.equals(connectionHandler, that.connectionHandler)) return false;
+    if (!Objects.equals(exceptionHandler, that.exceptionHandler)) return false;
 
     return true;
   }
@@ -64,6 +71,9 @@ public class HttpHandlers {
     }
     if (connectionHandler != null) {
       result = 31 * result + connectionHandler.hashCode();
+    }
+    if (exceptionHandler != null) {
+      result = 31 * result + exceptionHandler.hashCode();
     }
     return result;
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -95,7 +95,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -111,6 +110,7 @@ import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
 public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
   private static final Logger log = LoggerFactory.getLogger(HttpServerImpl.class);
+  private static final Handler<Throwable> DEFAULT_EXCEPTION_HANDLER = t -> log.trace("Connection failure", t);
   private static final String FLASH_POLICY_HANDLER_PROP_NAME = "vertx.flashPolicyHandler";
   private static final boolean USE_FLASH_POLICY_HANDLER = Boolean.getBoolean(FLASH_POLICY_HANDLER_PROP_NAME);
   private static final String DISABLE_WEBSOCKETS_PROP_NAME = "vertx.disableWebsockets";
@@ -141,7 +141,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
   private ContextImpl listenContext;
   private HttpServerMetrics metrics;
   private boolean logEnabled;
-  private Handler<Throwable> connectionExceptionHandler;
+  private Handler<Throwable> exceptionHandler;
 
   public HttpServerImpl(VertxInternal vertx, HttpServerOptions options) {
     this.options = new HttpServerOptions(options);
@@ -155,7 +155,6 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     }
     this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
     this.logEnabled = options.getLogActivity();
-    connectionExceptionHandler = t -> {log.trace("Connection failure", t);};
   }
 
   @Override
@@ -186,6 +185,15 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       throw new IllegalStateException("Please set handler before server is listening");
     }
     connectionHandler = handler;
+    return this;
+  }
+
+  @Override
+  public synchronized HttpServer exceptionHandler(Handler<Throwable> handler) {
+    if (listening) {
+      throw new IllegalStateException("Please set handler before server is listening");
+    }
+    exceptionHandler = handler;
     return this;
   }
 
@@ -259,13 +267,24 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
               }
               ChannelPipeline pipeline = ch.pipeline();
               if (sslHelper.isSSL()) {
+                io.netty.util.concurrent.Future<Channel> handshakeFuture;
                 if (options.isSni()) {
                   VertxSniHandler sniHandler = new VertxSniHandler(sslHelper, vertx);
                   pipeline.addLast(sniHandler);
+                  handshakeFuture = sniHandler.handshakeFuture();
                 } else {
-                  pipeline.addLast("ssl", new SslHandler(sslHelper.createEngine(vertx)));
+                  SslHandler handler = new SslHandler(sslHelper.createEngine(vertx));
+                  pipeline.addLast("ssl", handler);
+                  handshakeFuture = handler.handshakeFuture();
                 }
-                postSSLConfig(pipeline);
+                handshakeFuture.addListener(future -> {
+                  if (future.isSuccess()) {
+                    postSSLConfig(pipeline);
+                  } else {
+                    HandlerHolder<HttpHandlers> handler = httpHandlerMgr.chooseHandler(ch.eventLoop());
+                    handler.context.executeFromIO(() -> handler.handler.exceptionHandler.handle(future.cause()));
+                  }
+                });
               } else {
                 if (DISABLE_HC2) {
                   configureHttp1(pipeline);
@@ -331,13 +350,6 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     return this;
   }
 
-  // Visible for testing
-  public HttpServerImpl setConnectionExceptionHandler(Handler<Throwable> connectionExceptionHandler) {
-    Objects.requireNonNull(connectionExceptionHandler, "connectionExceptionHandler");
-    this.connectionExceptionHandler = connectionExceptionHandler;
-    return this;
-  }
-
   private VertxHttp2ConnectionHandler<Http2ServerConnection> setHandler(HandlerHolder<HttpHandlers> holder, Http2Settings upgrade, Channel ch) {
     return new VertxHttp2ConnectionHandlerBuilder<Http2ServerConnection>(ch)
         .connectionMap(connectionMap2)
@@ -371,6 +383,11 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
           } else {
             handleHttp2(pipeline.channel());
           }
+        }
+        @Override
+        protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+          // Will close the channel
+          super.handshakeFailure(ctx, cause);
         }
       });
     } else {
@@ -478,7 +495,13 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
       if (actualServer != null) {
 
-        actualServer.httpHandlerMgr.removeHandler(new HttpHandlers(requestStream.handler(), wsStream.handler(), connectionHandler), listenContext);
+        actualServer.httpHandlerMgr.removeHandler(
+          new HttpHandlers(
+            requestStream.handler(),
+            wsStream.handler(),
+            connectionHandler,
+            exceptionHandler == null ? DEFAULT_EXCEPTION_HANDLER : exceptionHandler)
+          , listenContext);
 
         if (actualServer.httpHandlerMgr.hasHandlers()) {
           // The actual server still has handlers so we don't actually close it
@@ -540,7 +563,13 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
 
   private void addHandlers(HttpServerImpl server, ContextImpl context) {
-    server.httpHandlerMgr.addHandler(new HttpHandlers(requestStream.handler(), wsStream.handler(), connectionHandler), context);
+    server.httpHandlerMgr.addHandler(
+      new HttpHandlers(
+        requestStream.handler(),
+        wsStream.handler(),
+        connectionHandler,
+        exceptionHandler == null ? DEFAULT_EXCEPTION_HANDLER : exceptionHandler)
+      , context);
   }
 
   private void actualClose(final ContextImpl closeContext, final Handler<AsyncResult<Void>> done) {
@@ -951,8 +980,8 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
       super.exceptionCaught(ctx, cause);
-      HandlerHolder<HttpHandlers> reqHandler = httpHandlerMgr.chooseHandler(ctx.channel().eventLoop());
-      reqHandler.context.executeFromIO(() -> HttpServerImpl.this.connectionExceptionHandler.handle(cause));
+      HandlerHolder<HttpHandlers> handler = httpHandlerMgr.chooseHandler(ctx.channel().eventLoop());
+      handler.context.executeFromIO(() -> handler.handler.exceptionHandler.handle(cause));
+    }
   }
-}
 }

--- a/src/main/java/io/vertx/core/net/NetServer.java
+++ b/src/main/java/io/vertx/core/net/NetServer.java
@@ -124,6 +124,16 @@ public interface NetServer extends Measured {
   NetServer listen(int port, Handler<AsyncResult<NetServer>> listenHandler);
 
   /**
+   * Set an exception handler called for socket errors happening before the connection
+   * is passed to the {@link #connectHandler}, e.g during the TLS handshake.
+   *
+   * @param handler the handler to set
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  NetServer exceptionHandler(Handler<Throwable> handler);
+
+  /**
    * Close the server. This will close any currently open connections. The close may not complete until after this
    * method has returned.
    */

--- a/src/test/benchmarks/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
+++ b/src/test/benchmarks/io/vertx/benchmarks/HttpServerHandlerBenchmark.java
@@ -231,7 +231,7 @@ public class HttpServerHandlerBenchmark extends BenchmarkBase {
           .add(HEADER_CONTENT_LENGTH, HELLO_WORLD_LENGTH);
       response.end(HELLO_WORLD_BUFFER);
     };
-    HandlerHolder<HttpHandlers> holder = new HandlerHolder<>(context, new HttpHandlers(app, null, null));
+    HandlerHolder<HttpHandlers> holder = new HandlerHolder<>(context, new HttpHandlers(app, null, null, null));
     ServerHandler handler = new ServerHandler(null, new HttpServerOptions(), "localhost", holder, null);
     vertxChannel.pipeline().addLast("handler", handler);
 

--- a/src/test/java/io/vertx/test/core/HttpConnectionEarlyResetTest.java
+++ b/src/test/java/io/vertx/test/core/HttpConnectionEarlyResetTest.java
@@ -46,11 +46,11 @@ public class HttpConnectionEarlyResetTest extends VertxTestBase {
     CountDownLatch listenLatch = new CountDownLatch(1);
     httpServer = vertx.createHttpServer()
       .requestHandler(request -> {})
+      .exceptionHandler(t -> {
+        caught.set(t);
+        resetLatch.countDown();
+      })
       .listen(8080, onSuccess(server -> listenLatch.countDown()));
-    ((HttpServerImpl) httpServer).setConnectionExceptionHandler(t -> {
-      caught.set(t);
-      resetLatch.countDown();
-    });
     awaitLatch(listenLatch);
   }
 

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -1524,6 +1524,10 @@ public class NetTest extends VertxTestBase {
 
       options.setPort(4043);
       server = vertx.createNetServer(options);
+      if (!shouldPass) {
+        waitForMore(1);
+      }
+      server.exceptionHandler(err -> complete());
       Handler<NetSocket> serverHandler = socket -> {
         indicatedServerName = socket.indicatedServerName();
         if (socket.isSsl()) {
@@ -1599,7 +1603,7 @@ public class NetTest extends VertxTestBase {
               received.appendBuffer(buffer);
               if (received.length() == expected.length()) {
                 assertEquals(expected, received);
-                testComplete();
+                complete();
               }
               if (startTLS && !upgradedClient.get()) {
                 upgradedClient.set(true);
@@ -1634,7 +1638,7 @@ public class NetTest extends VertxTestBase {
             if (shouldPass) {
               fail("Should not fail to connect");
             } else {
-              testComplete();
+              complete();
             }
           }
         });


### PR DESCRIPTION
fixes #2128

motivation: currently the `HttpServer` forwards connection errors to the `HttpConnection` associated with the channel. It happens that the channel can fail before an `HttpConnection` is created, e.g SSL handshake failure. Application can have an interest to handle such failures for auditing purposes. In addition an existing internal handler already exists for testing purposes. The same can be done for `NetServer`.

changes: add an exception handler on `HttpServer` to process channel errors before an `HttpConnection` is created. Make sure also that `HttpConnection` is created after the SSL handshake for HTTP/1 as it was for HTTP/2 due to ALPN (the ALPN negotiation defers the creation of `HtppConnection` after the SSL handshake when the negotiated protocol is determined), which implements a consistent behavior. The same for `NetServer`.