### PR TITLE
correct claim io.vertx.core.http.HttpClient#websocketStream to be fluent

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpClient.java
+++ b/src/main/java/io/vertx/core/http/HttpClient.java
@@ -1222,7 +1222,7 @@ public interface HttpClient extends Measured {
   /**
    * Create a WebSocket stream with the specified options
    * @param options  the request options
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(RequestOptions options);
 
@@ -1231,7 +1231,7 @@ public interface HttpClient extends Measured {
    * @param port  the port
    * @param host  the host
    * @param requestURI  the relative URI
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(int port, String host, String requestURI);
 
@@ -1239,7 +1239,7 @@ public interface HttpClient extends Measured {
    * Create a WebSocket stream to the specified host, relative request URI and default port
    * @param host  the host
    * @param requestURI  the relative URI
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String host, String requestURI);
 
@@ -1247,7 +1247,7 @@ public interface HttpClient extends Measured {
    * Create a WebSocket stream with the specified options, and with the specified headers
    * @param options  the request options
    * @param headers  the headers
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(RequestOptions options, MultiMap headers);
 
@@ -1257,7 +1257,7 @@ public interface HttpClient extends Measured {
    * @param host  the host
    * @param requestURI  the relative URI
    * @param headers  the headers
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(int port, String host, String requestURI, MultiMap headers);
 
@@ -1266,7 +1266,7 @@ public interface HttpClient extends Measured {
    * @param host  the host
    * @param requestURI  the relative URI
    * @param headers  the headers
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String host, String requestURI, MultiMap headers);
 
@@ -1276,7 +1276,7 @@ public interface HttpClient extends Measured {
    * @param options  the request options
    * @param headers  the headers
    * @param version  the websocket version
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(RequestOptions options, MultiMap headers, WebsocketVersion version);
 
@@ -1288,7 +1288,7 @@ public interface HttpClient extends Measured {
    * @param requestURI  the relative URI
    * @param headers  the headers
    * @param version  the websocket version
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(int port, String host, String requestURI, MultiMap headers, WebsocketVersion version);
 
@@ -1299,7 +1299,7 @@ public interface HttpClient extends Measured {
    * @param requestURI  the relative URI
    * @param headers  the headers
    * @param version  the websocket version
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String host, String requestURI, MultiMap headers, WebsocketVersion version);
 
@@ -1311,7 +1311,7 @@ public interface HttpClient extends Measured {
    * @param headers      the headers
    * @param version      the websocket version
    * @param subProtocols the subprotocols to use
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStreamAbs(String url, MultiMap headers, WebsocketVersion version, String subProtocols);
 
@@ -1322,7 +1322,7 @@ public interface HttpClient extends Measured {
    * @param headers  the headers
    * @param version  the websocket version
    * @param subProtocols  the subprotocols to use
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(RequestOptions options, MultiMap headers, WebsocketVersion version,
                                   String subProtocols);
@@ -1336,7 +1336,7 @@ public interface HttpClient extends Measured {
    * @param headers  the headers
    * @param version  the websocket version
    * @param subProtocols  the subprotocols to use
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(int port, String host, String requestURI, MultiMap headers, WebsocketVersion version,
                                   String subProtocols);
@@ -1349,7 +1349,7 @@ public interface HttpClient extends Measured {
    * @param headers  the headers
    * @param version  the websocket version
    * @param subProtocols  the subprotocols to use
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String host, String requestURI, MultiMap headers, WebsocketVersion version,
                                   String subProtocols);
@@ -1357,7 +1357,7 @@ public interface HttpClient extends Measured {
   /**
    * Create a WebSocket stream at the relative request URI using the default host and port and the specified headers
    * @param requestURI  the relative URI
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String requestURI);
 
@@ -1365,7 +1365,7 @@ public interface HttpClient extends Measured {
    * Create a WebSocket stream at the relative request URI using the default host and port and the specified headers
    * @param requestURI  the relative URI
    * @param headers  the headers
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String requestURI, MultiMap headers);
 
@@ -1375,7 +1375,7 @@ public interface HttpClient extends Measured {
    * @param requestURI  the relative URI
    * @param headers  the headers
    * @param version  the websocket version
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String requestURI, MultiMap headers, WebsocketVersion version);
 
@@ -1386,7 +1386,7 @@ public interface HttpClient extends Measured {
    * @param headers  the headers
    * @param version  the websocket version
    * @param subProtocols  the subprotocols
-   * @return a reference to this, so the API can be used fluently
+   * @return a stream emitting a WebSocket event when the client connection has been upgraded to a websocket
    */
   ReadStream<WebSocket> websocketStream(String requestURI, MultiMap headers, WebsocketVersion version,
                                   String subProtocols);


### PR DESCRIPTION
See https://github.com/vert-x3/issues/issues/319

Signed-off-by: wu-lee <eclipse.wu-lee@noodlefactory.co.uk>