### PR TITLE
Harmonizing SSL/TLS protocol options

### DIFF
--- a/src/main/java/examples/NetExamples.java
+++ b/src/main/java/examples/NetExamples.java
@@ -507,12 +507,15 @@ public class NetExamples {
     NetServer server = vertx.createNetServer(options);
   }
 
+  /**
+   * The default protocols are defined in {@link io.vertx.core.net.TCPSSLOptions#DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS}, but you can change them.
+   */
   public void example45(Vertx vertx, JksOptions keyStoreOptions) {
     NetServerOptions options = new NetServerOptions().
       setSsl(true).
       setKeyStoreOptions(keyStoreOptions).
-      addEnabledSecureTransportProtocol("TLSv1.1").
-      addEnabledSecureTransportProtocol("TLSv1.2");
+      removeEnabledSecureTransportProtocol("TLSv1").
+      addEnabledSecureTransportProtocol("TLSv1.3");
     NetServer server = vertx.createNetServer(options);
   }
 

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -392,6 +392,11 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public HttpClientOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (HttpClientOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
   public HttpClientOptions setTcpFastOpen(boolean tcpFastOpen) {
     return (HttpClientOptions) super.setTcpFastOpen(tcpFastOpen);
   }

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -324,6 +324,11 @@ public class HttpServerOptions extends NetServerOptions {
   }
 
   @Override
+  public HttpServerOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (HttpServerOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
   public HttpServerOptions setTcpFastOpen(boolean tcpFastOpen) {
     return (HttpServerOptions) super.setTcpFastOpen(tcpFastOpen);
   }

--- a/src/main/java/io/vertx/core/net/ClientOptionsBase.java
+++ b/src/main/java/io/vertx/core/net/ClientOptionsBase.java
@@ -337,6 +337,11 @@ public abstract class ClientOptionsBase extends TCPSSLOptions {
   }
 
   @Override
+  public ClientOptionsBase removeEnabledSecureTransportProtocol(String protocol) {
+    return (ClientOptionsBase) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
   public ClientOptionsBase setTcpFastOpen(boolean tcpFastOpen) {
     return (ClientOptionsBase) super.setTcpFastOpen(tcpFastOpen);
   }

--- a/src/main/java/io/vertx/core/net/NetClientOptions.java
+++ b/src/main/java/io/vertx/core/net/NetClientOptions.java
@@ -205,6 +205,11 @@ public class NetClientOptions extends ClientOptionsBase {
   }
 
   @Override
+  public NetClientOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (NetClientOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
   public NetClientOptions setUseAlpn(boolean useAlpn) {
     return (NetClientOptions) super.setUseAlpn(useAlpn);
   }

--- a/src/main/java/io/vertx/core/net/NetServerOptions.java
+++ b/src/main/java/io/vertx/core/net/NetServerOptions.java
@@ -246,6 +246,11 @@ public class NetServerOptions extends TCPSSLOptions {
   }
 
   @Override
+  public NetServerOptions removeEnabledSecureTransportProtocol(String protocol) {
+    return (NetServerOptions) super.removeEnabledSecureTransportProtocol(protocol);
+  }
+
+  @Override
   public NetServerOptions setTcpFastOpen(boolean tcpFastOpen) {
     return (NetServerOptions) super.setTcpFastOpen(tcpFastOpen);
   }

--- a/src/main/java/io/vertx/core/net/TCPSSLOptions.java
+++ b/src/main/java/io/vertx/core/net/TCPSSLOptions.java
@@ -71,7 +71,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
    *
    * SSLv3 is NOT enabled due to POODLE vulnerability http://en.wikipedia.org/wiki/POODLE
    */
-  public static final String[] DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS = {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+  public static final List<String> DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS = Collections.unmodifiableList(Arrays.asList("SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"));
 
   /**
    * The default TCP_FASTOPEN value = false
@@ -175,7 +175,7 @@ public abstract class TCPSSLOptions extends NetworkOptions {
     crlValues = new ArrayList<>();
     useAlpn = DEFAULT_USE_ALPN;
     sslEngineOptions = DEFAULT_SSL_ENGINE;
-    enabledSecureTransportProtocols = new LinkedHashSet<>(Arrays.asList(DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS));
+    enabledSecureTransportProtocols = new LinkedHashSet<>(DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS);
     tcpFastOpen = DEFAULT_TCP_FAST_OPEN;
     tcpCork = DEFAULT_TCP_CORK;
     tcpQuickAck = DEFAULT_TCP_QUICKACK;

--- a/src/main/java/io/vertx/core/net/impl/SSLHelper.java
+++ b/src/main/java/io/vertx/core/net/impl/SSLHelper.java
@@ -119,9 +119,6 @@ public class SSLHelper {
 
   private static final Logger log = LoggerFactory.getLogger(SSLHelper.class);
 
-  // Make sure SSLv3 is NOT enabled due to POODLE vulnerability http://en.wikipedia.org/wiki/POODLE
-  private static final String[] DEFAULT_ENABLED_PROTOCOLS = {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
-
   private boolean ssl;
   private boolean sni;
   private KeyCertOptions keyCertOptions;
@@ -411,13 +408,10 @@ public class SSLHelper {
       engine.setEnabledCipherSuites(toUse);
     }
     engine.setUseClientMode(client);
-    Set<String> protocols = new LinkedHashSet<>(Arrays.asList(DEFAULT_ENABLED_PROTOCOLS));
-    protocols.retainAll(Arrays.asList(engine.getEnabledProtocols()));
-    if (enabledProtocols != null && !enabledProtocols.isEmpty() && !protocols.isEmpty()) {
-      protocols.retainAll(enabledProtocols);
-      if (protocols.isEmpty()) {
-        log.warn("no SSL/TLS protocols are enabled due to configuration restrictions");
-      }
+    Set<String> protocols = new LinkedHashSet<>(enabledProtocols);
+    protocols.retainAll(Arrays.asList(engine.getSupportedProtocols()));
+    if (protocols.isEmpty()) {
+      log.warn("no SSL/TLS protocols are enabled due to configuration restrictions");
     }
     engine.setEnabledProtocols(protocols.toArray(new String[protocols.size()]));
     if (!client) {

--- a/src/test/java/io/vertx/test/core/HttpTLSTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTLSTest.java
@@ -295,7 +295,7 @@ public abstract class HttpTLSTest extends HttpTestBase {
   @Test
   // Specify some non matching TLS protocols
   public void testTLSNonMatchingProtocolVersions() throws Exception {
-    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll().serverEnabledSecureTransportProtocol(new String[]{"TLSv1.2"}).clientEnabledSecureTransportProtocol(new String[]{"SSLv2Hello"}).fail();
+    testTLS(Cert.NONE, Trust.NONE, Cert.SERVER_JKS, Trust.NONE).clientTrustAll().serverEnabledSecureTransportProtocol(new String[]{"TLSv1.2"}).clientEnabledSecureTransportProtocol(new String[]{"SSLv2Hello", "TLSv1.1"}).fail();
   }
 
   @Test
@@ -1051,8 +1051,11 @@ public abstract class HttpTLSTest extends HttpTestBase {
       for (String suite: clientEnabledCipherSuites) {
         options.addEnabledCipherSuite(suite);
       }
-      for (String protocols: clientEnabledSecureTransportProtocol) {
-        options.addEnabledSecureTransportProtocol(protocols);
+      if(clientEnabledSecureTransportProtocol.length > 0) {
+        options.getEnabledSecureTransportProtocols().forEach(options::removeEnabledSecureTransportProtocol);
+      }
+      for (String protocol : clientEnabledSecureTransportProtocol) {
+        options.addEnabledSecureTransportProtocol(protocol);
       }
       if (proxyType != null) {
         ProxyOptions proxyOptions;
@@ -1085,8 +1088,11 @@ public abstract class HttpTLSTest extends HttpTestBase {
       for (String suite: serverEnabledCipherSuites) {
         serverOptions.addEnabledCipherSuite(suite);
       }
-      for (String protocols: serverEnabledSecureTransportProtocol) {
-        serverOptions.addEnabledSecureTransportProtocol(protocols);
+      if(serverEnabledSecureTransportProtocol.length > 0) {
+        serverOptions.getEnabledSecureTransportProtocols().forEach(serverOptions::removeEnabledSecureTransportProtocol);
+      }
+      for (String protocol : serverEnabledSecureTransportProtocol) {
+        serverOptions.addEnabledSecureTransportProtocol(protocol);
       }
       server = createHttpServer(serverOptions.setPort(4043));
       server.connectionHandler(conn -> complete());

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -1553,6 +1553,9 @@ public class NetTest extends VertxTestBase {
       for (String suite: enabledCipherSuites) {
         options.addEnabledCipherSuite(suite);
       }
+      if(enabledSecureTransportProtocols.length > 0) {
+        options.getEnabledSecureTransportProtocols().forEach(options::removeEnabledSecureTransportProtocol);
+      }
       for (String protocol : enabledSecureTransportProtocols) {
         options.addEnabledSecureTransportProtocol(protocol);
       }
@@ -1618,6 +1621,9 @@ public class NetTest extends VertxTestBase {
         clientOptions.setKeyCertOptions(clientCert.get());
         for (String suite: enabledCipherSuites) {
           clientOptions.addEnabledCipherSuite(suite);
+        }
+        if(enabledSecureTransportProtocols.length > 0) {
+          clientOptions.getEnabledSecureTransportProtocols().forEach(clientOptions::removeEnabledSecureTransportProtocol);
         }
         for (String protocol : enabledSecureTransportProtocols) {
           clientOptions.addEnabledSecureTransportProtocol(protocol);

--- a/src/test/java/io/vertx/test/core/SSLHelperTest.java
+++ b/src/test/java/io/vertx/test/core/SSLHelperTest.java
@@ -114,19 +114,17 @@ public class SSLHelperTest extends VertxTestBase {
 
   @Test
   public void testPreserveEnabledSecureTransportProtocolOrder() throws Exception {
-    String[] protocols = {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
     HttpServerOptions options = new HttpServerOptions();
-    for (String protocol : protocols) {
-      options.addEnabledSecureTransportProtocol(protocol);
-    }
-    assertEquals(new ArrayList<>(options.getEnabledSecureTransportProtocols()), Arrays.asList(protocols));
-    assertEquals(new ArrayList<>(new HttpServerOptions(options).getEnabledSecureTransportProtocols()), Arrays.asList(protocols));
+    List<String> expectedProtocols = new ArrayList<>(options.getEnabledSecureTransportProtocols());
+
+    options.removeEnabledSecureTransportProtocol("TLSv1");
+    options.addEnabledSecureTransportProtocol("SSLv3");
+    expectedProtocols.remove("TLSv1");
+    expectedProtocols.add("SSLv3");
+
+    assertEquals(new ArrayList<>(options.getEnabledSecureTransportProtocols()), expectedProtocols);
+    assertEquals(new ArrayList<>(new HttpServerOptions(options).getEnabledSecureTransportProtocols()), expectedProtocols);
     JsonObject json = options.toJson();
-    assertEquals(new ArrayList<>(new HttpServerOptions(json).getEnabledSecureTransportProtocols()), Arrays.asList(protocols));
-    SSLHelper helper = new SSLHelper(options, Cert.SERVER_JKS.get(), null);
-    List<String> engineProtocols = Arrays.asList(helper.createEngine((VertxInternal) vertx).getEnabledProtocols());
-    List<String> expectedProtocols = new ArrayList<>(Arrays.asList(protocols));
-    expectedProtocols.retainAll(engineProtocols);
-    assertEquals(engineProtocols, expectedProtocols);
+    assertEquals(new ArrayList<>(new HttpServerOptions(json).getEnabledSecureTransportProtocols()), expectedProtocols);
   }
 }


### PR DESCRIPTION
Implementation for https://github.com/eclipse/vert.x/issues/2179:

> Right now, `SSLHelper` is 
> 
> 1. taking the `DEFAULT_ENABLED_PROTOCOLS` as a basis protocol list
> 2. removing those protocols from that protocol list which are not already enabled in the `SSLEngine` by default (effectively leaving only those protocols in place which were enabled in the `SSLEngine` already)
> 3. if the developer added protocols to the `options`, the current protocol list is filtered to only leave those
> 
> This means that there is currently no way to add protocols not already enabled in both `SSLHelper` and `SSLEngine` by default - for my Java 8 setup, that is SSLv3 (disabled by both) and SSLv2Hello (enabled by `SSLHelper`, but disabled by `SSLEngine`).
> 
> As I need SSLv3 and SSLv2Hello support for a customer's legacy devices, I'd like to bring this forward. Let's not discuss the security implications here ☹️ 
> 
> I propose to move the `DEFAULT_ENABLED_PROTOCOLS` field from `SSLHelper` to `TCPSSLOptions`, where all other `DEFAULT_*` are. There, this field will be documented, so that developers know what the defaults are. A `addEnabledSecureTransportProtocol(String protocol)` method is already in place, a `removeEnabledSecureTransportProtocol(String protocol)` should be added. While the names are quite long, they are quite descriptive and the add-method is backwards compatible.
> 
> `SSLHelper` can then simply get that list, remove those protocols not supported by `SSLEngine` and tell `SSLEngine` to use the remainder of them.
> 
> `TCPSSLOptions.addEnabledSecureTransportProtocol` and `getEnabledSecureTransportProtocols` are being invoked/overwritten in several places:
> 
> - `ClientOptionsBase`, `HttpClientOptions`, `HttpServerOptions`, `NetClientOptions`, `NetServerOptions`: `removeEnabledSecureTransportProtocol` needs to be added
> - `EventBusOptionsConverter` and `TCPSSLOptionsConverter`: nothing to do
> - `NetExamples`: make it clearer by comments and code what is enabled and what not
> - `TCPSSLOptions` constructor: take over `other` values
> - `SSLHelper`: as described above
> - `SSLHelperTest`, `HttpTLSTest`, `NetTest`: analyze how they worked until now; add tests for additional protocols if possible

Signed-off-by: Philipp Lehmann <github@phil.to>