### PR TITLE
Adding metrics SPI methods for the event loop

### DIFF
--- a/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
+++ b/src/main/java/io/vertx/core/metrics/impl/DummyVertxMetrics.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.metrics.impl;
 
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.SingleThreadEventLoop;
 import io.vertx.core.Verticle;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.eventbus.ReplyFailure;
@@ -23,10 +25,17 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocket;
-import io.vertx.core.spi.metrics.*;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.core.net.NetServerOptions;
 import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.impl.transport.Transport;
+import io.vertx.core.spi.metrics.DatagramSocketMetrics;
+import io.vertx.core.spi.metrics.EventBusMetrics;
+import io.vertx.core.spi.metrics.HttpClientMetrics;
+import io.vertx.core.spi.metrics.HttpServerMetrics;
+import io.vertx.core.spi.metrics.PoolMetrics;
+import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.core.spi.metrics.VertxMetrics;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -54,6 +63,16 @@ public class DummyVertxMetrics implements VertxMetrics {
   @Override
   public EventBusMetrics createEventBusMetrics() {
     return DummyEventBusMetrics.INSTANCE;
+  }
+
+  @Override
+  public void eventLoopGroupCreated(final Class<? extends Transport> transport, final String name, final MultithreadEventLoopGroup eventLoopGroup) {
+
+  }
+
+  @Override
+  public void eventLoopCreated(final Class<? extends Transport> transport, final String name, final MultithreadEventLoopGroup eventLoopGroup, final SingleThreadEventLoop eventLoop) {
+
   }
 
   @Override

--- a/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java
+++ b/src/main/java/io/vertx/core/net/impl/transport/EpollTransport.java
@@ -14,7 +14,6 @@ package io.vertx.core.net.impl.transport;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.epoll.Epoll;

--- a/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
+++ b/src/main/java/io/vertx/core/spi/metrics/VertxMetrics.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.spi.metrics;
 
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.SingleThreadEventLoop;
 import io.vertx.core.Verticle;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
@@ -19,7 +21,12 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.metrics.Measured;
-import io.vertx.core.net.*;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.core.net.impl.transport.Transport;
 
 /**
  * The main Vert.x metrics SPI which Vert.x will use internally. This interface serves two purposes, one
@@ -152,4 +159,32 @@ public interface VertxMetrics extends Metrics, Measured {
    * @return the thread pool metrics SPI or {@code null} when metrics are disabled
    */
   PoolMetrics<?> createPoolMetrics(String poolType, String poolName, int maxPoolSize);
+
+
+  /**
+   * Called when a new EventLoop is created, allows access to the pendingTasks() in the given
+   * event loop.
+   *
+   * Will only be called for {@link Transport} and none of the native transport implementations.
+   *
+   * @param transport the transport implementation used for this event loop.
+   * @param name  the name for this eventloop
+   * @param eventLoopGroup the group this event loop belongs to
+   * @param eventLoop the newly created event loop.
+   */
+  default void eventLoopCreated(Class<? extends Transport> transport, String name, MultithreadEventLoopGroup eventLoopGroup, SingleThreadEventLoop eventLoop) {
+
+  }
+
+  /**
+   * Called when a new EventLoopGroup is created, allows access to the executorCount.
+   *
+   * @param transport the transport implementation used for this event loop.
+   * @param name the name for this event loop group
+   * @param eventLoopGroup the newly created event loop group.
+   */
+  default void eventLoopGroupCreated(Class<? extends Transport> transport, String name, MultithreadEventLoopGroup eventLoopGroup) {
+
+  }
+
 }

--- a/src/test/java/io/vertx/test/core/MetricsTest.java
+++ b/src/test/java/io/vertx/test/core/MetricsTest.java
@@ -35,15 +35,19 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.metrics.MetricsOptions;
 import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.impl.transport.Transport;
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.test.fakemetrics.EndpointMetric;
 import io.vertx.test.fakemetrics.FakeDatagramSocketMetrics;
 import io.vertx.test.fakemetrics.FakeEventBusMetrics;
