### PR TITLE
Enable websocket compression

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -983,6 +983,14 @@ Set the trust options in jks format, aka Java truststore
 +++
 Set whether compression is enabled
 +++
+|[[tryWebsocketDeflateFrameCompression]]`tryWebsocketDeflateFrameCompression`|`Boolean`|
++++
+Set option to offer Deflate Frame websocket compression
++++
+|[[tryWebsocketTryPermessageDefalteCompression]]`tryWebsocketTryPermessageDefalteCompression`|`Boolean`|
++++
+Set option to offer Permessage Deflate websocket compression
++++
 |[[useAlpn]]`useAlpn`|`Boolean`|
 +++
 Set the ALPN usage.
@@ -994,6 +1002,22 @@ Set whether Netty pooled buffers are enabled
 |[[verifyHost]]`verifyHost`|`Boolean`|
 +++
 Set whether hostname verification is enabled
++++
+|[[websocketCompressionAllowClientNoContext]]`websocketCompressionAllowClientNoContext`|`Boolean`|
++++
+Set the websocket compression allow client no context option
++++
+|[[websocketCompressionDeflateUseWebkitName]]`websocketCompressionDeflateUseWebkitName`|`Boolean`|
++++
+Sets the option to use the webkit name with the deflate frame compression
++++
+|[[websocketCompressionLevel]]`websocketCompressionLevel`|`Number (int)`|
++++
+Set websocket compression level
++++
+|[[websocketCompressionRequestServerNoContext]]`websocketCompressionRequestServerNoContext`|`Boolean`|
++++
+Set the websocket compression server no context option
 +++
 |===
 
@@ -1224,6 +1248,30 @@ Set the ALPN usage.
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|[[websocketAllowServerNoContext]]`websocketAllowServerNoContext`|`Boolean`|
++++
+Set the WebSocket Allow Server No Context option
++++
+|[[websocketCompressionLevel]]`websocketCompressionLevel`|`Number (int)`|
++++
+Set the WebSocket compression level
++++
+|[[websocketFrameDeflateCompressionSupported]]`websocketFrameDeflateCompressionSupported`|`Boolean`|
++++
+Enable or disable support for WebSocket Defalte Frame compression
++++
+|[[websocketPermessageDeflateCompressionIsSupported]]`websocketPermessageDeflateCompressionIsSupported`|`Boolean`|
++++
+Get whether WebSocket Permessage Deflate compression is supported
++++
+|[[websocketPermessageDeflateCompressionSupported]]`websocketPermessageDeflateCompressionSupported`|`Boolean`|
++++
+Enable or disable support for WebSocket Permessage Deflate compression
++++
+|[[websocketPreferredClientNoContext]]`websocketPreferredClientNoContext`|`Boolean`|
++++
+Set the WebSocket Preferred Client No Context setting
 +++
 |[[websocketSubProtocols]]`websocketSubProtocols`|`String`|
 +++

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -104,8 +104,26 @@ import io.vertx.core.json.JsonArray;
     if (json.getValue("tryUseCompression") instanceof Boolean) {
       obj.setTryUseCompression((Boolean)json.getValue("tryUseCompression"));
     }
+    if (json.getValue("tryWebsocketDeflateFrameCompression") instanceof Boolean) {
+      obj.setTryWebsocketDeflateFrameCompression((Boolean)json.getValue("tryWebsocketDeflateFrameCompression"));
+    }
+    if (json.getValue("tryWebsocketTryPermessageDefalteCompression") instanceof Boolean) {
+      obj.setTryWebsocketTryPermessageDefalteCompression((Boolean)json.getValue("tryWebsocketTryPermessageDefalteCompression"));
+    }
     if (json.getValue("verifyHost") instanceof Boolean) {
       obj.setVerifyHost((Boolean)json.getValue("verifyHost"));
+    }
+    if (json.getValue("websocketCompressionAllowClientNoContext") instanceof Boolean) {
+      obj.setWebsocketCompressionAllowClientNoContext((Boolean)json.getValue("websocketCompressionAllowClientNoContext"));
+    }
+    if (json.getValue("websocketCompressionDeflateUseWebkitName") instanceof Boolean) {
+      obj.setWebsocketCompressionDeflateUseWebkitName((Boolean)json.getValue("websocketCompressionDeflateUseWebkitName"));
+    }
+    if (json.getValue("websocketCompressionLevel") instanceof Number) {
+      obj.setWebsocketCompressionLevel(((Number)json.getValue("websocketCompressionLevel")).intValue());
+    }
+    if (json.getValue("websocketCompressionRequestServerNoContext") instanceof Boolean) {
+      obj.setWebsocketCompressionRequestServerNoContext((Boolean)json.getValue("websocketCompressionRequestServerNoContext"));
     }
   }
 
