### PR TITLE
Local async map

### DIFF
--- a/src/main/asciidoc/java/shareddata.adoc
+++ b/src/main/asciidoc/java/shareddata.adoc
@@ -51,10 +51,13 @@ map2 = sd.getLocalMap("mymap2");
 Buffer buff = map2.get("eek");
 ----
 
-=== Asynchronous maps
+=== Asynchronous shared maps
 
-Asynchronous maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
+Asynchronous shared maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
 When clustered, data can be put from any node and retrieved from the same node or any other node.
+
+IMPORTANT: In clustered mode, asynchronous shared maps rely on distributed data structures provided by the cluster manager.
+Beware that the latency relative to asynchronous shared map operations can be much higher in clustered than in local mode.
 
 This makes them really useful for things like storing session state in a farm of servers hosting a Vert.x web
 application.

--- a/src/main/asciidoc/java/shareddata.adoc
+++ b/src/main/asciidoc/java/shareddata.adoc
@@ -3,8 +3,12 @@
 Shared data contains functionality that allows you to safely share data between different parts of your application,
 or different applications in the same Vert.x instance or across a cluster of Vert.x instances.
 
-Shared data includes local shared maps, distributed, cluster-wide maps, asynchronous cluster-wide locks and
-asynchronous cluster-wide counters.
+Shared data provides:
+
+ * synchronous shared maps (local)
+ * asynchronous maps (local or cluster-wide)
+ * asynchronous locks (local or cluster-wide)
+ * asynchronous counters (local or cluster-wide)
 
 IMPORTANT: The behavior of the distributed data structure depends on the cluster manager you use. Backup
 (replication) and behavior when a network partition is faced are defined by the cluster manager and its
@@ -47,16 +51,16 @@ map2 = sd.getLocalMap("mymap2");
 Buffer buff = map2.get("eek");
 ----
 
-=== Cluster-wide asynchronous maps
+=== Asynchronous maps
 
-Cluster-wide asynchronous maps allow data to be put in the map from any node of the cluster and retrieved from any
-other node.
+Asynchronous maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
+When clustered, data can be put from any node and retrieved from the same node or any other node.
 
 This makes them really useful for things like storing session state in a farm of servers hosting a Vert.x web
 application.
 
 You get an instance of `link:../../apidocs/io/vertx/core/shareddata/AsyncMap.html[AsyncMap]` with
-`link:../../apidocs/io/vertx/core/shareddata/SharedData.html#getClusterWideMap-java.lang.String-io.vertx.core.Handler-[getClusterWideMap]`.
+`link:../../apidocs/io/vertx/core/shareddata/SharedData.html#getAsyncMap-java.lang.String-io.vertx.core.Handler-[getAsyncMap]`.
 
 Getting the map is asynchronous and the result is returned to you in the handler that you specify. Here's an example:
 
@@ -64,7 +68,7 @@ Getting the map is asynchronous and the result is returned to you in the handler
 ----
 SharedData sd = vertx.sharedData();
 
