### PR TITLE
Provide user-friendly way to test an HTTP header value

### DIFF
--- a/src/main/java/io/vertx/core/MultiMap.java
+++ b/src/main/java/io/vertx/core/MultiMap.java
@@ -20,6 +20,7 @@ import io.vertx.core.http.CaseInsensitiveHeaders;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * This class represents a MultiMap of String keys to a List of String values.
@@ -91,6 +92,34 @@ public interface MultiMap extends Iterable<Map.Entry<String, String>> {
    */
   @GenIgnore
   boolean contains(CharSequence name);
+
+  /**
+   * Check if there is a header with the specified {@code name} and {@code value}.
+   *
+   * If {@code caseInsensitive} is {@code true}, value is compared in a case-insensitive way.
+   *
+   * @param name The name to search for
+   * @return true if at least one entry is found
+   */
+  default boolean contains(String name, String value, boolean caseInsensitive) {
+    return getAll(name).stream()
+      .anyMatch(val -> caseInsensitive ? val.equalsIgnoreCase(value) : val.equals(value));
+  }
+
+  /**
+   * Like {@link #contains(String, String, boolean)} but accepting {@code CharSequence} parameters.
+   */
+  @GenIgnore
+  default boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
+    Predicate<String> predicate;
+    if (caseInsensitive) {
+      String valueAsString = value.toString();
+      predicate = val -> val.equalsIgnoreCase(valueAsString);
+    } else {
+      predicate = val -> val.contentEquals(value);
+    }
+    return getAll(name).stream().anyMatch(predicate);
+  }
 
   /**
    * Return true if empty

--- a/src/main/java/io/vertx/core/MultiMap.java
+++ b/src/main/java/io/vertx/core/MultiMap.java
@@ -96,10 +96,11 @@ public interface MultiMap extends Iterable<Map.Entry<String, String>> {
   /**
    * Check if there is a header with the specified {@code name} and {@code value}.
    *
-   * If {@code caseInsensitive} is {@code true}, value is compared in a case-insensitive way.
+   * If {@code caseInsensitive} is {@code true}, {@code value} is compared in a case-insensitive way.
    *
-   * @param name The name to search for
-   * @return true if at least one entry is found
+   * @param name the name to search for
+   * @param value the value to search for
+   * @return {@code true} if at least one entry is found
    */
   default boolean contains(String name, String value, boolean caseInsensitive) {
     return getAll(name).stream()

--- a/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
@@ -154,6 +154,16 @@ public class HeadersAdaptor implements MultiMap {
   }
 
   @Override
+  public boolean contains(String name, String value, boolean caseInsensitive) {
+    return headers.contains(name, value, caseInsensitive);
+  }
+
+  @Override
+  public boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
+    return headers.contains(name, value, caseInsensitive);
+  }
+
+  @Override
   public MultiMap add(CharSequence name, CharSequence value) {
     headers.add(name, value);
     return this;

--- a/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
@@ -11,9 +11,7 @@
 package io.vertx.core.http.impl;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
-import io.netty.util.AsciiString;
 import io.vertx.core.MultiMap;
 
 import java.util.AbstractList;
@@ -25,18 +23,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static io.netty.util.AsciiString.*;
-
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
 public class Http2HeadersAdaptor implements MultiMap {
 
   static CharSequence toLowerCase(CharSequence s) {
-    if (s instanceof AsciiString) {
-      AsciiString asciiString = (AsciiString) s;
-      return asciiString.toLowerCase();
-    }
     StringBuilder buffer = null;
     int len = s.length();
     for (int index = 0; index < len; index++) {
@@ -234,24 +226,6 @@ public class Http2HeadersAdaptor implements MultiMap {
   @Override
   public boolean contains(CharSequence name) {
     return headers.contains(toLowerCase(name));
-  }
-
-  @Override
-  public boolean contains(String name, String value, boolean caseInsensitive) {
-    if (headers instanceof DefaultHttp2Headers) {
-      DefaultHttp2Headers h = (DefaultHttp2Headers) headers;
-      return h.contains(toLowerCase(name), value, caseInsensitive ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
-    }
-    return MultiMap.super.contains(name, value, caseInsensitive);
-  }
-
-  @Override
-  public boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
-    if (headers instanceof DefaultHttp2Headers) {
-      DefaultHttp2Headers h = (DefaultHttp2Headers) headers;
-      return h.contains(toLowerCase(name), value, caseInsensitive ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
-    }
-    return MultiMap.super.contains(name, value, caseInsensitive);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
@@ -11,7 +11,9 @@
 package io.vertx.core.http.impl;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
 import io.vertx.core.MultiMap;
 
 import java.util.AbstractList;
@@ -23,12 +25,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static io.netty.util.AsciiString.*;
+
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
 public class Http2HeadersAdaptor implements MultiMap {
 
   static CharSequence toLowerCase(CharSequence s) {
+    if (s instanceof AsciiString) {
+      AsciiString asciiString = (AsciiString) s;
+      return asciiString.toLowerCase();
+    }
     StringBuilder buffer = null;
     int len = s.length();
     for (int index = 0; index < len; index++) {
@@ -226,6 +234,24 @@ public class Http2HeadersAdaptor implements MultiMap {
   @Override
   public boolean contains(CharSequence name) {
     return headers.contains(toLowerCase(name));
+  }
+
+  @Override
+  public boolean contains(String name, String value, boolean caseInsensitive) {
+    if (headers instanceof DefaultHttp2Headers) {
+      DefaultHttp2Headers h = (DefaultHttp2Headers) headers;
+      return h.contains(toLowerCase(name), value, caseInsensitive ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
+    }
+    return MultiMap.super.contains(name, value, caseInsensitive);
+  }
+
+  @Override
+  public boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
+    if (headers instanceof DefaultHttp2Headers) {
+      DefaultHttp2Headers h = (DefaultHttp2Headers) headers;
+      return h.contains(toLowerCase(name), value, caseInsensitive ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
+    }
+    return MultiMap.super.contains(name, value, caseInsensitive);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -212,6 +212,50 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
+  public boolean contains(String name, String value, boolean ignoreCase) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        if (ignoreCase) {
+          if (AsciiString.contentEqualsIgnoreCase(value, e.getValue())) {
+            return true;
+          }
+        } else {
+          if (AsciiString.contentEquals(value, e.getValue())) {
+            return true;
+          }
+        }
+      }
+      e = e.next;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean contains(CharSequence name, CharSequence value, boolean ignoreCase) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        if (ignoreCase) {
+          if (AsciiString.contentEqualsIgnoreCase(value, e.getValue())) {
+            return true;
+          }
+        } else {
+          if (AsciiString.contentEquals(value, e.getValue())) {
+            return true;
+          }
+        }
+      }
+      e = e.next;
+    }
+    return false;
+  }
+
+  @Override
   public String get(final String name) {
     return get((CharSequence) name);
   }

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -13,6 +13,7 @@ package io.vertx.core.http.impl.headers;
 
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.util.AsciiString;
+import io.netty.util.HashingStrategy;
 import io.vertx.core.MultiMap;
 
 import java.util.AbstractMap;
@@ -25,6 +26,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+
+import static io.netty.util.AsciiString.*;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -216,16 +219,11 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     int h = AsciiString.hashCode(name);
     int i = index(h);
     VertxHttpHeaders.MapEntry e = entries[i];
+    HashingStrategy<CharSequence> strategy = ignoreCase ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER;
     while (e != null) {
       if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        if (ignoreCase) {
-          if (AsciiString.contentEqualsIgnoreCase(value, e.getValue())) {
-            return true;
-          }
-        } else {
-          if (AsciiString.contentEquals(value, e.getValue())) {
-            return true;
-          }
+        if (strategy.equals(value, e.getValue())) {
+          return true;
         }
       }
       e = e.next;
@@ -238,16 +236,11 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     int h = AsciiString.hashCode(name);
     int i = index(h);
     VertxHttpHeaders.MapEntry e = entries[i];
+    HashingStrategy<CharSequence> strategy = ignoreCase ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER;
     while (e != null) {
       if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        if (ignoreCase) {
-          if (AsciiString.contentEqualsIgnoreCase(value, e.getValue())) {
-            return true;
-          }
-        } else {
-          if (AsciiString.contentEquals(value, e.getValue())) {
-            return true;
-          }
+        if (strategy.equals(value, e.getValue())) {
+          return true;
         }
       }
       e = e.next;

--- a/src/test/java/io/vertx/test/core/CaseInsensitiveHeadersTest.java
+++ b/src/test/java/io/vertx/test/core/CaseInsensitiveHeadersTest.java
@@ -13,6 +13,7 @@ package io.vertx.test.core;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.HttpHeaders;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -944,5 +945,51 @@ public class CaseInsensitiveHeadersTest {
     for (Map.Entry<String, String> me:mmap) {
       me.setValue(null);
     }
+  }
+
+  @Test
+  public void testContainsValueString() {
+    MultiMap mmap = newMultiMap();
+
+    mmap.add("headeR", "vAlue");
+
+    assertTrue(mmap.contains("heaDer", "vAlue", false));
+    assertFalse(mmap.contains("heaDer", "Value", false));
+  }
+
+  @Test
+  public void testContainsValueStringIgnoreCase() {
+    MultiMap mmap = newMultiMap();
+
+    mmap.add("headeR", "vAlue");
+
+    assertTrue(mmap.contains("heaDer", "vAlue", true));
+    assertTrue(mmap.contains("heaDer", "Value", true));
+  }
+
+  @Test
+  public void testContainsValueCharSequence() {
+    MultiMap mmap = newMultiMap();
+
+    mmap.add("headeR", "vAlue");
+
+    CharSequence name = HttpHeaders.createOptimized("heaDer");
+    CharSequence vAlue = HttpHeaders.createOptimized("vAlue");
+    CharSequence Value = HttpHeaders.createOptimized("Value");
+    assertTrue(mmap.contains(name, vAlue, false));
+    assertFalse(mmap.contains(name, Value, false));
+  }
+
+  @Test
+  public void testContainsValueCharSequenceIgnoreCase() {
+    MultiMap mmap = newMultiMap();
+
+    mmap.add("headeR", "vAlue");
+
+    CharSequence name = HttpHeaders.createOptimized("heaDer");
+    CharSequence vAlue = HttpHeaders.createOptimized("vAlue");
+    CharSequence Value = HttpHeaders.createOptimized("Value");
+    assertTrue(mmap.contains(name, vAlue, true));
+    assertTrue(mmap.contains(name, Value, true));
   }
 }

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -42,19 +42,33 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.impl.HeadersAdaptor;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.impl.WorkerContext;
-import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.SocketAddress;
 import io.vertx.test.netty.TestLoggerFactory;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.util.concurrent.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -62,10 +76,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import static io.vertx.test.core.TestUtils.assertIllegalArgumentException;
-import static io.vertx.test.core.TestUtils.assertIllegalStateException;
-import static io.vertx.test.core.TestUtils.assertNullPointerException;
-import static java.util.Collections.singletonList;
+import static io.vertx.test.core.TestUtils.*;
+import static java.util.Collections.*;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -3893,6 +3905,102 @@ public abstract class HttpTest extends HttpTestBase {
 
     await();
 
+  }
+
+  @Test
+  public void testContainsValueString() {
+    server.requestHandler(req -> {
+      assertTrue(req.headers().contains("Foo", "foo", false));
+      assertFalse(req.headers().contains("Foo", "fOo", false));
+      req.response().putHeader("quux", "quux");
+      req.response().end();
+    });
+    server.listen(onSuccess(server -> {
+      HttpClientRequest req = client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        assertTrue(resp.headers().contains("Quux", "quux", false));
+        assertFalse(resp.headers().contains("Quux", "quUx", false));
+        testComplete();
+      });
+      req.putHeader("foo", "foo");
+      req.end();
+    }));
+    await();
+  }
+
+  @Test
+  public void testContainsValueStringIgnoreCase() {
+    server.requestHandler(req -> {
+      assertTrue(req.headers().contains("Foo", "foo", true));
+      assertTrue(req.headers().contains("Foo", "fOo", true));
+      req.response().putHeader("quux", "quux");
+      req.response().end();
+    });
+    server.listen(onSuccess(server -> {
+      HttpClientRequest req = client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        assertTrue(resp.headers().contains("Quux", "quux", true));
+        assertTrue(resp.headers().contains("Quux", "quUx", true));
+        testComplete();
+      });
+      req.putHeader("foo", "foo");
+      req.end();
+    }));
+    await();
+  }
+
+  @Test
+  public void testContainsValueCharSequence() {
+    CharSequence Foo = HttpHeaders.createOptimized("Foo");
+    CharSequence foo = HttpHeaders.createOptimized("foo");
+    CharSequence fOo = HttpHeaders.createOptimized("fOo");
+
+    CharSequence Quux = HttpHeaders.createOptimized("Quux");
+    CharSequence quux = HttpHeaders.createOptimized("quux");
+    CharSequence quUx = HttpHeaders.createOptimized("quUx");
+
+    server.requestHandler(req -> {
+      assertTrue(req.headers().contains(Foo, foo, false));
+      assertFalse(req.headers().contains(Foo, fOo, false));
+      req.response().putHeader(quux, quux);
+      req.response().end();
+    });
+    server.listen(onSuccess(server -> {
+      HttpClientRequest req = client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        assertTrue(resp.headers().contains(Quux, quux, false));
+        assertFalse(resp.headers().contains(Quux, quUx, false));
+        testComplete();
+      });
+      req.putHeader(foo, foo);
+      req.end();
+    }));
+    await();
+  }
+
+  @Test
+  public void testContainsValueCharSequenceIgnoreCase() {
+    CharSequence Foo = HttpHeaders.createOptimized("Foo");
+    CharSequence foo = HttpHeaders.createOptimized("foo");
+    CharSequence fOo = HttpHeaders.createOptimized("fOo");
+
+    CharSequence Quux = HttpHeaders.createOptimized("Quux");
+    CharSequence quux = HttpHeaders.createOptimized("quux");
+    CharSequence quUx = HttpHeaders.createOptimized("quUx");
+
+    server.requestHandler(req -> {
+      assertTrue(req.headers().contains(Foo, foo, true));
+      assertTrue(req.headers().contains(Foo, fOo, true));
+      req.response().putHeader(quux, quux);
+      req.response().end();
+    });
+    server.listen(onSuccess(server -> {
+      HttpClientRequest req = client.request(HttpMethod.GET, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+        assertTrue(resp.headers().contains(Quux, quux, true));
+        assertTrue(resp.headers().contains(Quux, quUx, true));
+        testComplete();
+      });
+      req.putHeader(foo, foo);
+      req.end();
+    }));
+    await();
   }
 
   protected File setupFile(String fileName, String content) throws Exception {


### PR DESCRIPTION
Fixes #2258

There is no easy way to test that an HTTP header is present and has a given value:

```java
    String value = HttpHeaders.WEBSOCKET.toString();
    boolean upgrade = headers.getAll(HttpHeaders.UPGRADE).stream()
      .anyMatch(val -> val.equalsIgnoreCase(value));
```

Drawbacks:

1. Testing a header value is a common task, especially if you write edge services or API gateways
2. The header value in this example should be tested in a case-insensitive way; so the `HttpHeaders` constant must be first converted to `String` (no `equalsIgnoreCase` on `CharSequence`)
3. A list of all headers needs to be created before testing
  