### PR TITLE
added assertion to check if correct content-encoding header was set a…

### DIFF
--- a/src/test/java/io/vertx/test/core/HttpCompressionTest.java
+++ b/src/test/java/io/vertx/test/core/HttpCompressionTest.java
@@ -78,6 +78,7 @@ public class HttpCompressionTest extends HttpTestBase {
     startServer(serverWithMaxCompressionLevel);
     clientraw.get(DEFAULT_HTTP_PORT + 1, DEFAULT_HTTP_HOST, "some-uri",
       resp -> {
+        assertEquals(HttpHeaders.IDENTITY.toString(), resp.headers().get(HttpHeaders.CONTENT_ENCODING));
         resp.bodyHandler(responseBuffer -> {
           String responseBody = responseBuffer.toString(CharsetUtil.UTF_8);
           assertEquals(COMPRESS_TEST_STRING, responseBody);


### PR DESCRIPTION
as discussed in the [google group](https://groups.google.com/forum/#!topic/vertx/b3kSVFphLlo), setting `content-encoding` to `identity` should skip compression of the response. By checking the `content-encoding` header we can make sure that compression was actually skipped, as the content is already decompressed when it is asserted.