### PR TITLE
Add support for listening on a SocketAddress to HttpServer. This

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1583,21 +1583,13 @@ Natives provide domain sockets support for `NetServer` and `HttpServer`:
 [source,$lang]
 ----
 {@link examples.CoreExamples#serverWithDomainSockets}
-----`
+----
 
 Or for http:
 [source,$lang]
 ----
-vertx.createHttpServer().requestHandler(req -> {
-  // Handle application
-}).listen(SocketAddress.domainSocketAddress("/var/tmp/http.sock"), ar -> {
-  if (ar.succeeded()) {
-    // Bound to socket
-  } else {
-    ar.cause().printStackTrace();
-  }
-});
-----`
+{@link examples.CoreExamples#httpServerWithDomainSockets}
+----
 
 
 As well as `NetClient`:

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1578,12 +1578,27 @@ Native on BSD gives you extra networking options:
 
 === Domain sockets
 
-Natives provide support domain sockets for `NetServer`:
+Natives provide domain sockets support for `NetServer` and `HttpServer`:
 
 [source,$lang]
 ----
 {@link examples.CoreExamples#serverWithDomainSockets}
+----`
+
+Or for http:
+[source,$lang]
 ----
+vertx.createHttpServer().requestHandler(req -> {
+  // Handle application
+}).listen(SocketAddress.domainSocketAddress("/var/tmp/http.sock"), ar -> {
+  if (ar.succeeded()) {
+    // Bound to socket
+  } else {
+    ar.cause().printStackTrace();
+  }
+});
+----`
+
 
 As well as `NetClient`:
 
@@ -1592,7 +1607,7 @@ As well as `NetClient`:
 {@link examples.CoreExamples#clientWithDomainSockets}
 ----
 
-NOTE: support for `HttpServer` and `HttpClient` can be expected in later versions of Vert.x
+NOTE: support for `HttpClient` can be expected in later versions of Vert.x
 
 == Security notes
 

--- a/src/main/java/examples/CoreExamples.java
+++ b/src/main/java/examples/CoreExamples.java
@@ -379,6 +379,18 @@ public class CoreExamples {
     }).listen(SocketAddress.domainSocketAddress("/var/tmp/myservice.sock"));
   }
 
+  public void httpServerWithDomainSockets(Vertx vertx) {
+    vertx.createHttpServer().requestHandler(req -> {
+      // Handle application
+    }).listen(SocketAddress.domainSocketAddress("/var/tmp/myservice.sock"), ar -> {
+      if (ar.succeeded()) {
+        // Bound to socket
+      } else {
+        ar.cause().printStackTrace();
+      }
+    });
+  }
+
   public void clientWithDomainSockets(Vertx vertx) {
     NetClient netClient = vertx.createNetClient();
 

--- a/src/main/java/io/vertx/core/http/HttpServer.java
+++ b/src/main/java/io/vertx/core/http/HttpServer.java
@@ -19,6 +19,7 @@ import io.vertx.core.Handler;
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
+import io.vertx.core.net.SocketAddress;
 import io.vertx.core.streams.ReadStream;
 
 /**
@@ -137,6 +138,17 @@ public interface HttpServer extends Measured {
   @Fluent
   HttpServer listen(int port, String host, Handler<AsyncResult<HttpServer>> listenHandler);
 
+  /**
+   * Tell the server to start listening on the given address supplying
+   * a handler that will be called when the server is actually
+   * listening (or has failed).
+   *
+   * @param address the address to listen on
+   * @param listenHandler  the listen handler
+   */
+  @Fluent
+  HttpServer listen(SocketAddress address, Handler<AsyncResult<HttpServer>> listenHandler);
+    
   /**
    * Like {@link #listen(int, String)} but the server will listen on host "0.0.0.0" and port specified here ignoring
    * any value in the {@link io.vertx.core.http.HttpServerOptions} that was used when creating the server.


### PR DESCRIPTION
enables DomainSockets support when using native transports (BSD &
Linux).

Signed-off-by: Thomas Cataldo <thomas.cataldo@blue-mind.net>