-sd.<String, String>getClusterWideMap("mymap", res -> {
+sd.<String, String>getAsyncMap("mymap", res -> {
   if (res.succeeded()) {
     AsyncMap<String, String> map = res.result();
   } else {
@@ -114,12 +118,12 @@ You can also remove entries from an asynchronous map, clear them and get the siz
 
 See the `link:../../apidocs/io/vertx/core/shareddata/AsyncMap.html[API docs]` for more information.
 
-=== Cluster-wide locks
+=== Asynchronous locks
 
-`link:../../apidocs/io/vertx/core/shareddata/Lock.html[Cluster wide locks]` allow you to obtain exclusive locks across the cluster -
+`link:../../apidocs/io/vertx/core/shareddata/Lock.html[Asynchronous locks]` allow you to obtain exclusive locks locally or across the cluster -
 this is useful when you want to do something or access a resource on only one node of a cluster at any one time.
 
-Cluster wide locks have an asynchronous API unlike most lock APIs which block the calling thread until the lock
+Asynchronous locks have an asynchronous API unlike most lock APIs which block the calling thread until the lock
 is obtained.
 
 To obtain a lock use `link:../../apidocs/io/vertx/core/shareddata/SharedData.html#getLock-java.lang.String-io.vertx.core.Handler-[getLock]`.
@@ -165,9 +169,9 @@ sd.getLockWithTimeout("mylock", 10000, res -> {
 });
 ----
 
-=== Cluster-wide counters
+=== Asynchronous counters
 
-It's often useful to maintain an atomic counter across the different nodes of your application.
+It's often useful to maintain an atomic counter locally or across the different nodes of your application.
 
 You can do this with `link:../../apidocs/io/vertx/core/shareddata/Counter.html[Counter]`.
 

--- a/src/main/java/examples/SharedDataExamples.java
+++ b/src/main/java/examples/SharedDataExamples.java
@@ -11,11 +11,13 @@
 
 package examples;
 
-import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.net.*;
-import io.vertx.core.shareddata.*;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Counter;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.Lock;
+import io.vertx.core.shareddata.SharedData;
 
 /**
  * Created by tim on 19/01/15.
@@ -49,7 +51,7 @@ public class SharedDataExamples {
 
     SharedData sd = vertx.sharedData();
 
-    sd.<String, String>getClusterWideMap("mymap", res -> {
+    sd.<String, String>getAsyncMap("mymap", res -> {
       if (res.succeeded()) {
         AsyncMap<String, String> map = res.result();
       } else {

--- a/src/main/java/io/vertx/core/shareddata/SharedData.java
+++ b/src/main/java/io/vertx/core/shareddata/SharedData.java
@@ -26,6 +26,10 @@ import io.vertx.core.Handler;
  *   <li>asynchronous counters (local or cluster-wide)</li>
  * </ul>
  * <p>
+ * <p>
+ *   <strong>WARNING</strong>: In clustered mode, asynchronous maps/locks/counters rely on distributed data structures provided by the cluster manager.
+ *   Beware that the latency relative to asynchronous maps/locks/counters operations can be much higher in clustered than in local mode.
+ * </p>
  * Please see the documentation for more information.
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -46,6 +50,10 @@ public interface SharedData {
   /**
    * Get the {@link AsyncMap} with the specified name. When clustered, the map is accessible to all nodes in the cluster
    * and data put into the map from any node is visible to to any other node.
+   * <p>
+   *   <strong>WARNING</strong>: In clustered mode, asynchronous shared maps rely on distributed data structures provided by the cluster manager.
+   *   Beware that the latency relative to asynchronous shared maps operations can be much higher in clustered than in local mode.
+   * </p>
    *
    * @param name the name of the map
    * @param resultHandler the map will be returned asynchronously in this handler

--- a/src/main/java/io/vertx/core/shareddata/SharedData.java
+++ b/src/main/java/io/vertx/core/shareddata/SharedData.java
@@ -20,10 +20,10 @@ import io.vertx.core.Handler;
  * <p>
  * Shared data provides:
  * <ul>
- *   <li>Cluster wide maps which can be accessed from any node of the cluster</li>
- *   <li>Cluster wide locks which can be used to give exclusive access to resources across the cluster</li>
- *   <li>Cluster wide counters used to maintain counts consistently across the cluster</li>
- *   <li>Local maps for sharing data safely in the same Vert.x instance</li>
+ *   <li>synchronous shared maps (local)</li>
+ *   <li>asynchronous maps (local or cluster-wide)</li>
+ *   <li>asynchronous locks (local or cluster-wide)</li>
+ *   <li>asynchronous counters (local or cluster-wide)</li>
  * </ul>
  * <p>
  * Please see the documentation for more information.
@@ -39,11 +39,21 @@ public interface SharedData {
    *
    * @param name  the name of the map
    * @param resultHandler  the map will be returned asynchronously in this handler
+   * @throws IllegalStateException if the parent {@link io.vertx.core.Vertx} instance is not clustered
    */
   <K, V> void getClusterWideMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler);
 
   /**
-   * Get a cluster wide lock with the specified name. The lock will be passed to the handler when it is available.
+   * Get the {@link AsyncMap} with the specified name. When clustered, the map is accessible to all nodes in the cluster
+   * and data put into the map from any node is visible to to any other node.
+   *
+   * @param name the name of the map
+   * @param resultHandler the map will be returned asynchronously in this handler
+   */
+  <K, V> void getAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler);
+
+  /**
+   * Get an asynchronous lock with the specified name. The lock will be passed to the handler when it is available.
    *
    * @param name  the name of the lock
    * @param resultHandler  the handler
@@ -60,7 +70,7 @@ public interface SharedData {
   void getLockWithTimeout(String name, long timeout, Handler<AsyncResult<Lock>> resultHandler);
 
   /**
-   * Get a cluster wide counter. The counter will be passed to the handler.
+   * Get an asynchronous counter. The counter will be passed to the handler.
    *
    * @param name  the name of the counter.
    * @param resultHandler  the handler

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncMapImpl.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.core.shareddata.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.AsyncMap;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * @author Thomas Segismont
+ */
+public class LocalAsyncMapImpl<K, V> implements AsyncMap<K, V> {
+
+  private final Vertx vertx;
+  private final ConcurrentMap<K, Holder<V>> map;
+
+  public LocalAsyncMapImpl(Vertx vertx) {
+    this.vertx = vertx;
+    map = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void get(final K k, Handler<AsyncResult<V>> resultHandler) {
+    Holder<V> h = map.computeIfPresent(k, (key, holder) -> notExpiredOrNull(holder));
+    resultHandler.handle(Future.succeededFuture(valueOrNull(h)));
+  }
+
+  private Holder<V> notExpiredOrNull(Holder<V> holder) {
+    return holder.hasNotExpired() ? holder : null;
+  }
+
+  private V valueOrNull(Holder<V> h) {
+    return h != null ? h.value : null;
+  }
+
+  @Override
+  public void put(final K k, final V v, Handler<AsyncResult<Void>> resultHandler) {
+    map.put(k, new Holder<>(v));
+    resultHandler.handle(Future.succeededFuture());
+  }
+
+  @Override
+  public void putIfAbsent(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+    Holder<V> h = map.putIfAbsent(k, new Holder<>(v));
+    resultHandler.handle(Future.succeededFuture(valueOrNull(h)));
+  }
+
+  @Override
+  public void put(K k, V v, long timeout, Handler<AsyncResult<Void>> completionHandler) {
+    map.put(k, new Holder<>(v, timeout));
+    completionHandler.handle(Future.succeededFuture());
+    vertx.setTimer(timeout, l -> map.computeIfPresent(k, (key, holder) -> notExpiredOrNull(holder)));
+  }
+
+  @Override
+  public void putIfAbsent(K k, V v, long timeout, Handler<AsyncResult<V>> completionHandler) {
+    Holder<V> h = map.putIfAbsent(k, new Holder<>(v, timeout));
+    completionHandler.handle(Future.succeededFuture(valueOrNull(h)));
+    if (h == null) {
+      vertx.setTimer(timeout, l -> map.computeIfPresent(k, (key, holder) -> notExpiredOrNull(holder)));
+    }
+  }
+
+  @Override
+  public void removeIfPresent(K k, V v, Handler<AsyncResult<Boolean>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.remove(k, new Holder<>(v))));
+  }
+
+  @Override
+  public void replace(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+    Holder<V> h = map.replace(k, new Holder<>(v));
+    resultHandler.handle(Future.succeededFuture(valueOrNull(h)));
+  }
+
+  @Override
+  public void replaceIfPresent(K k, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.replace(k, new Holder<>(oldValue), new Holder<>(newValue))));
+  }
+
+  @Override
+  public void clear(Handler<AsyncResult<Void>> resultHandler) {
+    map.clear();
+    resultHandler.handle(Future.succeededFuture());
+  }
+
+  @Override
+  public void size(Handler<AsyncResult<Integer>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(map.size()));
+  }
+
+  @Override
+  public void keys(Handler<AsyncResult<Set<K>>> resultHandler) {
+    resultHandler.handle(Future.succeededFuture(new HashSet<>(map.keySet())));
+  }
+
+  @Override
+  public void values(Handler<AsyncResult<List<V>>> asyncResultHandler) {
+    List<V> result = map.values().stream()
+      .filter(Holder::hasNotExpired)
+      .map(h -> h.value)
+      .collect(toList());
+    asyncResultHandler.handle(Future.succeededFuture(result));
+  }
+
+  @Override
+  public void entries(Handler<AsyncResult<Map<K, V>>> asyncResultHandler) {
+    Map<K, V> result = new HashMap<>(map.size());
+    map.forEach((key, holder) -> {
+      if (holder.hasNotExpired()) {
+        result.put(key, holder.value);
+      }
+    });
+    asyncResultHandler.handle(Future.succeededFuture(result));
+  }
+
+  @Override
+  public void remove(final K k, Handler<AsyncResult<V>> resultHandler) {
+    Holder<V> h = map.remove(k);
+    resultHandler.handle(Future.succeededFuture(valueOrNull(h)));
+  }
+
+  private static class Holder<V> {
+    final V value;
+    final long expiresOn;
+
+    Holder(V value) {
+      Objects.requireNonNull(value);
+      this.value = value;
+      this.expiresOn = -1;
+    }
+
+    Holder(V value, long ttl) {
+      Objects.requireNonNull(value);
+      this.value = value;
+      this.expiresOn = System.currentTimeMillis() + ttl;
+    }
+
+    boolean hasNotExpired() {
+      return expiresOn <= 0 || System.currentTimeMillis() <= expiresOn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      Holder<?> holder = (Holder<?>) o;
+
+      if (!value.equals(holder.value)) return false;
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "Holder{" + "value=" + value + ", expiresOn=" + expiresOn + '}';
+    }
+  }
+}

