### PR TITLE
Properly log the exception, showing the trace

### DIFF
--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -199,7 +199,7 @@ public abstract class ConnectionBase {
     if (exceptionHandler != null) {
       exceptionHandler.handle(t);
     } else {
-      log.error(t);
+      log.error("Unhandled exception", t);
     }
   }
 


### PR DESCRIPTION
This change adds a log message to the log output. Which also results in logging the stack trace of the exception. Otherwise only the exception name will be logged which isn't really helpful as the `ConnectionBase` is already missing some handling of the exception in the first place. Finding the root cause of this exception can be rather hard.

Signed-off-by: Jens Reimann <jreimann@redhat.com>