### PR TITLE
HttpServerRequest provides a bytesRead() method

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerRequest.java
+++ b/src/main/java/io/vertx/core/http/HttpServerRequest.java
@@ -108,6 +108,11 @@ public interface HttpServerRequest extends ReadStream<Buffer> {
   String host();
 
   /**
+   * @return the total number of bytes read for the body of the request.
+   */
+  long bytesRead();
+
+  /**
    * @return the response. Each instance of this class has an {@link HttpServerResponse} instance attached to it. This is used
    * to send the response back to the client.
    */

--- a/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ServerRequestImpl.java
@@ -82,6 +82,7 @@ public class Http2ServerRequestImpl extends VertxHttp2Stream<Http2ServerConnecti
 
   private NetSocket netSocket;
 
+
   public Http2ServerRequestImpl(Http2ServerConnection conn, Http2Stream stream, HttpServerMetrics metrics,
       String serverOrigin, Http2Headers headers, String contentEncoding, boolean writable) {
     super(conn, stream, writable);
@@ -319,6 +320,14 @@ public class Http2ServerRequestImpl extends VertxHttp2Stream<Http2ServerConnecti
     CharSequence authority = headers.authority();
     return authority != null ? authority.toString() : null;
   }
+
+  @Override
+  public long bytesRead() {
+    synchronized (conn) {
+      return bytesRead;
+    }
+  }
+
 
   @Override
   public Http2ServerResponseImpl response() {

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -84,6 +84,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   private MultiMap attributes;
   private HttpPostRequestDecoder decoder;
   private boolean ended;
+  private long bytesRead;
 
 
   HttpServerRequestImpl(Http1xServerConnection conn,
@@ -158,6 +159,13 @@ public class HttpServerRequestImpl implements HttpServerRequest {
   @Override
   public @Nullable String host() {
     return getHeader(HttpHeaderNames.HOST);
+  }
+
+  @Override
+  public long bytesRead() {
+    synchronized (conn) {
+      return bytesRead;
+    }
   }
 
   @Override
@@ -373,6 +381,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
 
   void handleData(Buffer data) {
     synchronized (conn) {
+      bytesRead += data.getByteBuf().readableBytes();
       if (decoder != null) {
         try {
           decoder.offer(new DefaultHttpContent(data.getByteBuf()));

--- a/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerRequestImpl.java
@@ -381,7 +381,7 @@ public class HttpServerRequestImpl implements HttpServerRequest {
 
   void handleData(Buffer data) {
     synchronized (conn) {
-      bytesRead += data.getByteBuf().readableBytes();
+      bytesRead += data.length();
       if (decoder != null) {
         try {
           decoder.offer(new DefaultHttpContent(data.getByteBuf()));

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -3855,5 +3855,4 @@ public class Http1xTest extends HttpTest {
       .end();
     await();
   }
-
 }

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -3855,4 +3855,32 @@ public class Http1xTest extends HttpTest {
       .end();
     await();
   }
+
+  @Test
+  public void testBytesReadRequest() throws Exception {
+    int length = 2048;
+    Buffer expected = Buffer.buffer(TestUtils.randomAlphaString(length));
+    server.close();
+    server = vertx.createHttpServer(new HttpServerOptions()
+      .setPort(DEFAULT_HTTP_PORT)
+      .setHost(DEFAULT_HTTP_HOST)
+      .setCompressionSupported(true));
+    server.requestHandler(req -> {
+      req.bodyHandler(buffer -> {
+        assertEquals(req.bytesRead(), length);
+        req.response().end();
+      });
+    });
+
+    client.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+      resp.bodyHandler(buff -> {
+        complete();
+      });
+    }).exceptionHandler(this::fail)
+      .putHeader("content-length", String.valueOf(length))
+      .write(expected)
+      .end();
+    await();
+  }
+
 }

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -3856,31 +3856,4 @@ public class Http1xTest extends HttpTest {
     await();
   }
 
-  @Test
-  public void testBytesReadRequest() throws Exception {
-    int length = 2048;
-    Buffer expected = Buffer.buffer(TestUtils.randomAlphaString(length));
-    server.close();
-    server = vertx.createHttpServer(new HttpServerOptions()
-      .setPort(DEFAULT_HTTP_PORT)
-      .setHost(DEFAULT_HTTP_HOST)
-      .setCompressionSupported(true));
-    server.requestHandler(req -> {
-      req.bodyHandler(buffer -> {
-        assertEquals(req.bytesRead(), length);
-        req.response().end();
-      });
-    });
-
-    client.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
-      resp.bodyHandler(buff -> {
-        complete();
-      });
-    }).exceptionHandler(this::fail)
-      .putHeader("content-length", String.valueOf(length))
-      .write(expected)
-      .end();
-    await();
-  }
-
 }

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -4097,7 +4097,7 @@ public abstract class HttpTest extends HttpTestBase {
     startServer();
     client.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
       resp.bodyHandler(buff -> {
-        complete();
+        testComplete();
       });
     }).exceptionHandler(this::fail)
       .putHeader("content-length", String.valueOf(length))

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -4084,6 +4084,29 @@ public abstract class HttpTest extends HttpTestBase {
     await();
   }
 
+  @Test
+  public void testBytesReadRequest() throws Exception {
+    int length = 2048;
+    Buffer expected = Buffer.buffer(TestUtils.randomAlphaString(length));;
+    server.requestHandler(req -> {
+      req.bodyHandler(buffer -> {
+        assertEquals(req.bytesRead(), length);
+        req.response().end();
+      });
+    });
+    startServer();
+    client.post(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, DEFAULT_TEST_URI, resp -> {
+      resp.bodyHandler(buff -> {
+        complete();
+      });
+    }).exceptionHandler(this::fail)
+      .putHeader("content-length", String.valueOf(length))
+      .write(expected)
+      .end();
+    await();
+  }
+
+
   protected File setupFile(String fileName, String content) throws Exception {
     File file = new File(testDir, fileName);
     if (file.exists()) {


### PR DESCRIPTION
This change is to expose `bytesRead` from `HttpServerRequest` similar to `bytesWritten` for the response.

The use case is the following:
 
Suppose I have a `loggerHandler` (middleware) where I would like to record the bytes read to a log file.
ex. `router.route().handler(loggerHandler);`

The logger handle wants to record bytesRead (not content length). If it isn't a middleware solution I _could_ wrap my request handler ReadStream with a `CountingReadStream` -- however for a more general middleware solution (see below) when `context.next()` is called, downstream handlers won't be using the wrapped CountingReadStream.

```java
@Override
public void handle(RoutingContext context) {
    CountingReadStream<Buffer> rs = new CountingReadStream<>(context.request());
    context.addBodyEndHandler(event -> {
         //the value from CountingReadStream is not correct here !
    });
    context.next();
}
```

With the exposed `bytesRead` I can log that information in the `addBodyEndHandler` in my middleware.

```java
@Override
public void handle(RoutingContext context) {
    context.addBodyEndHandler(event -> {
         //do whatever you want with context.request().bytesRead()
    });
    context.next();
}
```