### PR TITLE
Add missing VertxGen annotation

### DIFF
--- a/src/main/java/io/vertx/core/parsetools/JsonEventType.java
+++ b/src/main/java/io/vertx/core/parsetools/JsonEventType.java
@@ -11,11 +11,14 @@
 
 package io.vertx.core.parsetools;
 
+import io.vertx.codegen.annotations.VertxGen;
+
 /**
  * The possibles types of {@link JsonEvent} emitted by the {@link JsonParser}.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
+@VertxGen
 public enum JsonEventType {
 
   /**


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Add the missing `VertxGen` annotation to the enum type.