@@ -145,5 +163,9 @@ import io.vertx.core.json.JsonArray;
     json.put("sendUnmaskedFrames", obj.isSendUnmaskedFrames());
     json.put("tryUseCompression", obj.isTryUseCompression());
     json.put("verifyHost", obj.isVerifyHost());
+    json.put("websocketCompressionAllowClientNoContext", obj.getWebsocketCompressionAllowClientNoContext());
+    json.put("websocketCompressionDeflateUseWebkitName", obj.getWebsocketCompressionDeflateUseWebkitName());
+    json.put("websocketCompressionLevel", obj.getWebsocketCompressionLevel());
+    json.put("websocketCompressionRequestServerNoContext", obj.getWebsocketCompressionRequestServerNoContext());
   }
 }

--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -74,6 +74,21 @@ import io.vertx.core.json.JsonArray;
     if (json.getValue("maxWebsocketMessageSize") instanceof Number) {
       obj.setMaxWebsocketMessageSize(((Number)json.getValue("maxWebsocketMessageSize")).intValue());
     }
+    if (json.getValue("websocketAllowServerNoContext") instanceof Boolean) {
+      obj.setWebsocketAllowServerNoContext((Boolean)json.getValue("websocketAllowServerNoContext"));
+    }
+    if (json.getValue("websocketCompressionLevel") instanceof Number) {
+      obj.setWebsocketCompressionLevel(((Number)json.getValue("websocketCompressionLevel")).intValue());
+    }
+    if (json.getValue("websocketFrameDeflateCompressionSupported") instanceof Boolean) {
+      obj.setWebsocketFrameDeflateCompressionSupported((Boolean)json.getValue("websocketFrameDeflateCompressionSupported"));
+    }
+    if (json.getValue("websocketPermessageDeflateCompressionSupported") instanceof Boolean) {
+      obj.setWebsocketPermessageDeflateCompressionSupported((Boolean)json.getValue("websocketPermessageDeflateCompressionSupported"));
+    }
+    if (json.getValue("websocketPreferredClientNoContext") instanceof Boolean) {
+      obj.setWebsocketPreferredClientNoContext((Boolean)json.getValue("websocketPreferredClientNoContext"));
+    }
     if (json.getValue("websocketSubProtocols") instanceof String) {
       obj.setWebsocketSubProtocols((String)json.getValue("websocketSubProtocols"));
     }
@@ -100,6 +115,11 @@ import io.vertx.core.json.JsonArray;
     json.put("maxInitialLineLength", obj.getMaxInitialLineLength());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
     json.put("maxWebsocketMessageSize", obj.getMaxWebsocketMessageSize());
