### PR TITLE
Fixes #2406

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
+++ b/src/main/java/io/vertx/core/http/impl/ConnectionManager.java
@@ -53,13 +53,13 @@ class ConnectionManager {
   }
 
   synchronized void start(boolean checkExpired) {
-    this.timerID = checkExpired ? client.getVertx().setTimer(1, id -> checkExpired()) : -1;
+    this.timerID = checkExpired ? client.getVertx().setTimer(1000, id -> checkExpired()) : -1;
   }
 
   private synchronized void checkExpired() {
     long timestamp = System.currentTimeMillis();
     endpointMap.values().forEach(e -> e.pool.closeIdle(timestamp));
-    timerID = client.getVertx().setTimer(1, id -> checkExpired());
+    timerID = client.getVertx().setTimer(1000, id -> checkExpired());
   }
 
   private static final class EndpointKey {


### PR DESCRIPTION
Don't search for timed out keep-alive Connections every Millisecond. This burns CPU.
Just search every 1000ms
Fixes #2406