### PR TITLE
Fix multiple handler completion on deploy fail

### DIFF
--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -493,12 +493,13 @@ public class DeploymentManager {
               if (deployCount.incrementAndGet() == verticles.length) {
                 reportSuccess(deploymentID, callingContext, completionHandler);
               }
-            } else if (!failureReported.get()) {
+            } else if (!failureReported.getAndSet(true)) {
               context.runCloseHooks(closeHookAsyncResult -> reportFailure(ar.cause(), callingContext, completionHandler));
             }
           });
         } catch (Throwable t) {
-          context.runCloseHooks(closeHookAsyncResult -> reportFailure(t, callingContext, completionHandler));
+          if (!failureReported.getAndSet(true))
+            context.runCloseHooks(closeHookAsyncResult -> reportFailure(t, callingContext, completionHandler));
         }
       });
     }

--- a/src/main/java/io/vertx/core/impl/DeploymentManager.java
+++ b/src/main/java/io/vertx/core/impl/DeploymentManager.java
@@ -493,12 +493,12 @@ public class DeploymentManager {
               if (deployCount.incrementAndGet() == verticles.length) {
                 reportSuccess(deploymentID, callingContext, completionHandler);
               }
-            } else if (!failureReported.getAndSet(true)) {
+            } else if (failureReported.compareAndSet(false, true)) {
               context.runCloseHooks(closeHookAsyncResult -> reportFailure(ar.cause(), callingContext, completionHandler));
             }
           });
         } catch (Throwable t) {
-          if (!failureReported.getAndSet(true))
+          if (failureReported.compareAndSet(false, true))
             context.runCloseHooks(closeHookAsyncResult -> reportFailure(t, callingContext, completionHandler));
         }
       });


### PR DESCRIPTION
When starting multiple verticles, if more than one fails it results in a duplicate call to the completionHandler. 
The boolean that should prevent duplicate calls is never set to true.

Also, in the catch block, the same check should be made as the same error could occur there.