### PR TITLE
Serialize messages sent to the connection in the order of the synchronization monitor

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -484,7 +484,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
       RandomAccessFile raf = null;
       try {
         raf = new RandomAccessFile(file, "r");
-        conn.queueForWrite(new DefaultHttpResponse(version, status, headers));
+        conn.writeToChannel(new DefaultHttpResponse(version, status, headers));
         conn.sendFile(raf, Math.min(offset, file.length()), contentLength);
       } catch (IOException e) {
         try {

--- a/src/main/java/io/vertx/core/http/impl/ServerConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerConnection.java
@@ -205,16 +205,16 @@ public class ServerConnection extends Http1xConnectionBase implements HttpConnec
   }
 
   @Override
-  public void writeToChannel(Object obj, ChannelPromise promise) {
+  public void writeToChannel(Object msg, ChannelPromise promise) {
     if (METRICS_ENABLED && metrics != null) {
-      long bytes = getBytes(obj);
+      long bytes = getBytes(msg);
       if (bytes == -1) {
-        log.warn("Metrics could not be updated to include bytes written because of unknown object " + obj.getClass() + " being written.");
+        log.warn("Metrics could not be updated to include bytes written because of unknown object " + msg.getClass() + " being written.");
       } else {
         bytesWritten += bytes;
       }
     }
-    super.writeToChannel(obj, promise);
+    super.writeToChannel(msg, promise);
   }
 
   ServerWebSocket upgrade(HttpServerRequest request, HttpRequest nettyReq) {

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -56,43 +56,13 @@ public abstract class ConnectionBase {
   private Handler<Void> closeHandler;
   private boolean read;
   private boolean needsFlush;
-  private Thread ctxThread;
-  private boolean needsAsyncFlush;
+  private int writeInProgress;
   private Object metric;
 
   protected ConnectionBase(VertxInternal vertx, ChannelHandlerContext chctx, ContextImpl context) {
     this.vertx = vertx;
     this.chctx = chctx;
     this.context = context;
-  }
-
-  public synchronized final void startRead() {
-    checkContext();
-    read = true;
-    if (ctxThread == null) {
-      ctxThread = Thread.currentThread();
-    }
-  }
-
-  protected synchronized final void endReadAndFlush() {
-    read = false;
-    if (needsFlush) {
-      needsFlush = false;
-      if (needsAsyncFlush) {
-        // If the connection has been written to from outside the event loop thread e.g. from a worker thread
-        // Then Netty might end up executing the flush *before* the write as Netty checks for event loop and if not
-        // it executes using the executor.
-        // To avoid this ordering issue we must runOnContext in this situation
-        context.runOnContext(v -> chctx.flush());
-      } else {
-        // flush now
-        chctx.flush();
-      }
-    }
-  }
-
-  public void queueForWrite(final Object obj) {
-    queueForWrite(obj, chctx.voidPromise());
   }
 
   /**
@@ -105,22 +75,56 @@ public abstract class ConnectionBase {
     return obj;
   }
 
-  public synchronized void queueForWrite(final Object obj, ChannelPromise promise) {
-    needsFlush = true;
-    needsAsyncFlush = Thread.currentThread() != ctxThread;
-    chctx.write(encode(obj), promise);
+  public synchronized final void startRead() {
+    checkContext();
+    read = true;
+  }
+
+  protected synchronized final void endReadAndFlush() {
+    if (read) {
+      read = false;
+      if (needsFlush && writeInProgress == 0) {
+        needsFlush = false;
+        chctx.flush();
+      }
+    }
+  }
+
+  private void write(Object msg, ChannelPromise promise) {
+    msg = encode(msg);
+    if (read || writeInProgress > 0) {
+      needsFlush = true;
+      chctx.write(msg, promise);
+    } else {
+      needsFlush = false;
+      chctx.writeAndFlush(msg, promise);
+    }
+  }
+
+  public synchronized void writeToChannel(Object msg, ChannelPromise promise) {
+    // Make sure we serialize all the messages as this method can be called from various threads:
+    // two "sequential" calls to writeToChannel (we can say that as it is synchronized) should preserve
+    // the message order independently of the thread. To achieve this we need to reschedule messages
+    // not on the event loop or if there are pending async message for the channel.
+    if (chctx.executor().inEventLoop() && writeInProgress == 0) {
+      write(msg, promise);
+    } else {
+      queueForWrite(msg, promise);
+    }
+  }
+
+  private void queueForWrite(Object msg, ChannelPromise promise) {
+    writeInProgress++;
+    context.runOnContext(v -> {
+      synchronized (ConnectionBase.this) {
+        writeInProgress--;
+        write(msg, promise);
+      }
+    });
   }
 
   public void writeToChannel(Object obj) {
     writeToChannel(obj, chctx.voidPromise());
-  }
-
-  public synchronized void writeToChannel(Object obj, ChannelPromise promise) {
-    if (read) {
-      queueForWrite(obj, promise);
-    } else {
-      chctx.writeAndFlush(encode(obj), promise);
-    }
   }
 
   // This is a volatile read inside the Netty channel implementation


### PR DESCRIPTION
motivation: currently the `ConnectionBase` class does not  serialize the messages written with `writeToChannel` to the underlying channel when a message is written outside of the event loop followed by a message written from the event loop thread. This can cause out of order issues when ordering is assumed by the Vert.x code using `ConnectionBase`, for instance calling `HttpClientRequest#end()` outside of the event loop sends an last `HttpContent` message to the channel then release the connection to the pool (with pipelining), this connection might be provided then to a waiter that uses it and send pipelined messages, e.g an `HttpRequest` message.

changes: change the implementation of `writeToChannel` and write the message to the channel when the current thread is the event loop or there are no asynchronous message _write in progress_ otherwise a write task is scheduled causing further messages to be scheduled as well. Two sequential calls to `writeToChannel` (the method is synchronized) will have their messages in the same order the synchronization monitor (the class) allowed. In particular an asynchronous task calling `writeToChannel` started after a call to `writeToChannel` will have its message sent after.