+    json.put("websocketAllowServerNoContext", obj.getWebsocketAllowServerNoContext());
+    json.put("websocketCompressionLevel", obj.getWebsocketCompressionLevel());
+    json.put("websocketFrameDeflateCompressionSupported", obj.getWebsocketFrameDeflateCompressionSupported());
+    json.put("websocketPermessageDeflateCompressionIsSupported", obj.getWebsocketPermessageDeflateCompressionIsSupported());
+    json.put("websocketPreferredClientNoContext", obj.getWebsocketPreferredClientNoContext());
     if (obj.getWebsocketSubProtocols() != null) {
       json.put("websocketSubProtocols", obj.getWebsocketSubProtocols());
     }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -154,6 +154,32 @@ public class HttpClientOptions extends ClientOptionsBase {
    * Default initial buffer size for HttpObjectDecoder = 128 bytes
    */
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
+  
+  /**
+   * Default offer WebSocket Deflate Frame compression = false
+   */
+  public static final boolean DEFAULT_TRY_USE_WEBSOCKET_DEFLATE_FRAME = false;
+  
+  /** 
+   * Default offer WebSocket Permessage Deflate Compression = false
+   */
+  public static final boolean DEFAULT_TRY_USE_WEBSOCKET_PERMESSAGE_DEFLATE = false;
+  
+  /**
+   * Default WebSocket compression level = 6
+   */
+  public static final int DEFAULT_WEBSOCKET_COMPRESSION_LEVEL = 6;
+  
+  /** 
+   * Default WebSocket Compression client no context allowance = false
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_CLIENT_NO_CONTEXT = false;
+  
+  /** 
+   * Default WebSocket Compression server no context allowance = false
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_REQUEST_SERVER_NO_CONTEXT = false;
+  
 
   private boolean verifyHost = true;
   private int maxPoolSize;
@@ -181,6 +207,13 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int maxRedirects;
   private boolean forceSni;
   private int decoderInitialBufferSize;
+  
+  private boolean websocketTryUseDeflateFrame;
+  private boolean websocketTryUsePermessageDeflate;
+  private int websocketCompressionLevel;
+  private boolean websocketAllowClientNoContext;
+  private boolean websocketRequestServerNoContext;
+  
 
   /**
    * Default constructor
@@ -222,6 +255,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.maxRedirects = other.maxRedirects;
     this.forceSni = other.forceSni;
     this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
+    this.websocketTryUseDeflateFrame = other.websocketTryUseDeflateFrame;
+    this.websocketTryUsePermessageDeflate = other.websocketTryUsePermessageDeflate;
+    this.websocketAllowClientNoContext = other.websocketAllowClientNoContext;
+    this.websocketCompressionLevel = other.websocketCompressionLevel;
+    this.websocketRequestServerNoContext = other.websocketRequestServerNoContext;
   }
 
   /**
@@ -272,6 +310,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxRedirects = DEFAULT_MAX_REDIRECTS;
     forceSni = DEFAULT_FORCE_SNI;
     decoderInitialBufferSize = DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
+    websocketTryUseDeflateFrame = DEFAULT_TRY_USE_WEBSOCKET_DEFLATE_FRAME;
+    websocketTryUsePermessageDeflate = DEFAULT_TRY_USE_WEBSOCKET_PERMESSAGE_DEFLATE;
+    websocketCompressionLevel = DEFAULT_WEBSOCKET_COMPRESSION_LEVEL;
+    websocketAllowClientNoContext = DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_CLIENT_NO_CONTEXT;
+    websocketRequestServerNoContext = DEFAULT_WEBSOCKET_COMPRESSION_REQUEST_SERVER_NO_CONTEXT;
   }
 
   @Override
@@ -964,6 +1007,106 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
+   * Set option to offer Deflate Frame websocket compression
+   * @param tryDeflateFrame
+   * @return  a reference to this, so the API can be used fluently
+   */
+ public HttpClientOptions setTryUsePerFrameWebsocketCompression (boolean tryUsePerFrameWebsocketCompression )
+ {
+	 this.websocketTryUseDeflateFrame = tryUsePerFrameWebsocketCompression;
+	 return this;
+ }
+ 
+ /** 
+  * 
+  * @return Whether Deflate Frame websocket compression will be offered
+  */
+ public boolean tryWebsocketDeflateFrameCompression()
+ {
+	 return this.websocketTryUseDeflateFrame;
+ }
+ 
+/**
+ * Set option to offer Permessage Deflate websocket compression
+ * @param tryPermessageDeflate
+ * @return  a reference to this, so the API can be used fluently
+ */
+ public HttpClientOptions setTryUsePerMessageWebsocketCompression (boolean tryUsePerMessageWebsocketCompression )
+ {
+	 this.websocketTryUsePermessageDeflate = tryUsePerMessageWebsocketCompression;
+	 return this;
+ }
+ 
+ /**
+  * 
+  * @return whether Permessage Deflate websocket compression will be offered
+  */
+ public boolean tryUsePerMessageWebsocketCompression ()
+ {
+	 return this.websocketTryUsePermessageDeflate;
+ }
+ 
+ /** 
+  * Set websocket compression level
+  * @param compressionLevel
+  * @return a reference to this, so the API can be used fluently
+  */
+ public HttpClientOptions setWebsocketCompressionLevel (int websocketCompressionLevel)
+ {
+	 this.websocketCompressionLevel = websocketCompressionLevel;
+	 return this;
+ }
+ 
+ /**
+  * 
+  * @return websocket compression level
+  */
+ public int websocketCompressionLevel()
+ {
+	 return this.websocketCompressionLevel;
+ }
+ 
+ /**
+  * Set the websocket compression allow client no context option
+  * @param allowClientNoContext
+  * @return a reference to this, so the API can be used fluently
+  */
+ public HttpClientOptions setWebsocketCompressionAllowClientNoContext(boolean allowClientNoContext)
+ {
+	 this.websocketAllowClientNoContext = allowClientNoContext;
+	 return this;
+ }
+ 
+ /**
+  * 
+  * @return the current websocket compression client no context setting
+  */
+ public boolean getWebsocketCompressionAllowClientNoContext()
+ {
+	 return this.websocketAllowClientNoContext;
+ }
+ 
+ /**
+  * Set the websocket compression server no context option
+  * @param requestServerNoContext
+  * @return a reference to this, so the API can be used fluently
+  */
+ public HttpClientOptions setWebsocketCompressionRequestServerNoContext(boolean requestServerNoContext)
+ {
+	this.websocketRequestServerNoContext = requestServerNoContext;
+	return this;
+ }
+ 
+ /**
+  * 
+  * @return current setting of the websocket compression server no context option
+  */
+ public boolean getWebsocketCompressionRequestServerNoContext()
+ {
+	 return this.websocketRequestServerNoContext;
+ }
+   
+  /**
    * @return the initial buffer size for the HTTP decoder
    */
   public int getDecoderInitialBufferSize() { return decoderInitialBufferSize; }
@@ -1008,6 +1151,12 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (sendUnmaskedFrames != that.sendUnmaskedFrames) return false;
     if (maxRedirects != that.maxRedirects) return false;
     if (decoderInitialBufferSize != that.decoderInitialBufferSize) return false;
+    
+    if (websocketTryUseDeflateFrame != that.websocketTryUseDeflateFrame) return false;
+    if (websocketTryUsePermessageDeflate != that.websocketTryUsePermessageDeflate) return false;
+    if (websocketCompressionLevel != that.websocketCompressionLevel) return false;
+    if (websocketAllowClientNoContext != that.websocketAllowClientNoContext) return false;
+    if (websocketRequestServerNoContext != that.websocketRequestServerNoContext) return false;
 
     return true;
   }
