### PR TITLE
Fix ClusteredEventBusStartFailureTest

### DIFF
--- a/src/test/java/io/vertx/test/core/ClusteredEventBusStartFailureTest.java
+++ b/src/test/java/io/vertx/test/core/ClusteredEventBusStartFailureTest.java
@@ -35,7 +35,7 @@ public class ClusteredEventBusStartFailureTest extends AsyncTestBase {
   public void testCallbackInvokedOnFailure() throws Exception {
 
     // will trigger java.net.UnknownHostException
-    String hostName = getClass().getSimpleName();
+    String hostName = "zoom.zoom.zen.tld";
 
     VertxOptions options = new VertxOptions()
       .setClusterManager(new FakeClusterManager())


### PR DESCRIPTION
On some networking configurations the CountDownLatch would expire.

Using an improbable dotted hostname fixes the issue and makes the test pass.