### PR TITLE
Decouple the FileResolver from a Vertx instance - fixes #2428

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1137,7 +1137,7 @@ Set to true to enabled network activity logging: Netty's pipeline is configured 
 +++
 |[[maxChunkSize]]`maxChunkSize`|`Number (int)`|
 +++
-Set the maximum HTTP chunk size
+Set the maximum HTTP chunk size that link will receive
 +++
 |[[maxHeaderSize]]`maxHeaderSize`|`Number (int)`|
 +++

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -21,7 +21,7 @@ import io.vertx.core.spi.cluster.ClusterManager;
 
 import java.util.Objects;
 
-import static io.vertx.core.impl.FileResolver.DISABLE_FILE_CACHING_PROP_NAME;
+import static io.vertx.core.file.impl.FileResolver.DISABLE_FILE_CACHING_PROP_NAME;
 
 /**
  * Instances of this class are used to configure {@link io.vertx.core.Vertx} instances.

--- a/src/main/java/io/vertx/core/file/impl/FileResolver.java
+++ b/src/main/java/io/vertx/core/file/impl/FileResolver.java
@@ -9,14 +9,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
  */
 
-package io.vertx.core.impl;
+package io.vertx.core.file.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.file.impl.FileSystemImpl;
 
 import java.io.Closeable;
 import java.io.File;
@@ -64,18 +61,16 @@ public class FileResolver {
   private static final String JAR_URL_SEP = "!/";
   private static final Pattern JAR_URL_SEP_PATTERN = Pattern.compile(JAR_URL_SEP);
 
-  private final Vertx vertx;
   private final File cwd;
   private File cacheDir;
   private Thread shutdownHook;
   private final boolean enableCaching;
 
-  public FileResolver(Vertx vertx) {
-    this(vertx, VertxOptions.DEFAULT_FILE_CACHING_ENABLED);
+  public FileResolver() {
+    this(VertxOptions.DEFAULT_FILE_CACHING_ENABLED);
   }
 
-  public FileResolver(Vertx vertx, boolean enableCaching) {
-    this.vertx = vertx;
+  public FileResolver(boolean enableCaching) {
     this.enableCaching = enableCaching;
     String cwdOverride = System.getProperty("vertx.cwd");
     if (cwdOverride != null) {
@@ -88,13 +83,18 @@ public class FileResolver {
     }
   }
 
-  public void close(Handler<AsyncResult<Void>> handler) {
-    deleteCacheDir(handler);
-    if (shutdownHook != null) {
-      // May throw IllegalStateException if called from other shutdown hook so ignore that
-      try {
-        Runtime.getRuntime().removeShutdownHook(shutdownHook);
-      } catch (IllegalStateException ignore) {
+  /**
+   * Close this file resolver, this is a blocking operation.
+   */
+  public void close() throws IOException {
+    deleteCacheDir();
+    synchronized (this) {
+      if (shutdownHook != null) {
+        // May throw IllegalStateException if called from other shutdown hook so ignore that
+        try {
+          Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException ignore) {
+        }
       }
     }
   }
@@ -294,22 +294,29 @@ public class FileResolver {
       throw new IllegalStateException("Failed to create cache dir");
     }
     // Add shutdown hook to delete on exit
-    shutdownHook = new Thread(() -> {
-      CountDownLatch latch = new CountDownLatch(1);
-      deleteCacheDir(ar -> latch.countDown());
-      try {
-        latch.await(10, TimeUnit.SECONDS);
-      } catch (Exception ignore) {
-      }
-    });
-    Runtime.getRuntime().addShutdownHook(shutdownHook);
+    synchronized (this) {
+      shutdownHook = new Thread(() -> {
+        CountDownLatch latch = new CountDownLatch(1);
+        new Thread(() -> {
+          try {
+            deleteCacheDir();
+          } catch (IOException ignore) {
+          }
+          latch.countDown();
+        }).run();
+        try {
+          latch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      });
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+    }
   }
 
-  private void deleteCacheDir(Handler<AsyncResult<Void>> handler) {
+  private void deleteCacheDir() throws IOException {
     if (cacheDir != null && cacheDir.exists()) {
-      vertx.fileSystem().deleteRecursive(cacheDir.getAbsolutePath(), true, handler);
-    } else {
-      handler.handle(Future.succeededFuture());
+      FileSystemImpl.delete(cacheDir.toPath(), true);
     }
   }
 }

--- a/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
+++ b/src/main/java/io/vertx/core/file/impl/FileSystemImpl.java
@@ -616,30 +616,34 @@ public class FileSystemImpl implements FileSystem {
       public Void perform() {
         try {
           Path source = vertx.resolveFile(path).toPath();
-          if (recursive) {
-            Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
-              public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-              }
-              public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
-                if (e == null) {
-                  Files.delete(dir);
-                  return FileVisitResult.CONTINUE;
-                } else {
-                  throw e;
-                }
-              }
-            });
-          } else {
-            Files.delete(source);
-          }
+          delete(source, recursive);
         } catch (IOException e) {
           throw new FileSystemException(e);
         }
         return null;
       }
     };
+  }
+
+  public static void delete(Path path, boolean recursive) throws IOException {
+    if (recursive) {
+      Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+        public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+          if (e == null) {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+          } else {
+            throw e;
+          }
+        }
+      });
+    } else {
+      Files.delete(path);
+    }
   }
 
   private BlockingAction<Void> mkdirInternal(String path, Handler<AsyncResult<Void>> handler) {

--- a/src/test/java/io/vertx/test/core/FileResolverTestBase.java
+++ b/src/test/java/io/vertx/test/core/FileResolverTestBase.java
@@ -17,7 +17,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.impl.FileResolver;
+import io.vertx.core.file.impl.FileResolver;
 import io.vertx.core.impl.VertxInternal;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,16 +43,12 @@ public abstract class FileResolverTestBase extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    resolver = new FileResolver(vertx);
+    resolver = new FileResolver();
   }
 
   @Override
   protected void tearDown() throws Exception {
-    CountDownLatch latch = new CountDownLatch(1);
-    resolver.close(onSuccess(res -> {
-      latch.countDown();
-    }));
-    awaitLatch(latch);
+    resolver.close();
     super.tearDown();
   }
 
@@ -177,19 +173,13 @@ public abstract class FileResolverTestBase extends VertxTestBase {
 
   @Test
   public void testDeleteCacheDir() throws Exception {
-    Vertx vertx2 = vertx();
-    FileResolver resolver2 = new FileResolver(vertx2);
+    FileResolver resolver2 = new FileResolver();
     File file = resolver2.resolveFile(webRoot + "/somefile.html");
     assertTrue(file.exists());
     File cacheDir = file.getParentFile().getParentFile();
     assertTrue(cacheDir.exists());
-    resolver2.close(onSuccess(res -> {
-      assertFalse(cacheDir.exists());
-      vertx2.close(res2 -> {
-        testComplete();
-      });
-    }));
-    await();
+    resolver2.close();
+    assertFalse(cacheDir.exists());
   }
 
   @Test


### PR DESCRIPTION
this will require changes in some projects (like vertx-web or vertx-dropwizard-metrics) that will break upon this change.