### PR TITLE
Fix bytesWritten when sending files with range

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -440,7 +440,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
         return;
       }
 
-      long contentLength = Math.min(length, file.length() - offset);
+      long contentLength = Math.min(length - offset, file.length() - offset);
       bytesWritten = contentLength;
       if (!headers.contentTypeSet()) {
         String contentType = MimeMapping.getMimeTypeForFilename(filename);

--- a/src/test/java/io/vertx/test/core/HttpTest.java
+++ b/src/test/java/io/vertx/test/core/HttpTest.java
@@ -1864,6 +1864,7 @@ public abstract class HttpTest extends HttpTestBase {
       res.response().sendFile("webroot/somefile.html", 6);
     }).listen(onSuccess(res -> {
       vertx.createHttpClient(new HttpClientOptions()).request(HttpMethod.GET, 8080, "localhost", "/", resp -> {
+        assertEquals(resp.headers().get("Content-Length"), String.valueOf(24));
         resp.bodyHandler(buff -> {
           assertTrue(buff.toString().startsWith("<body>blah</body></html>"));
           testComplete();
@@ -1876,9 +1877,10 @@ public abstract class HttpTest extends HttpTestBase {
   @Test
   public void testSendRangeFileFromClasspath() {
     vertx.createHttpServer(new HttpServerOptions().setPort(8080)).requestHandler(res -> {
-      res.response().sendFile("webroot/somefile.html", 6, 6);
+      res.response().sendFile("webroot/somefile.html", 6, 12);
     }).listen(onSuccess(res -> {
       vertx.createHttpClient(new HttpClientOptions()).request(HttpMethod.GET, 8080, "localhost", "/", resp -> {
+        assertEquals(resp.headers().get("Content-Length"), String.valueOf(6));
         resp.bodyHandler(buff -> {
           assertEquals("<body>", buff.toString());
           testComplete();


### PR DESCRIPTION
This fix sets the proper contentLength internally so that `bytesWritten` which is used by other classes is accurate.

I came across this issue while inspecting output from the `io.vertx.ext.web.handler.impl.LoggerHandlerImpl` which uses `bytesWritten` to log the response size in bytes.

When sending requests that use the HTTP range header one can request chunked portions of a response. On the first request asking for `bytes=0-512` the request log correctly shows the following.

```
INFO: 127.0.0.1 - - [Thu, 19 Apr 2018 02:21:27 GMT] "GET /static/small HTTP/1.1" 206 513 "-" "okhttp/3.8.0"
```

However on requests that do not start at byte 0 the `contentLength` on the `HttpServerResponseImpl` does not properly take into account the offset which means  `bytesWritten` is not correctly set and next the logger logs the following as one requests chunks further along in the file.

```
INFO: 127.0.0.1 - - [Thu, 19 Apr 2018 02:21:29 GMT] "GET /static/small HTTP/1.1" 206 1026 "-" "okhttp/3.8.0"
INFO: 127.0.0.1 - - [Thu, 19 Apr 2018 02:21:31 GMT] "GET /static/small HTTP/1.1" 206 1539 "-" "okhttp/3.8.0"
INFO: 127.0.0.1 - - [Thu, 19 Apr 2018 02:21:32 GMT] "GET /static/small HTTP/1.1" 206 2052 "-" "okhttp/3.8.0"
```

The content length logged for all these requests should match the `Content-Length: 513` header being returned but the offset was not being properly accounted for.

Signed-off-by: zsiegel <zsiegel87@gmail.com>