### PR TITLE
Getting corresponding shared map

### DIFF
--- a/src/main/java/io/vertx/core/shareddata/SharedData.java
+++ b/src/main/java/io/vertx/core/shareddata/SharedData.java
@@ -80,4 +80,11 @@ public interface SharedData {
    */
   <K, V> LocalMap<K, V> getLocalMap(String name);
 
+  /**
+   * Get the cluster wide map if Vert.x instance is clustered or local otherwise.
+   *
+   * @param name  the name of the map
+   * @param resultHandler  the map will be returned asynchronously in this handler
+   */
+  <K, V> void getMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler);
 }

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalAsAsyncMap.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalAsAsyncMap.java
@@ -1,0 +1,104 @@
+package io.vertx.core.shareddata.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.LocalMap;
+
+import java.util.*;
+
+/**
+ * @author <a href="http://nlq.su">Anton Potsyus</a>
+ */
+final class LocalAsAsyncMap<K, V> implements AsyncMap<K, V> {
+  private final Vertx vertx;
+  private final LocalMap<K, V> map;
+
+  public LocalAsAsyncMap(Vertx vertx, LocalMap<K, V> map) {
+    this.vertx = vertx;
+    this.map = map;
+  }
+
+  @Override
+  public void get(K key, Handler<AsyncResult<V>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.get(key)));
+  }
+
+  @Override
+  public void put(K key, V value, Handler<AsyncResult<Void>> completionHandler) {
+    map.put(key, value);
+    completionHandler.handle(Future.succeededFuture());
+  }
+
+  @Override
+  public void put(K key, V value, long ttl, Handler<AsyncResult<Void>> completionHandler) {
+    put(key, value, handlerWithTTL(key, value, ttl, completionHandler));
+  }
+
+  @Override
+  public void putIfAbsent(K key, V value, Handler<AsyncResult<V>> completionHandler) {
+    completionHandler.handle(Future.succeededFuture(map.putIfAbsent(key, value)));
+  }
+
+  @Override
+  public void putIfAbsent(K key, V value, long ttl, Handler<AsyncResult<V>> completionHandler) {
+    putIfAbsent(key, value, handlerWithTTL(key, value, ttl, completionHandler));
+  }
+
+  @Override
+  public void remove(K key, Handler<AsyncResult<V>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.remove(key)));
+  }
+
+  @Override
+  public void removeIfPresent(K key, V value, Handler<AsyncResult<Boolean>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.removeIfPresent(key, value)));
+  }
+
+  @Override
+  public void replace(K key, V value, Handler<AsyncResult<V>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.replace(key, value)));
+  }
+
+  @Override
+  public void replaceIfPresent(K key, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.replaceIfPresent(key, oldValue, newValue)));
+  }
+
+  @Override
+  public void clear(Handler<AsyncResult<Void>> completionHandler) {
+    map.clear();
+    completionHandler.handle(Future.succeededFuture());
+  }
+
+  @Override
+  public void size(Handler<AsyncResult<Integer>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.size()));
+  }
+
+  @Override
+  public void keys(Handler<AsyncResult<Set<K>>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(new HashSet<>(map.keySet())));
+  }
+
+  @Override
+  public void values(Handler<AsyncResult<List<V>>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(new ArrayList<>(map.values())));
+  }
+
+  @Override
+  public void entries(Handler<AsyncResult<Map<K, V>>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(new HashMap<>(map)));
+  }
+
+  private <T> Handler<AsyncResult<T>> handlerWithTTL(K key, V value, long ttl, Handler<AsyncResult<T>> completionHandler) {
+    return event -> {
+      if (event.succeeded()) {
+        vertx.setTimer(ttl, timer -> map.remove(key, value));
+      }
+      completionHandler.handle(event);
+    };
+  }
+}

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -37,12 +37,14 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 public class SharedDataImpl implements SharedData {
 
-  private static final long DEFAULT_LOCK_TIMEOUT = 10 * 1000;
+  private static final long DEFAULT_LOCK_TIMEOUT = SECONDS.toMillis(10);
 
   private final VertxInternal vertx;
   private final ClusterManager clusterManager;
@@ -106,11 +108,22 @@ public class SharedDataImpl implements SharedData {
    * Return a {@code Map} with the specific {@code name}. All invocations of this method with the same value of {@code name}
    * are guaranteed to return the same {@code Map} instance. <p>
    */
+  @Override
   @SuppressWarnings("unchecked")
   public <K, V> LocalMap<K, V> getLocalMap(String name) {
     return (LocalMap<K, V>) localMaps.computeIfAbsent(name, n -> new LocalMapImpl<>(n, localMaps));
   }
 
+  @Override
+  public <K, V> void getMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler) {
+    Objects.requireNonNull(name, "name");
+    Objects.requireNonNull(resultHandler, "resultHandler");
+    if (vertx.isClustered()) {
+      getClusterWideMap(name, resultHandler);
+    } else {
+      resultHandler.handle(Future.succeededFuture(new LocalAsAsyncMap<>(vertx, getLocalMap(name))));
+    }
+  }
 
   private void getLocalLock(String name, long timeout, Handler<AsyncResult<Lock>> resultHandler) {
     AsynchronousLock lock = localLocks.computeIfAbsent(name, n -> new AsynchronousLock(vertx));

--- a/src/test/java/io/vertx/test/core/LocalSharedDataTest.java
+++ b/src/test/java/io/vertx/test/core/LocalSharedDataTest.java
@@ -307,6 +307,42 @@ public class LocalSharedDataTest extends VertxTestBase {
     assertFalse(containsExact(values, json3));
   }
 
+  @Test
+  public void testLocalMapPutTTL() {
+    sharedData.<String, String>getMap("foo", onSuccess(map1 -> {
+      final int ttl = 10;
+      map1.put("pocket", "precious", ttl, onSuccess(event -> {
+        vertx.setTimer(ttl, timer -> {
+          sharedData.<String, String>getMap("foo", onSuccess(map2 -> {
+            map2.get("pocket", onSuccess(value -> {
+              assertNull(value);
+              testComplete();
+            }));
+          }));
+        });
+      }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testLocalMapPutIfAbsentTTL() {
+    sharedData.<String, String>getMap("foo", onSuccess(map1 -> {
+      final int ttl = 10;
+      map1.putIfAbsent("pocket", "precious", ttl, onSuccess(value1 -> {
+        assertNull(value1);
+        vertx.setTimer(ttl, timer -> {
+          sharedData.<String, String>getMap("foo", onSuccess(map2 -> {
+            map2.get("pocket", onSuccess(value2 -> {
+              assertNull(value2);
+              testComplete();
+            }));
+          }));
+        });
+      }));
+    }));
+    await();
+  }
 
 
   class SomeOtherClass {


### PR DESCRIPTION
_in place of  outdated pull request #2094_

Sometimes it is very uncomfortable to choose an appropriate map explicitly, especialy if we don't know in advance whether the Vert.x instance clustered or not. E.g. when writing tests which may use cluster in some cases or not, choosing the "right" map leads to changes in production code.

The goal of the proposed changes is to make it easier to work with shared data without paying attention if the instance is clustered or not.