--- a/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncMapImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/LocalAsyncMapImpl.java
@@ -1,17 +1,12 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
- * ------------------------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.core.shareddata.impl;

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -41,6 +41,7 @@ public class SharedDataImpl implements SharedData {
 
   private final VertxInternal vertx;
   private final ClusterManager clusterManager;
+  private final ConcurrentMap<String, LocalAsyncMapImpl<?, ?>> localAsyncMaps = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, AsynchronousLock> localLocks = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Counter> localCounters = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, LocalMap<?, ?>> localMaps = new ConcurrentHashMap<>();
@@ -72,16 +73,17 @@ public class SharedDataImpl implements SharedData {
     Objects.requireNonNull(name, "name");
     Objects.requireNonNull(resultHandler, "resultHandler");
     if (clusterManager == null) {
-      throw new IllegalStateException("Can't get cluster wide map if not clustered");
+      getLocalAsyncMap(name, resultHandler);
+    } else {
+      clusterManager.<K, V>getAsyncMap(name, ar -> {
+        if (ar.succeeded()) {
+          // Wrap it
+          resultHandler.handle(Future.succeededFuture(new WrappedAsyncMap<K, V>(ar.result())));
+        } else {
+          resultHandler.handle(Future.failedFuture(ar.cause()));
+        }
+      });
     }
-    clusterManager.<K, V>getAsyncMap(name, ar -> {
-      if (ar.succeeded()) {
-        // Wrap it
-        resultHandler.handle(Future.succeededFuture(new WrappedAsyncMap<K, V>(ar.result())));
-      } else {
-        resultHandler.handle(Future.failedFuture(ar.cause()));
-      }
-    });
   }
 
   @Override
@@ -123,6 +125,11 @@ public class SharedDataImpl implements SharedData {
     return (LocalMap<K, V>) localMaps.computeIfAbsent(name, n -> new LocalMapImpl<>(n, localMaps));
   }
 
+  @SuppressWarnings("unchecked")
+  private <K, V> void getLocalAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler) {
+    LocalAsyncMapImpl<K, V> asyncMap = (LocalAsyncMapImpl<K, V>) localAsyncMaps.computeIfAbsent(name, n -> new LocalAsyncMapImpl<>(vertx));
+    resultHandler.handle(Future.succeededFuture(new WrappedAsyncMap<>(asyncMap)));
+  }
 
   private void getLocalLock(String name, long timeout, Handler<AsyncResult<Lock>> resultHandler) {
     AsynchronousLock lock = localLocks.computeIfAbsent(name, n -> new AsynchronousLock(vertx));

--- a/src/main/java/io/vertx/core/shareddata/package-info.java
+++ b/src/main/java/io/vertx/core/shareddata/package-info.java
@@ -15,8 +15,12 @@
  * Shared data contains functionality that allows you to safely share data between different parts of your application,
  * or different applications in the same Vert.x instance or across a cluster of Vert.x instances.
  *
- * Shared data includes local shared maps, distributed, cluster-wide maps, asynchronous cluster-wide locks and
- * asynchronous cluster-wide counters.
+ * Shared data provides:
+ *
+ *  * synchronous shared maps (local)
+ *  * asynchronous maps (local or cluster-wide)
+ *  * asynchronous locks (local or cluster-wide)
+ *  * asynchronous counters (local or cluster-wide)
  *
  * IMPORTANT: The behavior of the distributed data structure depends on the cluster manager you use. Backup
  * (replication) and behavior when a network partition is faced are defined by the cluster manager and its
@@ -41,16 +45,16 @@
  * {@link examples.SharedDataExamples#example1}
  * ----
  *
- * === Cluster-wide asynchronous maps
+ * === Asynchronous maps
  *
- * Cluster-wide asynchronous maps allow data to be put in the map from any node of the cluster and retrieved from any
- * other node.
+ * Asynchronous maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
+ * When clustered, data can be put from any node and retrieved from the same node or any other node.
  *
  * This makes them really useful for things like storing session state in a farm of servers hosting a Vert.x web
  * application.
  *
  * You get an instance of {@link io.vertx.core.shareddata.AsyncMap} with
- * {@link io.vertx.core.shareddata.SharedData#getClusterWideMap(java.lang.String, io.vertx.core.Handler)}.
+ * {@link io.vertx.core.shareddata.SharedData#getAsyncMap(java.lang.String, io.vertx.core.Handler)}.
  *
  * Getting the map is asynchronous and the result is returned to you in the handler that you specify. Here's an example:
  *
@@ -87,12 +91,12 @@
  *
  * See the {@link io.vertx.core.shareddata.AsyncMap API docs} for more information.
  *
- * === Cluster-wide locks
+ * === Asynchronous locks
  *
- * {@link io.vertx.core.shareddata.Lock Cluster wide locks} allow you to obtain exclusive locks across the cluster -
+ * {@link io.vertx.core.shareddata.Lock Asynchronous locks} allow you to obtain exclusive locks locally or across the cluster -
  * this is useful when you want to do something or access a resource on only one node of a cluster at any one time.
  *
- * Cluster wide locks have an asynchronous API unlike most lock APIs which block the calling thread until the lock
+ * Asynchronous locks have an asynchronous API unlike most lock APIs which block the calling thread until the lock
  * is obtained.
  *
  * To obtain a lock use {@link io.vertx.core.shareddata.SharedData#getLock(java.lang.String, io.vertx.core.Handler)}.
@@ -118,9 +122,9 @@
  * {@link examples.SharedDataExamples#example6}
  * ----
  *
- * === Cluster-wide counters
+ * === Asynchronous counters
  *
- * It's often useful to maintain an atomic counter across the different nodes of your application.
+ * It's often useful to maintain an atomic counter locally or across the different nodes of your application.
  *
  * You can do this with {@link io.vertx.core.shareddata.Counter}.
  *

--- a/src/main/java/io/vertx/core/shareddata/package-info.java
+++ b/src/main/java/io/vertx/core/shareddata/package-info.java
@@ -45,10 +45,13 @@
  * {@link examples.SharedDataExamples#example1}
  * ----
  *
- * === Asynchronous maps
+ * === Asynchronous shared maps
  *
- * Asynchronous maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
+ * Asynchronous shared maps allow data to be put in the map and retrieved locally when Vert.x is not clustered.
  * When clustered, data can be put from any node and retrieved from the same node or any other node.
+ *
+ * IMPORTANT: In clustered mode, asynchronous shared maps rely on distributed data structures provided by the cluster manager.
+ * Beware that the latency relative to asynchronous shared map operations can be much higher in clustered than in local mode.
  *
  * This makes them really useful for things like storing session state in a farm of servers hosting a Vert.x web
  * application.

--- a/src/test/java/io/vertx/test/core/AsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/AsyncMapTest.java
@@ -105,7 +105,7 @@ public abstract class AsyncMapTest extends VertxTestBase {
   public void testMapPutTtl() {
     getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       map.put("pipo", "molo", 10, onSuccess(vd -> {
-        vertx.setTimer(10, l -> {
+        vertx.setTimer(15, l -> {
           getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map2 -> {
             map2.get("pipo", onSuccess(res -> {
               assertNull(res);

--- a/src/test/java/io/vertx/test/core/AsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/AsyncMapTest.java
@@ -119,6 +119,25 @@ public abstract class AsyncMapTest extends VertxTestBase {
   }
 
   @Test
+  public void testMapPutTtlThenPut() {
+    getVertx().sharedData().getAsyncMap("foo", onSuccess(map -> {
+      map.put("pipo", "molo", 10, onSuccess(vd -> {
+        map.put("pipo", "mili", onSuccess(vd2 -> {
+          vertx.setTimer(20, l -> {
+            getVertx().sharedData().getAsyncMap("foo", onSuccess(map2 -> {
+              map2.get("pipo", onSuccess(res -> {
+                assertEquals("mili", res);
+                testComplete();
+              }));
+            }));
+          });
+        }));
+      }));
+    }));
+    await();
+  }
+
+  @Test
   public void testMapPutIfAbsentGetByte() {
     testMapPutIfAbsentGet((byte)1, (byte)2);
   }

--- a/src/test/java/io/vertx/test/core/AsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/AsyncMapTest.java
@@ -18,8 +18,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.AsyncMap;
-import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.test.fakecluster.FakeClusterManager;
 import org.junit.Test;
 
 import java.io.Serializable;
@@ -34,25 +32,9 @@ import static io.vertx.test.core.TestUtils.*;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class AsyncMapTest extends VertxTestBase {
+public abstract class AsyncMapTest extends VertxTestBase {
 
-  protected int getNumNodes() {
-    return 1;
-  }
-
-  protected Vertx getVertx() {
-    return vertices[0];
-  }
-
-  public void setUp() throws Exception {
-    super.setUp();
-    startNodes(getNumNodes());
-  }
-
-  @Override
-  protected ClusterManager getClusterManager() {
-    return new FakeClusterManager();
-  }
+  protected abstract Vertx getVertx();
 
   @Test
   public void testMapPutGetByte() {

--- a/src/test/java/io/vertx/test/core/AsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/AsyncMapTest.java
@@ -34,7 +34,7 @@ import static io.vertx.test.core.TestUtils.*;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class ClusterWideMapTest extends VertxTestBase {
+public class AsyncMapTest extends VertxTestBase {
 
   protected int getNumNodes() {
     return 1;
@@ -121,10 +121,10 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testMapPutTtl() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       map.put("pipo", "molo", 10, onSuccess(vd -> {
         vertx.setTimer(10, l -> {
-          getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map2 -> {
+          getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map2 -> {
             map2.get("pipo", onSuccess(res -> {
               assertNull(res);
               testComplete();
@@ -203,11 +203,11 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testMapPutIfAbsentTtl() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       map.putIfAbsent("pipo", "molo", 10, onSuccess(vd -> {
         assertNull(vd);
         vertx.setTimer(10, l -> {
-          getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map2 -> {
+          getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map2 -> {
             map2.get("pipo", onSuccess(res -> {
               assertNull(res);
               testComplete();
@@ -487,17 +487,17 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testGetMapWithNullName() throws Exception {
-    assertNullPointerException(() -> getVertx().sharedData().<String, String>getClusterWideMap(null, ar -> {}));
+    assertNullPointerException(() -> getVertx().sharedData().<String, String>getAsyncMap(null, ar -> {}));
   }
 
   @Test
   public void testGetMapWithNullResultHandler() throws Exception {
-    assertNullPointerException(() -> getVertx().sharedData().<String, String>getClusterWideMap("foo", null));
+    assertNullPointerException(() -> getVertx().sharedData().<String, String>getAsyncMap("foo", null));
   }
 
   @Test
   public void testPutNullKey() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       assertIllegalArgumentException(() -> map.put(null, "foo", ar2 -> {}));
       testComplete();
     }));
@@ -506,7 +506,7 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testPutNullValue() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       assertIllegalArgumentException(() -> map.put("foo", null, ar2 -> {}));
       testComplete();
     }));
@@ -515,7 +515,7 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testPutInvalidKey() {
-    getVertx().sharedData().<SomeObject, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<SomeObject, String>getAsyncMap("foo", onSuccess(map -> {
       assertIllegalArgumentException(() -> map.put(new SomeObject(), "foo", ar2 -> {}));
       testComplete();
     }));
@@ -524,7 +524,7 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testPutInvalidValue() {
-    getVertx().sharedData().<String, SomeObject>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, SomeObject>getAsyncMap("foo", onSuccess(map -> {
       assertIllegalArgumentException(() -> map.put("foo", new SomeObject(), ar2 -> {}));
       testComplete();
     }));
@@ -533,7 +533,7 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testPutIfAbsentInvalidKey() {
-    getVertx().sharedData().<SomeObject, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<SomeObject, String>getAsyncMap("foo", onSuccess(map -> {
       assertIllegalArgumentException(() -> map.putIfAbsent(new SomeObject(), "foo", ar2 -> {}));
       testComplete();
     }));
@@ -542,7 +542,7 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testPutIfAbsentInvalidValue() {
-    getVertx().sharedData().<String, SomeObject>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, SomeObject>getAsyncMap("foo", onSuccess(map -> {
       assertIllegalArgumentException(() -> map.putIfAbsent("foo", new SomeObject(), ar2 -> {}));
       testComplete();
     }));
@@ -551,9 +551,9 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testMultipleMaps() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       map.put("foo", "bar", onSuccess(v -> {
-        getVertx().sharedData().<String, String>getClusterWideMap("bar", onSuccess(map2 -> {
+        getVertx().sharedData().<String, String>getAsyncMap("bar", onSuccess(map2 -> {
           map2.get("foo", onSuccess(res -> {
             assertNull(res);
             testComplete();
@@ -566,9 +566,9 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testClear() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       map.put("foo", "bar", onSuccess(v -> {
-        getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map2 -> {
           map2.clear(onSuccess(v2 -> {
             map.get("foo", onSuccess(res -> {
               assertNull(res);
@@ -583,13 +583,13 @@ public class ClusterWideMapTest extends VertxTestBase {
 
   @Test
   public void testSize() {
-    getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map -> {
       map.size(onSuccess(size -> {
         assertEquals(0, size.intValue());
         map.put("foo", "bar", onSuccess(v -> {
           map.size(onSuccess(size2 -> {
             assertEquals(1, size2.intValue());
-            getVertx().sharedData().<String, String>getClusterWideMap("foo", onSuccess(map2 -> {
+            getVertx().sharedData().<String, String>getAsyncMap("foo", onSuccess(map2 -> {
               map2.size(onSuccess(size3 -> {
                 assertEquals(1, size3.intValue());
                 testComplete();
@@ -653,23 +653,23 @@ public class ClusterWideMapTest extends VertxTestBase {
     List<Future> futures = new ArrayList<>(map.size());
     map.forEach((key, value) -> {
       Future future = Future.future();
-      getVertx().sharedData().getClusterWideMap("foo", onSuccess(asyncMap -> {
+      getVertx().sharedData().getAsyncMap("foo", onSuccess(asyncMap -> {
         asyncMap.put(key, value, future);
       }));
       futures.add(future);
     });
     CompositeFuture.all(futures).setHandler(onSuccess(cf -> {
       Vertx v = getVertx();
-      v.sharedData().<JsonObject, Buffer>getClusterWideMap("foo", onSuccess(asyncMap -> {
+      v.sharedData().<JsonObject, Buffer>getAsyncMap("foo", onSuccess(asyncMap -> {
         test.accept(v, asyncMap);
       }));
     }));
   }
 
   private <K, V> void testMapPutGet(K k, V v) {
-    getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map -> {
       map.put(k, v, onSuccess(vd -> {
-        getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map2 -> {
           map2.get(k, onSuccess(res -> {
             assertEquals(v, res);
             testComplete();
@@ -681,10 +681,10 @@ public class ClusterWideMapTest extends VertxTestBase {
   }
 
   private <K, V> void testMapPutIfAbsentGet(K k, V v) {
-    getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map -> {
       map.putIfAbsent(k, v, onSuccess(res -> {
         assertNull(res);
-        getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map2 -> {
           map2.get(k, onSuccess(res2 -> {
             assertEquals(v, res2);
             map.putIfAbsent(k, v, onSuccess(res3 -> {
@@ -699,10 +699,10 @@ public class ClusterWideMapTest extends VertxTestBase {
   }
 
   private <K, V> void testMapRemove(K k, V v) {
-    getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map -> {
       map.put(k, v, onSuccess(res -> {
         assertNull(res);
-        getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map2 -> {
           map2.remove(k, onSuccess(res2 -> {
             assertEquals(v, res2);
             testComplete();
@@ -714,10 +714,10 @@ public class ClusterWideMapTest extends VertxTestBase {
   }
 
   private <K, V> void testMapRemoveIfPresent(K k, V v, V other) {
-    getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map -> {
       map.put(k, v, onSuccess(res -> {
         assertNull(res);
-        getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map2 -> {
           map2.removeIfPresent(k, other, onSuccess(res2 -> {
             assertFalse(res2);
             map2.removeIfPresent(k, v, onSuccess(res3 -> {
@@ -732,10 +732,10 @@ public class ClusterWideMapTest extends VertxTestBase {
   }
 
   private <K, V> void testMapReplace(K k, V v, V other) {
-    getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map -> {
       map.put(k, v, onSuccess(res -> {
         assertNull(res);
-        getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map2 -> {
           map2.replace(k, other, onSuccess(res2 -> {
             assertEquals(v, res2);
             map2.get(k, onSuccess(res3 -> {
@@ -758,10 +758,10 @@ public class ClusterWideMapTest extends VertxTestBase {
   }
 
   private <K, V> void testMapReplaceIfPresent(K k, V v, V other) {
-    getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map -> {
+    getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map -> {
       map.put(k, v, onSuccess(res -> {
         assertNull(res);
-        getVertx().sharedData().<K, V>getClusterWideMap("foo", onSuccess(map2 -> {
+        getVertx().sharedData().<K, V>getAsyncMap("foo", onSuccess(map2 -> {
           map2.replaceIfPresent(k, v, other, onSuccess(res2 -> {
             map2.replaceIfPresent(k, v, other, onSuccess(res3 -> {
               assertFalse(res3);

--- a/src/test/java/io/vertx/test/core/AsyncMapTestDifferentNodes.java
+++ b/src/test/java/io/vertx/test/core/AsyncMapTestDifferentNodes.java
@@ -16,7 +16,7 @@ import io.vertx.core.Vertx;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class ClusterWideMapTestDifferentNodes extends ClusterWideMapTest {
+public class AsyncMapTestDifferentNodes extends AsyncMapTest {
 
 
   @Override

--- a/src/test/java/io/vertx/test/core/ClusteredAsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/ClusteredAsyncMapTest.java
@@ -12,19 +12,16 @@
 package io.vertx.test.core;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.test.fakecluster.FakeClusterManager;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class AsyncMapTestDifferentNodes extends AsyncMapTest {
-
-
-  @Override
-  protected int getNumNodes() {
-    return 2;
-  }
+public class ClusteredAsyncMapTest extends AsyncMapTest {
 
   int pos;
+
   @Override
   protected Vertx getVertx() {
     Vertx vertx = vertices[pos];
@@ -34,5 +31,17 @@ public class AsyncMapTestDifferentNodes extends AsyncMapTest {
     return vertx;
   }
 
+  public void setUp() throws Exception {
+    super.setUp();
+    startNodes(getNumNodes());
+  }
 
+  protected int getNumNodes() {
+    return 2;
+  }
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new FakeClusterManager();
+  }
 }

--- a/src/test/java/io/vertx/test/core/LocalAsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/LocalAsyncMapTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.Vertx;
+
+/**
+ * @author Thomas Segismont
+ */
+public class LocalAsyncMapTest extends AsyncMapTest {
+
+  @Override
+  protected Vertx getVertx() {
+    return vertx;
+  }
+}

--- a/src/test/java/io/vertx/test/core/LocalAsyncMapTest.java
+++ b/src/test/java/io/vertx/test/core/LocalAsyncMapTest.java
@@ -1,17 +1,12 @@
 /*
- * Copyright (c) 2011-2017 The original author or authors
- * ------------------------------------------------------
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * and Apache License v2.0 which accompanies this distribution.
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
- *     The Eclipse Public License is available at
- *     http://www.eclipse.org/legal/epl-v10.html
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
- *     The Apache License v2.0 is available at
- *     http://www.opensource.org/licenses/apache2.0.php
- *
- * You may elect to redistribute this code under either of these licenses.
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
 package io.vertx.test.core;

--- a/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
+++ b/src/test/java/io/vertx/test/fakecluster/FakeClusterManager.java
@@ -24,6 +24,7 @@ import io.vertx.core.shareddata.Counter;
 import io.vertx.core.shareddata.Lock;
 import io.vertx.core.shareddata.impl.AsynchronousCounter;
 import io.vertx.core.shareddata.impl.AsynchronousLock;
+import io.vertx.core.shareddata.impl.LocalAsyncMapImpl;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
 import io.vertx.core.spi.cluster.ChoosableIterable;
 import io.vertx.core.spi.cluster.ClusterManager;
@@ -31,14 +32,11 @@ import io.vertx.core.spi.cluster.NodeListener;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -49,7 +47,7 @@ public class FakeClusterManager implements ClusterManager {
 
   private static Map<String, FakeClusterManager> nodes = Collections.synchronizedMap(new LinkedHashMap<>());
 
-  private static ConcurrentMap<String, ConcurrentMap> asyncMaps = new ConcurrentHashMap<>();
+  private static ConcurrentMap<String, LocalAsyncMapImpl> asyncMaps = new ConcurrentHashMap<>();
   private static ConcurrentMap<String, ConcurrentMap> asyncMultiMaps = new ConcurrentHashMap<>();
   private static ConcurrentMap<String, Map> syncMaps = new ConcurrentHashMap<>();
   private static ConcurrentMap<String, AsynchronousLock> locks = new ConcurrentHashMap<>();
@@ -128,18 +126,10 @@ public class FakeClusterManager implements ClusterManager {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public <K, V> void getAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler) {
-    ConcurrentMap map = asyncMaps.get(name);
-    if (map == null) {
-      map = new ConcurrentHashMap<>();
-      ConcurrentMap prevMap = asyncMaps.putIfAbsent(name, map);
-      if (prevMap != null) {
-        map = prevMap;
-      }
-    }
-    @SuppressWarnings("unchecked")
-    ConcurrentMap<K, V> theMap = map;
-    vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture(new FakeAsyncMap<>(theMap))));
+    LocalAsyncMapImpl<K, V> asyncMap = asyncMaps.computeIfAbsent(name, n -> new LocalAsyncMapImpl(vertx));
+    vertx.runOnContext(v -> resultHandler.handle(Future.succeededFuture(asyncMap)));
   }
 
   @Override
@@ -257,98 +247,6 @@ public class FakeClusterManager implements ClusterManager {
     public void release() {
       delegate.release();
     }
-  }
-
-  private class FakeAsyncMap<K, V> implements AsyncMap<K, V> {
-
-    private final Map<K, V> map;
-
-    public FakeAsyncMap(Map<K, V> map) {
-      this.map = map;
-    }
-
-    @Override
-    public void get(final K k, Handler<AsyncResult<V>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.get(k)), resultHandler);
-    }
-
-    @Override
-    public void put(final K k, final V v, Handler<AsyncResult<Void>> resultHandler) {
-      vertx.executeBlocking(fut -> {
-        map.put(k, v);
-        fut.complete();
-      }, resultHandler);
-    }
-
-    @Override
-    public void putIfAbsent(K k, V v, Handler<AsyncResult<V>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.putIfAbsent(k, v)), resultHandler);
-    }
-
-    @Override
-    public void put(K k, V v, long timeout, Handler<AsyncResult<Void>> completionHandler) {
-      put(k, v, completionHandler);
-      vertx.setTimer(timeout, tid -> map.remove(k));
-    }
-
-    @Override
-    public void putIfAbsent(K k, V v, long timeout, Handler<AsyncResult<V>> completionHandler) {
-      Future<V> future = Future.future();
-      putIfAbsent(k, v, future);
-      future.map(vv -> {
-        if (vv == null) vertx.setTimer(timeout, tid -> map.remove(k));
-        return vv;
-      }).setHandler(completionHandler);
-    }
-
-    @Override
-    public void removeIfPresent(K k, V v, Handler<AsyncResult<Boolean>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.remove(k, v)), resultHandler);
-    }
-
-    @Override
-    public void replace(K k, V v, Handler<AsyncResult<V>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.replace(k, v)), resultHandler);
-    }
-
-    @Override
-    public void replaceIfPresent(K k, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.replace(k, oldValue, newValue)), resultHandler);
-    }
-
-    @Override
-    public void clear(Handler<AsyncResult<Void>> resultHandler) {
-      vertx.executeBlocking(fut -> {
-        map.clear();
-        fut.complete();
-      }, resultHandler);
-    }
-
-    @Override
-    public void size(Handler<AsyncResult<Integer>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.size()), resultHandler);
-    }
-
-    @Override
-    public void keys(Handler<AsyncResult<Set<K>>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(new HashSet<>(map.keySet())), resultHandler);
-    }
-
-    @Override
-    public void values(Handler<AsyncResult<List<V>>> asyncResultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(new ArrayList<>(map.values())), asyncResultHandler);
-    }
-
-    @Override
-    public void entries(Handler<AsyncResult<Map<K, V>>> asyncResultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(new HashMap<>(map)), asyncResultHandler);
-    }
-
-    @Override
-    public void remove(final K k, Handler<AsyncResult<V>> resultHandler) {
-      vertx.executeBlocking(fut -> fut.complete(map.remove(k)), resultHandler);
-    }
-
   }
 
   private class FakeAsyncMultiMap<K, V> implements AsyncMultiMap<K, V> {


### PR DESCRIPTION
Fixes #2137 

Users often develop and test verticles in local mode and later deploy them in clustered mode. With shared data APIs this can lead to strange behavior:

- counters and locks can be used in local/clustered
- async map can be used in clustered mode only

We got questions/issues about this quite a few times so here's what I did:

- Added #getAsyncMap; the new one works regardless of the cluster status;
- reworked the Javadoc and the doc
- made sure AsyncMap is tested in both local/clustered mode
- implemented a local AsyncMap wich supports TTL correctly (ie an entry stays in the map even if previous binding had a TTL); the FakeClusterManager reuses this implemation