### PR TITLE
JsonParser fails to handle floating point numbers in buffering mode

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
+++ b/src/main/java/io/vertx/core/parsetools/impl/JsonParserImpl.java
@@ -322,6 +322,9 @@ public class JsonParserImpl implements JsonParser {
           case VALUE_NUMBER_INT:
             buffer.writeNumber(parser.getLongValue());
             break;
+          case VALUE_NUMBER_FLOAT:
+            buffer.writeNumber(parser.getDoubleValue());
+            break;
           case VALUE_STRING:
             buffer.writeString(parser.getText());
             break;


### PR DESCRIPTION
Fixes #2155

Missing switch branch in buffering mode.
Updated the tests (added floating point value and, while at it, base64/byte array value)