### PR TITLE
DecodeException

### DIFF
--- a/src/main/java/io/vertx/core/json/Json.java
+++ b/src/main/java/io/vertx/core/json/Json.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.netty.buffer.ByteBufInputStream;
 import io.vertx.core.buffer.Buffer;
 
@@ -42,8 +43,8 @@ import static java.time.format.DateTimeFormatter.ISO_INSTANT;
  */
 public class Json {
 
-  public static ObjectMapper mapper = new ObjectMapper();
-  public static ObjectMapper prettyMapper = new ObjectMapper();
+  public static ObjectMapper mapper = new ObjectMapper().enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+  public static ObjectMapper prettyMapper = new ObjectMapper().enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
   static {
     // Non-standard JSON but we allow C style comments in our JSON


### PR DESCRIPTION
Throw DecodeException for invalid json strings containing trailing elements after a valid substring like "{\n    \"foo\": {\n    \"baz\" : \"bazValue\",\n    \"bar\" : \"barValue\"}\n    },\n     \"bla\" : [ \"a\" , \"b\", \"c\"],\n     \"xxx\" : 0.3\n}"