+import io.vertx.test.fakemetrics.FakeEventLoopGroupMetrics;
+import io.vertx.test.fakemetrics.FakeEventLoopMetrics;
 import io.vertx.test.fakemetrics.FakeHttpClientMetrics;
 import io.vertx.test.fakemetrics.FakeHttpServerMetrics;
 import io.vertx.test.fakemetrics.FakeMetricsBase;
 import io.vertx.test.fakemetrics.FakeMetricsFactory;
 import io.vertx.test.fakemetrics.FakePoolMetrics;
+import io.vertx.test.fakemetrics.FakeVertxMetrics;
 import io.vertx.test.fakemetrics.HandlerMetric;
 import io.vertx.test.fakemetrics.HttpClientMetric;
 import io.vertx.test.fakemetrics.HttpServerMetric;
@@ -54,14 +58,22 @@ import io.vertx.test.fakemetrics.SocketMetric;
 import io.vertx.test.fakemetrics.WebSocketMetric;
 import org.junit.Test;
 
-import java.util.*;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.Is.is;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -89,6 +101,7 @@ public class MetricsTest extends VertxTestBase {
       });
       awaitLatch(latch);
     }
+    FakeVertxMetrics.reset();
     super.tearDown();
   }
 
@@ -1126,4 +1139,81 @@ public class MetricsTest extends VertxTestBase {
       future.complete(null);
     };
   }
+
+  @Test
+  public void testEventLoopGroupMetrics() {
+    final List<FakeEventLoopGroupMetrics> metrics = FakeVertxMetrics.eventLoopGroups;
+    assertNotNull(metrics);
+    assertEquals(2, metrics.size());
+
+    final Optional<FakeEventLoopGroupMetrics> eventLoop = metrics.stream()
+      .filter(metric -> "eventloop".equals(metric.getName()))
+      .findFirst();
+    assertTrue(eventLoop.isPresent());
+    assertFieldsNotNull(eventLoop.get());
+
+    final Optional<FakeEventLoopGroupMetrics> acceptorEventLoop = metrics.stream()
+      .filter(metric -> "acceptor-eventloop".equals(metric.getName()))
+      .findFirst();
+    assertTrue(acceptorEventLoop.isPresent());
+    assertFieldsNotNull(acceptorEventLoop.get());
+    assertThreadsNotStarted();
+
+  }
+
+  private void assertFieldsNotNull(final FakeEventLoopGroupMetrics fakeEventLoopGroupMetrics) {
+    assertNotNull(fakeEventLoopGroupMetrics.getEventLoopGroup());
+    assertNotNull(fakeEventLoopGroupMetrics.getTransport());
+    assertEquals(fakeEventLoopGroupMetrics.getTransport(), Transport.class);
+  }
+
+  @Test
+  public void testEventLoopMetrics() {
+    final List<FakeEventLoopMetrics> metrics = FakeVertxMetrics.eventLoops;
+    assertNotNull(metrics);
+    assertTrue(!metrics.isEmpty());
+
+    final List<FakeEventLoopMetrics> eventLoops = metrics.stream()
+      .filter(metric -> "eventloop".equals(metric.getName()))
+      .collect(Collectors.toList());
+    assertTrue(!eventLoops.isEmpty());
+    assertFieldsNotNull(eventLoops);
+
+    final List<FakeEventLoopMetrics> accessorEventLoop = metrics.stream()
+      .filter(metric -> "acceptor-eventloop".equals(metric.getName()))
+      .collect(Collectors.toList());
+    assertEquals(1, accessorEventLoop.size());
+    assertFieldsNotNull(accessorEventLoop);
+
+    assertThreadsNotStarted();
+  }
+
+  private void assertThreadsNotStarted() {
+    final List<Thread> eventLoopThreads = Thread.getAllStackTraces().keySet().stream()
+      .filter(t -> t.getName().startsWith("vert.x-eventloop-thread-"))
+      .collect(Collectors.toList());
+    assertEquals(0, eventLoopThreads.size());
+
+    final List<Thread> acceptorEventLoopThreads = Thread.getAllStackTraces().keySet().stream()
+      .filter(t -> t.getName().startsWith("vert.x-acceptor-thread-"))
+      .collect(Collectors.toList());
+
+    assertEquals(0, acceptorEventLoopThreads.size());
+  }
+
+  private void assertFieldsNotNull(final List<FakeEventLoopMetrics> eventLoopsMetrics) {
+    eventLoopsMetrics.stream()
+      .forEach(eventLoop -> {
+        assertNotNull(eventLoop);
+        assertNotNull(eventLoop.getEventLoop());
+        assertNotNull(eventLoop.getEventLoopGroup());
+        assertNotNull(eventLoop.getName());
+        assertNotNull(eventLoop.getTransport());
+        assertEquals(eventLoop.getTransport(), Transport.class);
+
+      });
+
+  }
+
+
 }

