### PR TITLE
Hydrate vert.x cache for directory on first access

### DIFF
--- a/src/main/java/io/vertx/core/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/impl/FileResolver.java
@@ -22,13 +22,11 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
 import java.util.UUID;
@@ -129,24 +127,24 @@ public class FileResolver {
         //Cache all elements in the parent directory if it exists
         //this is so that listing the directory after an individual file has
         //been read works.
-        if (file.getParent() != null) {
-          URL directoryContents = cl.getResource(file.getParent());
+        String parentFileName = file.getParent();
+        if (parentFileName != null) {
+          URL directoryContents = cl.getResource(parentFileName);
           if (directoryContents != null) {
-            unpackUrlResource(directoryContents, file.getParent());
+            unpackUrlResource(directoryContents, parentFileName, cl);
           }
         }
 
         URL url = cl.getResource(fileName);
         if (url != null) {
-          return unpackUrlResource(url, fileName);
+          return unpackUrlResource(url, fileName, cl);
         }
       }
     }
     return file;
   }
 
-  private File unpackUrlResource(URL url, String fileName) {
-    ClassLoader cl = getClassLoader();
+  private File unpackUrlResource(URL url, String fileName, ClassLoader cl) {
     String prot = url.getProtocol();
     switch (prot) {
       case "file":

--- a/src/test/java/io/vertx/test/core/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/test/core/FileResolverTestBase.java
@@ -27,9 +27,13 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -54,6 +58,17 @@ public abstract class FileResolverTestBase extends VertxTestBase {
     }));
     awaitLatch(latch);
     super.tearDown();
+  }
+
+  @Test
+  public void testReadFileInDirThenReadDir() {
+    Buffer buff = vertx.fileSystem().readFileBlocking("webroot/subdir/subfile.html");
+    assertEquals(buff.toString(), "<html><body>subfile</body></html>");
+    Set<String> names = vertx.fileSystem().readDirBlocking("webroot/subdir").stream().map(path -> {
+      int idx = path.lastIndexOf('/');
+      return idx == -1 ? path : path.substring(idx + 1);
+    }).collect(Collectors.toSet());
+    assertEquals(names, new HashSet<>(Arrays.asList("subdir2", "subfile.html")));
   }
 
   @Test


### PR DESCRIPTION
When a file is first access -- when caching is enabled, vert.x will copy
the file to a cache directory.

Subsequent listing of the directory will match the cache however the
contents of the directory will be only the recently accessed file.

To circumvent this bug -- when a file is first accessed, the
FileResolver will cache all other files in the same directory.

Fixes #2126