### PR TITLE
HTTP client requests should always prefix request URI with / for absolute queries

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -495,6 +495,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
     URL url = parseUrl(absoluteURI);
     Boolean ssl = false;
     int port = url.getPort();
+    String relativeUri = url.getPath().isEmpty() ? "/" + url.getFile() : url.getFile();
     String protocol = url.getProtocol();
     if ("ftp".equals(protocol)) {
       if (port == -1) {
@@ -514,7 +515,7 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       }
     }
     // if we do not know the protocol, the port still may be -1, we will handle that below
-    return createRequest(method, protocol, url.getHost(), port, ssl, url.getFile(), null);
+    return createRequest(method, protocol, url.getHost(), port, ssl, relativeUri, null);
   }
 
   @Override


### PR DESCRIPTION
Related to https://github.com/vert-x3/vertx-web/issues/908

Note, that `http://127.0.0.1:8080?test=something` is valid URL. Provided PR prefixes URL `path` with '/' in case of empty path, because based on HTTP1 spec https://tools.ietf.org/html/rfc2616#section-5.1.2 it should be so.

Netty implements this behaviour as well: https://github.com/netty/netty/issues/719