--- a/src/test/java/io/vertx/test/fakemetrics/FakeEventLoopGroupMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeEventLoopGroupMetrics.java
@@ -1,0 +1,33 @@
+package io.vertx.test.fakemetrics;
+
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.vertx.core.net.impl.transport.Transport;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */
+public class FakeEventLoopGroupMetrics {
+
+  private final Class<? extends Transport> transport;
+  private final String name;
+  private final MultithreadEventLoopGroup eventLoopGroup;
+
+  public FakeEventLoopGroupMetrics(final Class<? extends Transport> transport, final String name, final MultithreadEventLoopGroup eventLoopGroup) {
+    this.transport = transport;
+    this.name = name;
+    this.eventLoopGroup = eventLoopGroup;
+  }
+
+  public Class<? extends Transport> getTransport() {
+    return transport;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public MultithreadEventLoopGroup getEventLoopGroup() {
+    return eventLoopGroup;
+  }
+}

--- a/src/test/java/io/vertx/test/fakemetrics/FakeEventLoopMetrics.java
+++ b/src/test/java/io/vertx/test/fakemetrics/FakeEventLoopMetrics.java
@@ -1,0 +1,40 @@
+package io.vertx.test.fakemetrics;
+
+import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.SingleThreadEventLoop;
+import io.vertx.core.net.impl.transport.Transport;
+
+/**
+ * @author marcus
+ * @since 1.0.0
+ */
+public class FakeEventLoopMetrics {
+
+  private final Class<? extends Transport> transport;
+  private final String name;
+  private final MultithreadEventLoopGroup eventLoopGroup;
+  private final SingleThreadEventLoop eventLoop;
+
+  public FakeEventLoopMetrics(final Class<? extends Transport> transport, final String name, final MultithreadEventLoopGroup eventLoopGroup, final SingleThreadEventLoop eventLoop) {
+    this.transport = transport;
+    this.name = name;
+    this.eventLoopGroup = eventLoopGroup;
+    this.eventLoop = eventLoop;
+  }
+
+  public Class<? extends Transport> getTransport() {
+    return transport;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public MultithreadEventLoopGroup getEventLoopGroup() {
+    return eventLoopGroup;
+  }
+
+  public SingleThreadEventLoop getEventLoop() {
+    return eventLoop;
+  }
+}


### PR DESCRIPTION
This closes #2349

With this and a custom implementation for the SPI I can create
```
# HELP vertx_transport_acceptor_eventloop_executor_count Event loop executor count, number of executors in the event loop group
# TYPE vertx_transport_acceptor_eventloop_executor_count gauge
vertx_transport_acceptor_eventloop_executor_count 1.0
# HELP vertx_transport_eventloop_executor_count Event loop executor count, number of executors in the event loop group
# TYPE vertx_transport_eventloop_executor_count gauge
vertx_transport_eventloop_executor_count 16.0
# HELP vertx_transport_eventloop_pending_tasks Number of pending tasks for a specific event loop executor
# TYPE vertx_transport_eventloop_pending_tasks gauge
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@5b218417",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@645aa696",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@6caf0677",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@413d1baf",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@16eb3ea3",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@273444fe",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@33bc72d1",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@1a75e76a",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@5524cca1",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@5032714f",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@48bb62",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@353352b6",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@4681c175",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@57a78e3",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@402c4085",} 0.0
vertx_transport_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@6fa51cd4",} 0.0
# HELP vertx_transport_acceptor_eventloop_pending_tasks Number of pending tasks for a specific event loop executor
# TYPE vertx_transport_acceptor_eventloop_pending_tasks gauge
vertx_transport_acceptor_eventloop_pending_tasks{instance="io.netty.channel.nio.NioEventLoop@14028087",} 0.0
```
which I deam quite useful.