@@ -1036,6 +1185,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     result = 31 * result + (sendUnmaskedFrames ? 1 : 0);
     result = 31 * result + maxRedirects;
     result = 31 * result + decoderInitialBufferSize;
+    result = 31 * result + (websocketTryUseDeflateFrame ? 1 : 0);
+    result = 31 * result + (websocketTryUsePermessageDeflate ? 1 : 0);
+    result = 31 * result + websocketCompressionLevel;
+    result = 31 * result + (websocketAllowClientNoContext ? 1 : 0);
+    result = 31 * result + (websocketRequestServerNoContext ? 1: 0);
     return result;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -110,6 +110,31 @@ public class HttpServerOptions extends NetServerOptions {
    * Default initial buffer size for HttpObjectDecoder = 128 bytes
    */
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
+  
+  /**
+   * Default support for WebSockets deflate frame compression
+   */
+  public static final boolean DEFAULT_WEBSOCKET_SUPPORT_DEFLATE_FRAME_COMPRESSION = true;
+  
+  /**
+   * Default support for WebSockets Permessage Deflate compression
+   */
+  public static final boolean DEFAULT_WEBSOCKET_SUPPORT_PERMESSAGE_DEFLATE_COMPRESSION = true;
+  
+  /**
+   * Default WebSocket compression level
+   */
+  public static final int DEFAULT_WEBSOCKET_COMPRESSION_LEVEL = 6;
+  
+  /**
+   * Default Websocket compression server no context
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_SERVER_NO_CONTEXT = false;
+  
+  /**
+   * Default WebSocket compression client no context
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_PREFERRED_CLIENT_NO_CONTEXT = false;
 
   private boolean compressionSupported;
   private int compressionLevel;
@@ -126,6 +151,11 @@ public class HttpServerOptions extends NetServerOptions {
   private boolean decompressionSupported;
   private boolean acceptUnmaskedFrames;
   private int decoderInitialBufferSize;
+  private boolean websocketDeflateFrameCompressionSupported;
+  private boolean websocketPermessageDeflateCompressionSupported;
+  private int websocketCompressionLevel;
+  private boolean websocketCompressionAllowServerNoContext;
+  private boolean websocketCompressionPreferredClientNoContext;
 
   /**
    * Default constructor
@@ -158,6 +188,11 @@ public class HttpServerOptions extends NetServerOptions {
     this.decompressionSupported = other.isDecompressionSupported();
     this.acceptUnmaskedFrames = other.isAcceptUnmaskedFrames();
     this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
+    this.websocketDeflateFrameCompressionSupported = other.websocketDeflateFrameCompressionSupported;
+    this.websocketPermessageDeflateCompressionSupported = other.websocketPermessageDeflateCompressionSupported;
+    this.websocketCompressionLevel = other.websocketCompressionLevel;
+    this.websocketCompressionPreferredClientNoContext = other.websocketCompressionPreferredClientNoContext;
+    this.websocketCompressionAllowServerNoContext = other.websocketCompressionAllowServerNoContext;
   }
 
   /**
@@ -198,6 +233,11 @@ public class HttpServerOptions extends NetServerOptions {
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     acceptUnmaskedFrames = DEFAULT_ACCEPT_UNMASKED_FRAMES;
     decoderInitialBufferSize = DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
+    websocketDeflateFrameCompressionSupported = DEFAULT_WEBSOCKET_SUPPORT_DEFLATE_FRAME_COMPRESSION;
+    websocketPermessageDeflateCompressionSupported = DEFAULT_WEBSOCKET_SUPPORT_PERMESSAGE_DEFLATE_COMPRESSION;
+    websocketCompressionLevel = DEFAULT_WEBSOCKET_COMPRESSION_LEVEL;
+    websocketCompressionPreferredClientNoContext = DEFAULT_WEBSOCKET_COMPRESSION_PREFERRED_CLIENT_NO_CONTEXT;
+    websocketCompressionAllowServerNoContext = DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_SERVER_NO_CONTEXT;
   }
 
   @Override
@@ -702,6 +742,96 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  /**
+   * Enable or disable support for WebSocket Defalte Frame compression
+   * @param deflateCompressionSupported
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setPerFrameWebsocketCompressionSupported  (boolean perFrameWebsocketCompressionSupported ) {
+	  this.websocketDeflateFrameCompressionSupported = perFrameWebsocketCompressionSupported;
+	  return this;
+  }
+  
+  /** 
+   * Get whether WebSocket Deflate Frame compression is supported
+   * @return true if the http server will accept Deflate Frame compression 
+   */
+  public boolean perFrameWebsocketCompressionSupported  () {
+	  return this.websocketDeflateFrameCompressionSupported;
+  }
+  
+  /**
+   * Enable or disable support for WebSocket Permessage Deflate compression
+   * @param permessageDeflateSupported
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setPerMessageWebsocketCompressionSupported  (boolean perMessageWebsocketCompressionSupported ) {
+	  this.websocketPermessageDeflateCompressionSupported = perMessageWebsocketCompressionSupported;
+	  return this;
+  }
+  
+  /**
+   * Get whether WebSocket Permessage Deflate compression is supported
+   * @return true if the http server will accept Permessage Deflate compression
+   */
+  public boolean perMessageWebsocketCompressionSupported  () {
+	  return this.websocketPermessageDeflateCompressionSupported;
+  }
+  
+  /**
+   * Set the WebSocket compression level 
+   * @param compressionLevel
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setWebsocketCompressionLevel (int websocketCompressionLevel) {
+	  this.websocketCompressionLevel = compressionLevel;
+	  return this;
+  }
+  
+  /**
+   * Get the WebSocket compression level
+   * @return the current WebSocket compression level
+   */
+  public int websocketCompressionLevel () {
+	  return this.websocketCompressionLevel;
+  }
+  
+  /**
+   * Set the WebSocket Allow Server No Context option
+   * @param allowServerNoContext 
+   * @return  a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setWebsocketAllowServerNoContext (boolean allowServerNoContext) {
+	  this.websocketCompressionAllowServerNoContext = allowServerNoContext;
+	  return this;
+  }
+  
+  /**
+   * Get current setting to allow server no context for WebSocket compression
+   * @return
+   */
+  public boolean getWebsocketAllowServerNoContext () {
+	  return this.websocketCompressionAllowServerNoContext;
+  }
+  
+  /**
+   * Set the WebSocket Preferred Client No Context setting
+   * @param preferredClientNoContext
+   * @return  a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setWebsocketPreferredClientNoContext (boolean preferredClientNoContext) {
+	  this.websocketCompressionPreferredClientNoContext = preferredClientNoContext;
+	  return this;
+  }
+  
+  /**
+   * Get the current setting of the WebSocket Compression Preferred Client no Context setting
+   * @return
+   */
+  public boolean getWebsocketPreferredClientNoContext () {
+	  return this.websocketCompressionPreferredClientNoContext;
+  }
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -723,6 +853,11 @@ public class HttpServerOptions extends NetServerOptions {
     if (decompressionSupported != that.decompressionSupported) return false;
     if (acceptUnmaskedFrames != that.acceptUnmaskedFrames) return false;
     if (decoderInitialBufferSize != that.decoderInitialBufferSize) return false;
+    if (websocketDeflateFrameCompressionSupported != that.websocketDeflateFrameCompressionSupported) return false;
+    if (websocketPermessageDeflateCompressionSupported != that.websocketPermessageDeflateCompressionSupported) return false;
+    if (websocketCompressionLevel != that.websocketCompressionLevel) return false;
+    if (websocketCompressionAllowServerNoContext != that.websocketCompressionAllowServerNoContext) return false;
+    if (websocketCompressionPreferredClientNoContext != that.websocketCompressionPreferredClientNoContext) return false;
 
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
 
@@ -745,6 +880,11 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + (decompressionSupported ? 1 : 0);
     result = 31 * result + (acceptUnmaskedFrames ? 1 : 0);
     result = 31 * result + decoderInitialBufferSize;
+    result = 31 * result + (websocketDeflateFrameCompressionSupported ? 1 : 0);
+    result = 31 * result + (websocketPermessageDeflateCompressionSupported ? 1 : 0);
+    result = 31 * result + websocketCompressionLevel;
+    result = 31 * result + (websocketCompressionAllowServerNoContext ? 1 : 0);
+    result = 31 * result + (websocketCompressionPreferredClientNoContext ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/ClientConnection.java
@@ -37,9 +37,16 @@ import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.impl.NetSocketImpl;
 import io.vertx.core.net.impl.VertxNetHandler;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateClientExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameClientExtensionHandshaker;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
 
 import java.net.URI;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
@@ -107,7 +114,7 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
   synchronized HttpClientRequestImpl getCurrentRequest() {
     return currentRequest;
   }
-
+  
   synchronized void toWebSocket(String requestURI, MultiMap headers, WebsocketVersion vers, String subProtocols,
                    int maxWebSocketFrameSize, Handler<WebSocket> wsConnect) {
     if (ws != null) {
@@ -132,9 +139,17 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
       } else {
         nettyHeaders = null;
       }
-      handshaker = WebSocketClientHandshakerFactory.newHandshaker(wsuri, version, subProtocols, false,
-                                                                  nettyHeaders, maxWebSocketFrameSize,!client.getOptions().isSendUnmaskedFrames(),false);
-      ChannelPipeline p = chctx.pipeline();
+            
+      ChannelPipeline p = chctx.channel().pipeline(); 
+      ArrayList<WebSocketClientExtensionHandshaker> extensionHandshakers = initializeWebsocketExtensionHandshakers(client.getOptions());
+      if (!extensionHandshakers.isEmpty()) {
+    	  p.addBefore("handler", "websocketsExtensionsHandler", new WebSocketClientExtensionHandler(
+    			  extensionHandshakers.toArray(new WebSocketClientExtensionHandshaker[extensionHandshakers.size()])));
+      }
+      
+      handshaker = WebSocketClientHandshakerFactory.newHandshaker(wsuri, version, subProtocols, !extensionHandshakers.isEmpty(),
+              nettyHeaders, maxWebSocketFrameSize,!client.getOptions().isSendUnmaskedFrames(),false);
+      
       p.addBefore("handler", "handshakeCompleter", new HandshakeInboundHandler(wsConnect, version != WebSocketVersion.V00));
       handshaker.handshake(chctx.channel()).addListener(future -> {
         Handler<Throwable> handler = exceptionHandler();
@@ -147,6 +162,22 @@ class ClientConnection extends Http1xConnectionBase implements HttpClientConnect
     }
   }
 
+  ArrayList<WebSocketClientExtensionHandshaker> initializeWebsocketExtensionHandshakers (HttpClientOptions options) {
+	  ArrayList<WebSocketClientExtensionHandshaker> extensionHandshakers = new ArrayList<WebSocketClientExtensionHandshaker>();
+	  if (options.tryWebsocketDeflateFrameCompression()) {
+		  extensionHandshakers.add(new DeflateFrameClientExtensionHandshaker(options.websocketCompressionLevel(),
+				  false));
+	  }
+	  
+	  if (options.tryUsePerMessageWebsocketCompression ()) {
+		  extensionHandshakers.add(new PerMessageDeflateClientExtensionHandshaker(options.websocketCompressionLevel(), 
+				  ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(), PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE, 
+				  options.getWebsocketCompressionAllowClientNoContext(), options.getWebsocketCompressionRequestServerNoContext()));
+	  }
+	  
+	  return extensionHandshakers;
+  }
+  
   private final class HandshakeInboundHandler extends ChannelInboundHandlerAdapter {
 
     private final boolean supportsContinuation;

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -16,6 +16,7 @@
 
 package io.vertx.core.http.impl;
 
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandshaker;
 import io.vertx.core.Closeable;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -48,6 +49,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -1033,7 +1035,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
     private Handler<Throwable> exceptionHandler;
     private Handler<Void> endHandler;
     private Boolean ssl;
-
+    
     WebSocketStream(int port, String host, String requestURI, MultiMap headers, WebsocketVersion version, String subProtocols, Boolean ssl) {
       this.port = port;
       this.host = host;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -46,6 +46,11 @@ import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.logging.LoggingHandler;
@@ -87,10 +92,12 @@ import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.streams.ReadStream;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -129,6 +136,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
   private final HttpStreamHandler<ServerWebSocket> wsStream = new HttpStreamHandler<>();
   private final HttpStreamHandler<HttpServerRequest> requestStream = new HttpStreamHandler<>();
   private Handler<HttpConnection> connectionHandler;
+  private final String subProtocols;
   private String serverOrigin;
 
   private ChannelGroup serverChannelGroup;
@@ -153,6 +161,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       creatingContext.addCloseHook(this);
     }
     this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
+    this.subProtocols = options.getWebsocketSubProtocols();
     this.logEnabled = options.getLogActivity();
   }
 
@@ -440,6 +449,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     if (options.getIdleTimeout() > 0) {
       pipeline.addLast("idle", new IdleStateHandler(0, 0, options.getIdleTimeout()));
     }
+
     if (!DISABLE_HC2) {
       pipeline.addLast("h2c", new Http2UpgradeHandler());
     }
@@ -450,6 +460,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       // some casting and a header check
       handler = new ServerHandler(sslHelper, options, serverOrigin, holder, metrics);
     } else {
+      initializeWebsocketExtensions (pipeline);
       handler = new ServerHandlerWithWebSockets(sslHelper, options, serverOrigin, holder, metrics);
     }
     handler.addHandler(conn -> {
@@ -459,6 +470,28 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       connectionMap.remove(pipeline.channel());
     });
     pipeline.addLast("handler", handler);
+
+  }
+  
+  void initializeWebsocketExtensions (ChannelPipeline pipeline) {
+	  ArrayList<WebSocketServerExtensionHandshaker> extensionHandshakers = new ArrayList<WebSocketServerExtensionHandshaker>();
+	  
+	  if (options.perFrameWebsocketCompressionSupported ()) {
+		  extensionHandshakers.add(new DeflateFrameServerExtensionHandshaker(options.websocketCompressionLevel()));
+	  }
+	  
+	  if (options.perMessageWebsocketCompressionSupported ()) {
+		  extensionHandshakers.add(new PerMessageDeflateServerExtensionHandshaker(options.websocketCompressionLevel(),
+				  ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(), PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE, 
+				  options.getWebsocketAllowServerNoContext(), options.getWebsocketPreferredClientNoContext()));
+	  }
+	  
+	  if (!extensionHandshakers.isEmpty()) {
+		  WebSocketServerExtensionHandler extensionHandler = new WebSocketServerExtensionHandler(
+			  extensionHandshakers.toArray(new WebSocketServerExtensionHandshaker[extensionHandshakers.size()]));
+		  pipeline.addLast("websocketExtensionHandler", extensionHandler);
+	  }
+	  
   }
 
   public void handleHttp2(Channel ch) {
@@ -678,7 +711,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             if (!closeFrameSent) {
               // Echo back close frame and close the connection once it was written.
               // This is specified in the WebSockets RFC 6455 Section  5.4.1
-              ch.writeAndFlush(wsFrame).addListener(ChannelFutureListener.CLOSE);
+              ch.writeAndFlush(new CloseWebSocketFrame().replace(wsFrame.getBinaryData())).addListener(ChannelFutureListener.CLOSE);
               closeFrameSent = true;
             }
             break;

--- a/src/main/java/io/vertx/core/http/impl/ServerHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/ServerHandler.java
@@ -87,7 +87,9 @@ public class ServerHandler extends VertxHttpHandler<ServerConnection> {
     try {
 
       WebSocketServerHandshakerFactory factory =
-        new WebSocketServerHandshakerFactory(HttpServerImpl.getWebSocketLocation(ch.pipeline(), request), conn.options.getWebsocketSubProtocols(), false,
+        new WebSocketServerHandshakerFactory(HttpServerImpl.getWebSocketLocation(ch.pipeline(), request), 
+          conn.options.getWebsocketSubProtocols(), 
+          conn.options.perMessageWebsocketCompressionSupported () || conn.options.perFrameWebsocketCompressionSupported (),
           conn.options.getMaxWebsocketFrameSize(), conn.options.isAcceptUnmaskedFrames());
       WebSocketServerHandshaker shake = factory.newHandshaker(request);
 


### PR DESCRIPTION
Server support is enabled by default (but the client must request it).
Client side must be specifically enabled in options.