### PR TITLE
Http improvements

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -12,6 +12,9 @@
 package io.vertx.core.http.impl;
 
 import io.netty.channel.Channel;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.impl.pool.Pool;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
@@ -110,9 +113,7 @@ class ConnectionManager {
     }
   }
 
-  void getConnection(String peerHost, boolean ssl, int port, String host,
-                     Function<HttpClientConnection, Boolean> onSuccess,
-                     Consumer<Throwable> onFailure) {
+  void getConnection(String peerHost, boolean ssl, int port, String host, Handler<AsyncResult<HttpClientConnection>> handler) {
     EndpointKey key = new EndpointKey(ssl, port, peerHost, host);
     while (true) {
       Endpoint endpoint = endpointMap.computeIfAbsent(key, targetAddress -> {
@@ -155,15 +156,12 @@ class ConnectionManager {
             metrics.dequeueRequest(endpoint.metric, metric);
           }
 
-          boolean claimed = onSuccess.apply(conn);
-          if (!claimed) {
-            conn.recycle();
-          }
+          handler.handle(Future.succeededFuture(conn));
         } else {
           if (metrics != null) {
             metrics.dequeueRequest(endpoint.metric, metric);
           }
-          onFailure.accept(ar.cause());
+          handler.handle(Future.failedFuture(ar.cause()));
         }
       })) {
         break;

--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -21,9 +21,6 @@ import io.vertx.core.spi.metrics.HttpClientMetrics;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * The connection manager associates remote hosts with pools, it also tracks all connections so they can be closed
@@ -137,18 +134,9 @@ class ConnectionManager {
       } else {
         metric = null;
       }
+
       if (endpoint.pool.getConnection(client.getVertx().getOrCreateContext(), ar -> {
         if (ar.succeeded()) {
-          /*
-        @Override
-        public void initConnection(ContextInternal ctx, HttpClientConnection conn) {
-          if (connectionHandler != null) {
-            ctx.executeFromIO(v -> {
-              connectionHandler.handle(conn);
-            });
-          }
-        }
-           */
 
           HttpClientConnection conn = ar.result();
 

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -225,11 +225,6 @@ class Http1xClientConnection extends Http1xConnectionBase implements HttpClientC
     }
 
     @Override
-    public void checkDrained() {
-      conn.handleInterestedOpsChanged();
-    }
-
-    @Override
     public void doPause() {
       conn.doPause();
     }

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientHandler.java
@@ -34,6 +34,7 @@ class Http1xClientHandler extends VertxHttpHandler<Http1xClientConnection> {
   private ContextInternal context;
   private ChannelHandlerContext chctx;
   private final HttpVersion version;
+  private final String peerHost;
   private final String host;
   private final int port;
   private final boolean ssl;
@@ -45,6 +46,7 @@ class Http1xClientHandler extends VertxHttpHandler<Http1xClientConnection> {
   public Http1xClientHandler(ConnectionListener<HttpClientConnection> listener,
                              ContextInternal context,
                              HttpVersion version,
+                             String peerHost,
                              String host,
                              int port,
                              boolean ssl,
@@ -54,6 +56,7 @@ class Http1xClientHandler extends VertxHttpHandler<Http1xClientConnection> {
     this.context = context;
     this.version = version;
     this.client = client;
+    this.peerHost = peerHost;
     this.host = host;
     this.port = port;
     this.ssl = ssl;
@@ -65,7 +68,7 @@ class Http1xClientHandler extends VertxHttpHandler<Http1xClientConnection> {
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     chctx = ctx;
-    Http1xClientConnection conn = new Http1xClientConnection(listener, version, client, endpointMetric, ctx, ssl, host, port, context, metrics);
+    Http1xClientConnection conn = new Http1xClientConnection(listener, version, client, endpointMetric, ctx, ssl, peerHost, host, port, context, metrics);
     if (metrics != null) {
       context.executeFromIO(v -> {
         Object metric = metrics.connected(conn.remoteAddress(), conn.remoteName());

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerHandler.java
@@ -17,9 +17,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
-import io.vertx.core.Handler;
 import io.vertx.core.VertxException;
-import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -62,16 +60,12 @@ public class Http1xServerHandler extends VertxHttpHandler<Http1xServerConnection
       serverOrigin,
       metrics);
     setConnection(conn);
-    conn.requestHandler(holder.handler.requesthHandler);
-    holder.context.executeFromIO(v -> {
-      if (metrics != null) {
+    conn.requestHandlers(holder.handler);
+    if (metrics != null) {
+      holder.context.executeFromIO(v -> {
         conn.metric(metrics.connected(conn.remoteAddress(), conn.remoteName()));
-      }
-      Handler<HttpConnection> connHandler = holder.handler.connectionHandler;
-      if (connHandler != null) {
-        connHandler.handle(conn);
-      }
-    });
+      });
+    }
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ClientConnection.java
@@ -241,13 +241,6 @@ class Http2ClientConnection extends Http2ConnectionBase implements HttpClientCon
     }
 
     @Override
-    public void checkDrained() {
-      synchronized (conn) {
-        handleInterestedOpsChanged();
-      }
-    }
-
-    @Override
     void handleInterestedOpsChanged() {
       if (request instanceof HttpClientRequestImpl && !isNotWritable()) {
         if (!isNotWritable()) {

--- a/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2ConnectionBase.java
@@ -196,9 +196,6 @@ abstract class Http2ConnectionBase extends ConnectionBase implements Http2FrameL
     }
   }
 
-  protected void onConnect() {
-  }
-
   protected void concurrencyChanged(long concurrency) {
   }
 

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.*;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.*;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.pool.ConnectionListener;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
+
+/**
+ * An HTTP/2 connection in clear text that upgraded from an HTTP/1 upgrade.
+ */
+public class Http2UpgradedClientConnection implements HttpClientConnection {
+
+  private HttpClientImpl client;
+  private HttpClientConnection current;
+
+  private Handler<Void> closeHandler;
+  private Handler<Void> shutdownHandler;
+  private Handler<GoAway> goAwayHandler;
+  private Handler<Throwable> exceptionHandler;
+  private Handler<Buffer> pingHandler;
+  private Handler<Http2Settings> remoteSettingsHandler;
+
+  Http2UpgradedClientConnection(HttpClientImpl client, Http1xClientConnection connection) {
+    this.client = client;
+    this.current = connection;
+  }
+
+  @Override
+  public Channel channel() {
+    return current.channel();
+  }
+
+  @Override
+  public void close() {
+    current.close();
+  }
+
+  /**
+   * The first stream that will send the request using HTTP/1, upgrades the connection when the protocol
+   * switches and receives the response with HTTP/2 frames.
+   */
+  private class UpgradingStream implements HttpClientStream {
+
+    private HttpClientRequestImpl request;
+    private Http1xClientConnection conn;
+    private HttpClientStream stream;
+
+    UpgradingStream(HttpClientStream stream, Http1xClientConnection conn) {
+      this.conn = conn;
+      this.stream = stream;
+    }
+
+    @Override
+    public HttpClientConnection connection() {
+      return current == null ? conn : current;
+    }
+
+    /**
+     * HTTP/2 clear text upgrade here.
+     */
+    @Override
+    public void writeHead(HttpMethod method,
+                          String rawMethod,
+                          String uri,
+                          MultiMap headers,
+                          String hostHeader,
+                          boolean chunked,
+                          ByteBuf buf,
+                          boolean end) {
+      ChannelPipeline pipeline = conn.channel().pipeline();
+      HttpClientCodec httpCodec = pipeline.get(HttpClientCodec.class);
+      class UpgradeRequestHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+          super.userEventTriggered(ctx, evt);
+          ChannelPipeline pipeline = ctx.pipeline();
+          if (evt == HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL) {
+            // Upgrade handler will remove itself and remove the HttpClientCodec
+            pipeline.remove(conn.handler());
+          }
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+          if (msg instanceof HttpResponse) {
+            pipeline.remove(this);
+            HttpResponse resp = (HttpResponse) msg;
+            if (resp.status() != HttpResponseStatus.SWITCHING_PROTOCOLS) {
+              // Insert the cloe headers to let the HTTP/1 stream close the connection
+              resp.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+            }
+          }
+          super.channelRead(ctx, msg);
+        }
+      }
+      VertxHttp2ClientUpgradeCodec upgradeCodec = new VertxHttp2ClientUpgradeCodec(client.getOptions().getInitialSettings()) {
+        @Override
+        public void upgradeTo(ChannelHandlerContext ctx, FullHttpResponse upgradeResponse) throws Exception {
+
+          // Now we need to upgrade this to an HTTP2
+          ConnectionListener<HttpClientConnection> listener = conn.listener();
+          VertxHttp2ConnectionHandler<Http2ClientConnection> handler = Http2ClientConnection.createHttp2ConnectionHandler(client, conn.endpointMetric(), listener, conn.getContext(), (conn, concurrency) -> {
+            conn.upgradeStream(request, ar -> {
+              UpgradingStream.this.conn.closeHandler(null);
+              UpgradingStream.this.conn.exceptionHandler(null);
+              if (ar.succeeded()) {
+                current = conn;
+                conn.closeHandler(closeHandler);
+                conn.exceptionHandler(exceptionHandler);
+                conn.pingHandler(pingHandler);
+                conn.goAwayHandler(goAwayHandler);
+                conn.shutdownHandler(shutdownHandler);
+                conn.remoteSettingsHandler(remoteSettingsHandler);
+                listener.onConcurrencyChange(concurrency);
+              } else {
+                // Handle me
+                ar.cause().printStackTrace();
+              }
+            });
+          });
+          conn.channel().pipeline().addLast(handler);
+          handler.clientUpgrade(ctx);
+        }
+      };
+      HttpClientUpgradeHandler upgradeHandler = new HttpClientUpgradeHandler(httpCodec, upgradeCodec, 65536);
+      pipeline.addAfter("codec", null, new UpgradeRequestHandler());
+      pipeline.addAfter("codec", null, upgradeHandler);
+      stream.writeHead(method, rawMethod, uri, headers, hostHeader, chunked, buf, end);
+    }
+
+    @Override
+    public int id() {
+      return 1;
+    }
+
+    @Override
+    public HttpVersion version() {
+      return HttpVersion.HTTP_2;
+    }
+
+    @Override
+    public Context getContext() {
+      return stream.getContext();
+    }
+
+    @Override
+    public void writeBuffer(ByteBuf buf, boolean end) {
+      stream.writeBuffer(buf, end);
+    }
+
+    @Override
+    public void writeFrame(int type, int flags, ByteBuf payload) {
+      stream.writeFrame(type, flags, payload);
+    }
+
+    @Override
+    public void reportBytesWritten(long numberOfBytes) {
+      stream.reportBytesWritten(numberOfBytes);
+    }
+
+    @Override
+    public void reportBytesRead(long numberOfBytes) {
+      stream.reportBytesRead(numberOfBytes);
+    }
+
+    @Override
+    public void doSetWriteQueueMaxSize(int size) {
+      stream.doSetWriteQueueMaxSize(size);
+    }
+
+    @Override
+    public boolean isNotWritable() {
+      return stream.isNotWritable();
+    }
+
+    @Override
+    public void doPause() {
+      stream.doPause();
+    }
+
+    @Override
+    public void doResume() {
+      stream.doResume();
+    }
+
+    @Override
+    public void reset(long code) {
+      stream.reset(code);
+    }
+
+    @Override
+    public void beginRequest(HttpClientRequestImpl req) {
+      request = req;
+      stream.beginRequest(req);
+    }
+
+    @Override
+    public void endRequest() {
+      stream.endRequest();
+    }
+
+    @Override
+    public NetSocket createNetSocket() {
+      return stream.createNetSocket();
+    }
+  }
+
+  @Override
+  public void createStream(Handler<AsyncResult<HttpClientStream>> handler) {
+    if (current instanceof Http1xClientConnection) {
+      current.createStream(ar -> {
+        if (ar.succeeded()) {
+          HttpClientStream stream = ar.result();
+          UpgradingStream upgradingStream = new UpgradingStream(stream, (Http1xClientConnection) current);
+          handler.handle(Future.succeededFuture(upgradingStream));
+        } else {
+          handler.handle(ar);
+        }
+      });
+    } else {
+      current.createStream(handler);
+    }
+  }
+
+  @Override
+  public ContextInternal getContext() {
+    return current.getContext();
+  }
+
+  @Override
+  public boolean checkInitialized() {
+    return current.checkInitialized();
+  }
+
+  @Override
+  public void recycle() {
+    current.recycle();
+  }
+
+  @Override
+  public HttpConnection closeHandler(Handler<Void> handler) {
+    closeHandler = handler;
+    current.closeHandler(handler);
+    return this;
+  }
+
+  @Override
+  public HttpConnection exceptionHandler(Handler<Throwable> handler) {
+    exceptionHandler = handler;
+    current.exceptionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public HttpConnection remoteSettingsHandler(Handler<Http2Settings> handler) {
+    if (current instanceof Http1xClientConnection) {
+      remoteSettingsHandler = handler;
+    } else {
+      current.remoteSettingsHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public HttpConnection pingHandler(@Nullable Handler<Buffer> handler) {
+    if (current instanceof Http1xClientConnection) {
+      pingHandler = handler;
+    } else {
+      current.pingHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public HttpConnection goAwayHandler(@Nullable Handler<GoAway> handler) {
+    if (current instanceof Http1xClientConnection) {
+      goAwayHandler = handler;
+    } else {
+      current.goAwayHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public HttpConnection shutdownHandler(@Nullable Handler<Void> handler) {
+    if (current instanceof Http1xClientConnection) {
+      shutdownHandler = handler;
+    } else {
+      current.shutdownHandler(handler);
+    }
+    return this;
+  }
+
+  @Override
+  public HttpConnection goAway(long errorCode, int lastStreamId, Buffer debugData) {
+    return current.goAway(errorCode, lastStreamId, debugData);
+  }
+
+  @Override
+  public HttpConnection shutdown() {
+    return current.shutdown();
+  }
+
+  @Override
+  public HttpConnection shutdown(long timeoutMs) {
+    return current.shutdown(timeoutMs);
+  }
+
+  @Override
+  public HttpConnection updateSettings(Http2Settings settings) {
+    return current.updateSettings(settings);
+  }
+
+  @Override
+  public HttpConnection updateSettings(Http2Settings settings, Handler<AsyncResult<Void>> completionHandler) {
+    return current.updateSettings(settings, completionHandler);
+  }
+
+  @Override
+  public Http2Settings settings() {
+    return current.settings();
+  }
+
+  @Override
+  public Http2Settings remoteSettings() {
+    return current.remoteSettings();
+  }
+
+  @Override
+  public HttpConnection ping(Buffer data, Handler<AsyncResult<Buffer>> pongHandler) {
+    return current.ping(data, pongHandler);
+  }
+
+  @Override
+  public SocketAddress remoteAddress() {
+    return current.remoteAddress();
+  }
+
+  @Override
+  public SocketAddress localAddress() {
+    return current.localAddress();
+  }
+
+  @Override
+  public boolean isSsl() {
+    return current.isSsl();
+  }
+
+  @Override
+  public SSLSession sslSession() {
+    return current.sslSession();
+  }
+
+  @Override
+  public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    return current.peerCertificateChain();
+  }
+
+  @Override
+  public String indicatedServerName() {
+    return current.indicatedServerName();
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2UpgradedClientConnection.java
@@ -78,7 +78,7 @@ public class Http2UpgradedClientConnection implements HttpClientConnection {
 
     @Override
     public HttpClientConnection connection() {
-      return current == null ? conn : current;
+      return Http2UpgradedClientConnection.this;
     }
 
     /**
@@ -251,16 +251,6 @@ public class Http2UpgradedClientConnection implements HttpClientConnection {
   @Override
   public ContextInternal getContext() {
     return current.getContext();
-  }
-
-  @Override
-  public boolean checkInitialized() {
-    return current.checkInitialized();
-  }
-
-  @Override
-  public void recycle() {
-    current.recycle();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpChannelConnector.java
@@ -275,6 +275,7 @@ class HttpChannelConnector implements ConnectionProvider<HttpClientConnection> {
       listener,
       context,
       version,
+      peerHost,
       host,
       port,
       ssl,

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -20,7 +20,7 @@ import io.vertx.core.impl.ContextInternal;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-interface HttpClientConnection extends HttpConnection {
+public interface HttpClientConnection extends HttpConnection {
 
   Channel channel();
 
@@ -29,9 +29,5 @@ interface HttpClientConnection extends HttpConnection {
   void createStream(Handler<AsyncResult<HttpClientStream>> handler);
 
   ContextInternal getContext();
-
-  boolean checkInitialized();
-
-  void recycle();
 
 }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -24,10 +24,6 @@ interface HttpClientConnection extends HttpConnection {
 
   Channel channel();
 
-  void reportBytesWritten(long numberOfBytes);
-
-  void reportBytesRead(long s);
-
   void close();
 
   void createStream(Handler<AsyncResult<HttpClientStream>> handler);

--- a/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientConnection.java
@@ -30,7 +30,7 @@ interface HttpClientConnection extends HttpConnection {
 
   void close();
 
-  void createStream(HttpClientRequestImpl req, Handler<AsyncResult<HttpClientStream>> handler);
+  void createStream(Handler<AsyncResult<HttpClientStream>> handler);
 
   ContextInternal getContext();
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -957,8 +957,14 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
   }
 
   void getConnectionForRequest(String peerHost, boolean ssl, int port, String host,
-                               Handler<AsyncResult<HttpClientConnection>> handler) {
-    httpCM.getConnection(peerHost, ssl, port, host, handler);
+                               Handler<AsyncResult<HttpClientStream>> handler) {
+    httpCM.getConnection(peerHost, ssl, port, host, ar -> {
+      if (ar.succeeded()) {
+        ar.result().createStream(handler);
+      } else {
+        handler.handle(Future.failedFuture(ar.cause()));
+      }
+    });
   }
 
   /**

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestBase.java
@@ -93,7 +93,7 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
   }
 
   @Override
-  public io.vertx.core.http.HttpMethod method() {
+  public HttpMethod method() {
     return method;
   }
 
@@ -179,9 +179,6 @@ public abstract class HttpClientRequestBase implements HttpClientRequest {
 
   private void timeout(long timeoutMs) {
     handleException(new TimeoutException("The timeout period of " + timeoutMs + "ms has been exceeded while executing " + method + " " + uri + " for host " + host));
-  }
-
-  void handleResponseEnd() {
   }
 
   synchronized void dataReceived() {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -645,7 +645,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
   }
 
   private void connected(Handler<HttpVersion> headersHandler, HttpClientStream stream) {
-    HttpClientConnection conn = stream.connection();
+    HttpConnection conn = stream.connection();
 
     synchronized (this) {
       this.stream = stream;
@@ -664,20 +664,20 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
 
         if (completed) {
           // we also need to write the head so optimize this and write all out in once
-          stream.writeHeadWithContent(method, rawMethod, uri, headers, hostHeader(), chunked, pending, true);
-          conn.reportBytesWritten(written);
+          stream.writeHead(method, rawMethod, uri, headers, hostHeader(), chunked, pending, true);
+          stream.reportBytesWritten(written);
           stream.endRequest();
         } else {
-          stream.writeHeadWithContent(method, rawMethod, uri, headers, hostHeader(), chunked, pending, false);
+          stream.writeHead(method, rawMethod, uri, headers, hostHeader(), chunked, pending, false);
         }
       } else {
         if (completed) {
           // we also need to write the head so optimize this and write all out in once
-          stream.writeHeadWithContent(method, rawMethod, uri, headers, hostHeader(), chunked, null, true);
-          conn.reportBytesWritten(written);
+          stream.writeHead(method, rawMethod, uri, headers, hostHeader(), chunked, null, true);
+          stream.reportBytesWritten(written);
           stream.endRequest();
         } else {
-          stream.writeHead(method, rawMethod, uri, headers, hostHeader(), chunked);
+          stream.writeHead(method, rawMethod, uri, headers, hostHeader(), chunked, null, false);
         }
       }
       this.connecting = false;
@@ -781,7 +781,7 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
     }
     s.writeBuffer(buff, end);
     if (end) {
-      s.connection().reportBytesWritten(written); // MUST BE READ UNDER SYNCHRONIZATION
+      s.reportBytesWritten(written); // MUST BE READ UNDER SYNCHRONIZATION
     }
     if (end) {
       Handler<Void> handler;

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestImpl.java
@@ -249,7 +249,9 @@ public class HttpClientRequestImpl extends HttpClientRequestBase implements Http
           stream.getContext().runOnContext(v -> {
             synchronized (getLock()) {
               if (stream != null) {
-                stream.checkDrained();
+                if (!stream.isNotWritable()) {
+                  handleDrained();
+                }
               }
             }
           });

--- a/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientRequestPushPromise.java
@@ -56,17 +56,14 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  protected Object getLock() {
-    return this; //
-  }
-
-  @Override
   protected void doHandleResponse(HttpClientResponseImpl resp, long timeoutMs) {
-    synchronized (getLock()) {
-      if (respHandler != null) {
-        respHandler.handle(resp);
+    Handler<HttpClientResponse> handler;
+    synchronized (this) {
+      if ((handler = respHandler) == null) {
+        return;
       }
     }
+    handler.handle(resp);
   }
 
   @Override
@@ -74,11 +71,9 @@ class HttpClientRequestPushPromise extends HttpClientRequestBase {
   }
 
   @Override
-  public HttpClientRequest handler(Handler<HttpClientResponse> handler) {
-    synchronized (getLock()) {
-      respHandler = handler;
-      return this;
-    }
+  public synchronized HttpClientRequest handler(Handler<HttpClientResponse> handler) {
+    respHandler = handler;
+    return this;
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -255,7 +255,6 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
             handleException(t);
           }
         }
-        request.handleResponseEnd();
       }
     }
   }

--- a/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientResponseImpl.java
@@ -15,10 +15,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpFrame;
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.*;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
@@ -43,7 +40,7 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
   private final int statusCode;
   private final String statusMessage;
   private final HttpClientRequestBase request;
-  private final HttpClientConnection conn;
+  private final HttpConnection conn;
   private final HttpClientStream stream;
 
   private Handler<Buffer> dataHandler;
@@ -240,7 +237,7 @@ public class HttpClientResponseImpl implements HttpClientResponse  {
 
   void handleEnd(Buffer lastChunk, MultiMap trailers) {
     synchronized (conn) {
-      conn.reportBytesRead(bytesRead);
+      stream.reportBytesRead(bytesRead);
       bytesRead = 0;
       if (paused) {
         pausedLastChunk = lastChunk;

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -43,7 +43,6 @@ interface HttpClientStream {
 
   void doSetWriteQueueMaxSize(int size);
   boolean isNotWritable();
-  void checkDrained();
   void doPause();
   void doResume();
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -50,7 +50,6 @@ interface HttpClientStream {
   void doResume();
 
   void reset(long code);
-
   void beginRequest(HttpClientRequestImpl req);
   void endRequest();
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -49,7 +49,7 @@ interface HttpClientStream {
 
   void reset(long code);
 
-  void beginRequest();
+  void beginRequest(HttpClientRequestImpl req);
   void endRequest();
 
   NetSocket createNetSocket();

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -25,7 +25,8 @@ import io.vertx.core.net.NetSocket;
 interface HttpClientStream {
 
   /**
-   * @return the stream id or -1 for HTTP/1.x
+   * @return the stream id, {@code 1} denotes the first stream, HTTP/1 is a simple sequence, HTTP/2
+   * is the actual stream identifier.
    */
   int id();
 

--- a/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientStream.java
@@ -14,6 +14,7 @@ package io.vertx.core.http.impl;
 import io.netty.buffer.ByteBuf;
 import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.NetSocket;
@@ -33,13 +34,15 @@ interface HttpClientStream {
    */
   HttpVersion version();
 
-  HttpClientConnection connection();
+  HttpConnection connection();
   Context getContext();
 
-  void writeHead(HttpMethod method, String rawMethod, String uri, MultiMap headers, String hostHeader, boolean chunked);
-  void writeHeadWithContent(HttpMethod method, String rawMethod, String uri, MultiMap headers, String hostHeader, boolean chunked, ByteBuf buf, boolean end);
+  void writeHead(HttpMethod method, String rawMethod, String uri, MultiMap headers, String hostHeader, boolean chunked, ByteBuf buf, boolean end);
   void writeBuffer(ByteBuf buf, boolean end);
   void writeFrame(int type, int flags, ByteBuf payload);
+
+  void reportBytesWritten(long numberOfBytes);
+  void reportBytesRead(long numberOfBytes);
 
   void doSetWriteQueueMaxSize(int size);
   boolean isNotWritable();

--- a/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpHandlers.java
@@ -25,17 +25,17 @@ import java.util.Objects;
  */
 public class HttpHandlers {
 
-  final Handler<HttpServerRequest> requesthHandler;
+  final Handler<HttpServerRequest> requestHandler;
   final Handler<ServerWebSocket> wsHandler;
   final Handler<HttpConnection> connectionHandler;
   final Handler<Throwable> exceptionHandler;
 
   public HttpHandlers(
-    Handler<HttpServerRequest> requesthHandler,
+    Handler<HttpServerRequest> requestHandler,
     Handler<ServerWebSocket> wsHandler,
     Handler<HttpConnection> connectionHandler,
     Handler<Throwable> exceptionHandler) {
-    this.requesthHandler = requesthHandler;
+    this.requestHandler = requestHandler;
     this.wsHandler = wsHandler;
     this.connectionHandler = connectionHandler;
     this.exceptionHandler = exceptionHandler;
@@ -48,7 +48,7 @@ public class HttpHandlers {
 
     HttpHandlers that = (HttpHandlers) o;
 
-    if (!Objects.equals(requesthHandler, that.requesthHandler)) return false;
+    if (!Objects.equals(requestHandler, that.requestHandler)) return false;
     if (!Objects.equals(wsHandler, that.wsHandler)) return false;
     if (!Objects.equals(connectionHandler, that.connectionHandler)) return false;
     if (!Objects.equals(exceptionHandler, that.exceptionHandler)) return false;
@@ -59,8 +59,8 @@ public class HttpHandlers {
   @Override
   public int hashCode() {
     int result = 0;
-    if (requesthHandler != null) {
-      result = 31 * result + requesthHandler.hashCode();
+    if (requestHandler != null) {
+      result = 31 * result + requestHandler.hashCode();
     }
     if (wsHandler != null) {
       result = 31 * result + wsHandler.hashCode();

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -471,16 +471,6 @@ public final class HttpUtils {
     }
   }
 
-  static io.vertx.core.http.HttpVersion toVertxHttpVersion(HttpVersion version) {
-    if (version == io.netty.handler.codec.http.HttpVersion.HTTP_1_0) {
-      return io.vertx.core.http.HttpVersion.HTTP_1_0;
-    } else if (version == io.netty.handler.codec.http.HttpVersion.HTTP_1_1) {
-      return io.vertx.core.http.HttpVersion.HTTP_1_1;
-    } else {
-      return null;
-    }
-  }
-
   static io.vertx.core.http.HttpMethod toVertxMethod(String method) {
     try {
       return io.vertx.core.http.HttpMethod.valueOf(method);

--- a/src/main/java/io/vertx/core/http/impl/HttpUtils.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpUtils.java
@@ -380,6 +380,15 @@ public final class HttpUtils {
     return null;
   }
 
+  public static String encodeSettings(io.vertx.core.http.Http2Settings settings) {
+    Buffer buffer = Buffer.buffer();
+    fromVertxSettings(settings).forEach((c, l) -> {
+      buffer.appendUnsignedShort(c);
+      buffer.appendUnsignedInt(l);
+    });
+    return Base64.getUrlEncoder().encodeToString(buffer.getBytes());
+  }
+
   public static ByteBuf generateWSCloseFrameByteBuf(short statusCode, String reason) {
     if (reason != null)
       return Unpooled.copiedBuffer(

--- a/src/main/java/io/vertx/core/http/impl/pool/ConnectResult.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/ConnectResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl.pool;
+
+import io.netty.channel.Channel;
+import io.vertx.core.impl.ContextInternal;
+
+public class ConnectResult<C> {
+
+  private final C conn;
+  private final long concurrency;
+  private final Channel channel;
+  private final ContextInternal context;
+  private final long weight;
+
+  public ConnectResult(C connection, long concurrency, Channel channel, ContextInternal context, long weight) {
+    this.conn = connection;
+    this.concurrency = concurrency;
+    this.channel = channel;
+    this.context = context;
+    this.weight = weight;
+  }
+
+  public C connection() {
+    return conn;
+  }
+
+  public long concurrency() {
+    return concurrency;
+  }
+
+  public Channel channel() {
+    return channel;
+  }
+
+  public ContextInternal context() {
+    return context;
+  }
+
+  public long weight() {
+    return weight;
+  }
+}

--- a/src/main/java/io/vertx/core/http/impl/pool/ConnectionListener.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/ConnectionListener.java
@@ -11,37 +11,11 @@
 
 package io.vertx.core.http.impl.pool;
 
-import io.netty.channel.Channel;
-import io.vertx.core.impl.ContextInternal;
-
 /**
  * The listener definest the contract used by the {@link ConnectionProvider} to interact with the
  * connection pool. Its purpose is also to use a connection implementation without a pool.
  */
 public interface ConnectionListener<C> {
-
-  /**
-   * Signals the connection succeeded, provide all the info required to manage the connection
-   *
-   * @param conn the connection
-   * @param concurrency the connection concurrency
-   * @param channel the channel
-   * @param context the context
-   * @param actualWeight the actual weight
-   */
-  void onConnectSuccess(C conn,
-                        long concurrency,
-                        Channel channel,
-                        ContextInternal context,
-                        long actualWeight);
-
-  /**
-   * Signals the connection failed.
-   *
-   * @param context the context
-   * @param err the error
-   */
-  void onConnectFailure(ContextInternal context, Throwable err);
 
   /**
    * Signals the connection the concurrency changed to the {@code concurrency} value.

--- a/src/main/java/io/vertx/core/http/impl/pool/ConnectionProvider.java
+++ b/src/main/java/io/vertx/core/http/impl/pool/ConnectionProvider.java
@@ -11,6 +11,8 @@
 
 package io.vertx.core.http.impl.pool;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
 import io.vertx.core.impl.ContextInternal;
 
 /**
@@ -21,13 +23,13 @@ import io.vertx.core.impl.ContextInternal;
 public interface ConnectionProvider<C> {
 
   /**
-   * Connect to the server and signals the {@code listener} the success with {@link ConnectionListener#onConnectSuccess}
-   * or the failure with {@link ConnectionListener#onConnectFailure}.
+   * Connect to the server.
    *
    * @param listener the listener
    * @param context the context to use for the connection
+   * @param resultHandler the handler notified with the connection success or failure
    */
-  void connect(ConnectionListener<C> listener, ContextInternal context);
+  void connect(ConnectionListener<C> listener, ContextInternal context, Handler<AsyncResult<ConnectResult<C>>> resultHandler);
 
   /**
    * Close a connection.

--- a/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
+++ b/src/main/java/io/vertx/core/net/impl/ConnectionBase.java
@@ -72,6 +72,10 @@ public abstract class ConnectionBase {
     return obj;
   }
 
+  public ChannelHandler handler() {
+    return chctx.handler();
+  }
+
   public synchronized final void startRead() {
     checkContext();
     read = true;

--- a/src/test/java/io/vertx/test/core/Http1xMetricsTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xMetricsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.test.core;
+
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpVersion;
+
+public class Http1xMetricsTest extends HttpMetricsTestBase {
+
+  public Http1xMetricsTest() {
+    super(HttpVersion.HTTP_1_1);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    client = vertx.createHttpClient(new HttpClientOptions());
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT).setHost(DEFAULT_HTTP_HOST).setHandle100ContinueAutomatically(true));
+  }
+
+}

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -3330,17 +3330,17 @@ public class Http1xTest extends HttpTest {
         fail();
       });
       if (pipelined) {
-        req1.sendHead(v -> {
-          assertTrue(req1.reset());
-          req1.connection().closeHandler(v2 -> {
-            client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
-              assertEquals(200, resp.statusCode());
-              resp.bodyHandler(body -> {
-                assertEquals("Hello world", body.toString());
-                complete();
-              });
+        req1.connectionHandler(conn -> conn.closeHandler(v2 -> {
+          client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
+            assertEquals(200, resp.statusCode());
+            resp.bodyHandler(body -> {
+              assertEquals("Hello world", body.toString());
+              complete();
             });
           });
+        }));
+        req1.sendHead(v -> {
+          assertTrue(req1.reset());
         });
       } else {
         req1.sendHead(v -> {
@@ -3539,21 +3539,16 @@ public class Http1xTest extends HttpTest {
       if (pipelined) {
         requestReceived.thenAccept(v -> {
           req1.reset();
-          requestReceived.thenAccept(v1 -> {
-            req1.reset();
-            req1.connection().closeHandler(v2 -> {
-              client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/2", resp -> {
-                assertEquals(200, resp.statusCode());
-                resp.bodyHandler(body -> {
-                  assertEquals("Hello world", body.toString());
-                  complete();
-                });
-              });
+        });
+        req1.connectionHandler(conn -> conn.closeHandler(v2 -> {
+          client.getNow(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/2", resp -> {
+            assertEquals(200, resp.statusCode());
+            resp.bodyHandler(body -> {
+              assertEquals("Hello world", body.toString());
+              complete();
             });
           });
-          req1.handler(resp1 -> fail());
-          req1.end();
-        });
+        }));
         req1.handler(resp1 -> fail());
         req1.end();
       } else {

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -1103,6 +1103,7 @@ public class Http1xTest extends HttpTest {
     assertTrue(options.getKeyCertOptions() instanceof PemKeyCertOptions);
   }
 
+  @Test
   @Override
   public void testCloseHandlerNotCalledWhenConnectionClosedAfterEnd() throws Exception {
     testCloseHandlerNotCalledWhenConnectionClosedAfterEnd(0);

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -41,11 +41,9 @@ import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.TrustOptions;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.streams.Pump;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -24,19 +24,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
-import io.netty.handler.codec.http2.DefaultHttp2Headers;
-import io.netty.handler.codec.http2.Http2CodecUtil;
-import io.netty.handler.codec.http2.Http2ConnectionDecoder;
-import io.netty.handler.codec.http2.Http2ConnectionEncoder;
-import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2Error;
-import io.netty.handler.codec.http2.Http2EventAdapter;
-import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.codec.http2.Http2FrameListener;
-import io.netty.handler.codec.http2.Http2Headers;
-import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
-import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.codec.http2.*;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslHandler;
@@ -1129,7 +1117,20 @@ public class Http2ClientTest extends Http2TestBase {
           HttpServerCodec sourceCodec = new HttpServerCodec();
           HttpServerUpgradeHandler.UpgradeCodecFactory upgradeCodecFactory = protocol -> {
             if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-              return new Http2ServerUpgradeCodec(createHttpConnectionHandler(handler));
+              Http2ConnectionHandler httpConnectionHandler = createHttpConnectionHandler((a, b) -> {
+                return new Http2FrameListenerDecorator(handler.apply(a, b)) {
+                  @Override
+                  public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+                    super.onSettingsRead(ctx, settings);
+                    Http2Connection conn = a.connection();
+                    Http2Stream stream = conn.stream(1);
+                    DefaultHttp2Headers blah = new DefaultHttp2Headers();
+                    blah.status("200");
+                    b.frameWriter().writeHeaders(ctx, 1, blah, 0, true, ctx.voidPromise());
+                  }
+                };
+              });
+              return new Http2ServerUpgradeCodec(httpConnectionHandler);
             } else {
               return null;
             }
@@ -1541,9 +1542,15 @@ public class Http2ClientTest extends Http2TestBase {
     try {
       client.close();
       client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false).setHttp2ClearTextUpgrade(upgrade));
-      client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
-        assertEquals(HttpVersion.HTTP_2, resp.version());
-        testComplete();
+      client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp1 -> {
+        HttpConnection conn = resp1.request().connection();
+        assertEquals(HttpVersion.HTTP_2, resp1.version());
+        client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp2 -> {
+          assertSame(conn, resp2.request().connection());
+          testComplete();
+        }).exceptionHandler(this::fail).end();
+      }).connectionHandler(conn -> {
+        System.out.println("CONNECTED " + conn);
       }).exceptionHandler(this::fail).end();
       await();
     } finally {
@@ -1572,10 +1579,9 @@ public class Http2ClientTest extends Http2TestBase {
       client.close();
       client = vertx.createHttpClient(clientOptions.setUseAlpn(false).setSsl(false));
       client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
-        assertEquals(200, resp.statusCode());
+        assertEquals(400, resp.statusCode());
         assertEquals(HttpVersion.HTTP_1_1, resp.version());
         resp.bodyHandler(body -> {
-          assertEquals("wibble", body.toString());
           testComplete();
         });
       }).exceptionHandler(this::fail).end();

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -29,7 +29,6 @@ import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
-import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
 import io.vertx.core.DeploymentOptions;
@@ -48,13 +47,13 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.StreamResetException;
+import io.vertx.core.http.impl.HttpClientConnection;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.test.core.tls.Cert;
 import io.vertx.test.core.tls.Trust;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -64,7 +63,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -1546,7 +1544,7 @@ public class Http2ClientTest extends Http2TestBase {
         HttpConnection conn = resp1.request().connection();
         assertEquals(HttpVersion.HTTP_2, resp1.version());
         client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp2 -> {
-          assertSame(conn, resp2.request().connection());
+          assertSame(((HttpClientConnection)conn).channel(), ((HttpClientConnection)resp2.request().connection()).channel());
           testComplete();
         }).exceptionHandler(this::fail).end();
       }).connectionHandler(conn -> {

--- a/src/test/java/io/vertx/test/core/Http2ClientTest.java
+++ b/src/test/java/io/vertx/test/core/Http2ClientTest.java
@@ -277,7 +277,7 @@ public class Http2ClientTest extends Http2TestBase {
     req.handler(resp -> {
       Context ctx = vertx.getOrCreateContext();
       assertOnIOContext(ctx);
-      assertEquals(3, req.streamId());
+      assertEquals(1, req.streamId());
       assertEquals(1, reqCount.get());
       assertEquals(HttpVersion.HTTP_2, resp.version());
       assertEquals(200, resp.statusCode());
@@ -1338,7 +1338,7 @@ public class Http2ClientTest extends Http2TestBase {
       req.end(Buffer.buffer("request-body"));
     });
     req.sendHead(version -> {
-      assertEquals(3, req.streamId());
+      assertEquals(1, req.streamId());
     });
     await();
   }

--- a/src/test/java/io/vertx/test/core/Http2MetricsTest.java
+++ b/src/test/java/io/vertx/test/core/Http2MetricsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.test.core;
+
+import io.vertx.core.http.*;
+import io.vertx.test.fakemetrics.*;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Http2MetricsTest extends HttpMetricsTestBase {
+
+  public Http2MetricsTest() {
+    super(HttpVersion.HTTP_2);
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    client = vertx.createHttpClient(createBaseClientOptions());
+    server = vertx.createHttpServer(createBaseServerOptions().setHandle100ContinueAutomatically(true));
+  }
+
+  @Override
+  protected HttpServerOptions createBaseServerOptions() {
+    return Http2TestBase.createHttp2ServerOptions(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST);
+  }
+
+  @Override
+  protected HttpClientOptions createBaseClientOptions() {
+    return Http2TestBase.createHttp2ClientOptions();
+  }
+
+  @Test
+  public void testPushPromise() throws Exception {
+    waitFor(2);
+    int numBuffers = 10;
+    int contentLength = numBuffers * 1000;
+    server.requestHandler(req -> {
+      req.response().push(HttpMethod.GET, "/wibble", ar -> {
+        HttpServerResponse pushedResp = ar.result();
+        FakeHttpServerMetrics serverMetrics = FakeMetricsBase.getMetrics(server);
+        HttpServerMetric serverMetric = serverMetrics.getMetric(pushedResp);
+        assertNotNull(serverMetric);
+        pushedResp.putHeader("content-length", "" + contentLength);
+        AtomicInteger numBuffer = new AtomicInteger(numBuffers);
+        vertx.setPeriodic(1, timerID -> {
+          if (numBuffer.getAndDecrement() == 0) {
+            pushedResp.end();
+            assertNull(serverMetrics.getMetric(pushedResp));
+            vertx.cancelTimer(timerID);
+            complete();
+          } else {
+            pushedResp.write(TestUtils.randomBuffer(1000));
+          }
+        });
+      });
+    });
+    startServer();
+    client = vertx.createHttpClient(createBaseClientOptions());
+    FakeHttpClientMetrics metrics = FakeMetricsBase.getMetrics(client);
+    HttpClientRequest req = client.get(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, "/somepath", resp -> {
+    });
+    req.pushHandler(pushedReq -> {
+      HttpClientMetric metric = metrics.getMetric(pushedReq);
+      assertNotNull(metric);
+      assertSame(pushedReq, metric.request);
+      pushedReq.handler(resp -> {
+        resp.endHandler(v -> {
+          assertNull(metrics.getMetric(pushedReq));
+          complete();
+        });
+      });
+    });
+    req.end();
+    await();
+  }
+}

--- a/src/test/java/io/vertx/test/core/Http2Test.java
+++ b/src/test/java/io/vertx/test/core/Http2Test.java
@@ -50,6 +50,7 @@ public class Http2Test extends HttpTest {
     return Http2TestBase.createHttp2ClientOptions();
   }
 
+  @Test
   @Override
   public void testCloseHandlerNotCalledWhenConnectionClosedAfterEnd() throws Exception {
     testCloseHandlerNotCalledWhenConnectionClosedAfterEnd(1);

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -414,10 +414,10 @@ public abstract class HttpTest extends HttpTestBase {
     } else {
       req = client.request(method, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, uri, handler);
     }
-    testSimpleRequest(uri, method, req, absolute, ssl);
+    testSimpleRequest(uri, method, req);
   }
 
-  private void testSimpleRequest(String uri, HttpMethod method, HttpClientRequest request, boolean absolute, boolean ssl) {
+  private void testSimpleRequest(String uri, HttpMethod method, HttpClientRequest request) {
     int index = uri.indexOf('?');
     String path = index == -1 ? uri : uri.substring(0, index);
     String query = index == -1 ? null : uri.substring(index + 1);
@@ -3298,7 +3298,6 @@ public abstract class HttpTest extends HttpTestBase {
     }
   }
 
-  @Ignore
   @Test
   public void testClientLocalAddress() throws Exception {
     String expectedAddress = InetAddress.getLocalHost().getHostAddress();

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -36,6 +36,7 @@ import io.vertx.core.http.impl.HeadersAdaptor;
 import io.vertx.core.net.NetSocket;
 import io.vertx.test.netty.TestLoggerFactory;
 import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -406,23 +407,20 @@ public abstract class HttpTest extends HttpTestBase {
   }
 
   private void testSimpleRequest(String uri, HttpMethod method, boolean absolute, Handler<HttpClientResponse> handler) {
+    boolean ssl = this instanceof Http2Test;
     HttpClientRequest req;
     if (absolute) {
-      req = client.requestAbs(method, "http://" + DEFAULT_HTTP_HOST + ":" + DEFAULT_HTTP_PORT + uri, handler);
+      req = client.requestAbs(method, (ssl ? "https://" : "http://") + DEFAULT_HTTP_HOST + ":" + DEFAULT_HTTP_PORT + uri, handler);
     } else {
       req = client.request(method, DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, uri, handler);
     }
-    testSimpleRequest(uri, method, req, absolute);
+    testSimpleRequest(uri, method, req, absolute, ssl);
   }
 
-  private void testSimpleRequest(String uri, HttpMethod method, HttpClientRequest request, boolean absolute) {
+  private void testSimpleRequest(String uri, HttpMethod method, HttpClientRequest request, boolean absolute, boolean ssl) {
     int index = uri.indexOf('?');
     String path = index == -1 ? uri : uri.substring(0, index);
     String query = index == -1 ? null : uri.substring(index + 1);
-    if (absolute) {
-      server.close();
-      server = vertx.createHttpServer(createBaseServerOptions().setSsl(false).setUseAlpn(false));
-    }
     server.requestHandler(req -> {
       String expectedPath = req.method() == HttpMethod.CONNECT && req.version() == HttpVersion.HTTP_2 ? null : path;
       String expectedQuery = req.method() == HttpMethod.CONNECT && req.version() == HttpVersion.HTTP_2 ? null : query;
@@ -3300,6 +3298,7 @@ public abstract class HttpTest extends HttpTestBase {
     }
   }
 
+  @Ignore
   @Test
   public void testClientLocalAddress() throws Exception {
     String expectedAddress = InetAddress.getLocalHost().getHostAddress();


### PR DESCRIPTION
A set of HTTP improvements that fix bugs on the client and server and simplifies / improves the concurrency main on the client.

This PR is rebased already on several other PRs:
- https://github.com/eclipse/vert.x/pull/2366
- https://github.com/eclipse/vert.x/pull/2356

Noticeable refactoring have been necessary to
- being conformant for the h2c upgrade protocol
- improve and simplify (make easier to reason about) the client concurrency

Each commit can be examined separately to ease reasoning about the changes and likely examining the PR as a whole can be more challenging.
