### PR TITLE
Vertx http headers refactor

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -82,6 +82,11 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
+  public HttpHeaders add(String name, Object value) {
+    return add((CharSequence) name, (CharSequence) value);
+  }
+
+  @Override
   public VertxHttpHeaders add(final String name, final String strVal) {
     int h = AsciiString.hashCode(name);
     int i = index(h);
@@ -95,6 +100,15 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     int i = index(h);
     for (Object vstr: values) {
       add0(h, i, name, (String) vstr);
+    }
+    return this;
+  }
+
+  @Override
+  public VertxHttpHeaders add(CharSequence name, Iterable values) {
+    String n = name.toString();
+    for (Object seq: values) {
+      add(n, seq.toString());
     }
     return this;
   }
@@ -125,8 +139,23 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
+  public VertxHttpHeaders remove(CharSequence name) {
+    return remove(name.toString());
+  }
+
+  @Override
   public VertxHttpHeaders set(final String name, final String strVal) {
     return set0(name, strVal);
+  }
+
+  @Override
+  public HttpHeaders set(String name, Object value) {
+    return set0(name, (CharSequence) value);
+  }
+
+  @Override
+  public MultiMap set(CharSequence name, CharSequence value) {
+    return set(name.toString(), value.toString());
   }
 
   @Override
@@ -148,11 +177,12 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public VertxHttpHeaders clear() {
-    for (int i = 0; i < entries.length; i ++) {
-      entries[i] = null;
+  public VertxHttpHeaders set(CharSequence name, Iterable values) {
+    remove(name);
+    String n = name.toString();
+    for (Object seq: values) {
+      add(n, seq.toString());
     }
-    head.before = head.after = head;
     return this;
   }
 
@@ -191,13 +221,49 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public String get(final String name) {
+  public boolean contains(String name) {
+    return contains((CharSequence) name);
+  }
+
+  @Override
+  public boolean contains(CharSequence name) {
+    return get0(name) != null;
+  }
+
+  @Override
+  public String get(String name) {
     return get((CharSequence) name);
+  }
+
+
+  @Override
+  public String get(CharSequence name) {
+    Objects.requireNonNull(name, "name");
+    CharSequence ret = get0(name);
+    return ret != null ? ret.toString() : null;
   }
 
   @Override
   public List<String> getAll(final String name) {
     return getAll((CharSequence) name);
+  }
+
+  @Override
+  public List<String> getAll(CharSequence name) {
+    Objects.requireNonNull(name, "name");
+
+    LinkedList<String> values = new LinkedList<>();
+
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        values.addFirst(e.getValue().toString());
+      }
+      e = e.next;
+    }
+    return values;
   }
 
   @Override
@@ -244,11 +310,6 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public boolean contains(String name) {
-    return contains((CharSequence) name);
-  }
-
-  @Override
   public boolean isEmpty() {
     return head == head.after;
   }
@@ -265,62 +326,12 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public String get(CharSequence name) {
-    Objects.requireNonNull(name, "name");
-    CharSequence ret = get0(name);
-    return ret != null ? ret.toString() : null;
-  }
-
-  @Override
-  public List<String> getAll(CharSequence name) {
-    Objects.requireNonNull(name, "name");
-
-    LinkedList<String> values = new LinkedList<>();
-
-    int h = AsciiString.hashCode(name);
-    int i = index(h);
-    VertxHttpHeaders.MapEntry e = entries[i];
-    while (e != null) {
-      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        values.addFirst(e.getValue().toString());
-      }
-      e = e.next;
+  public VertxHttpHeaders clear() {
+    for (int i = 0; i < entries.length; i ++) {
+      entries[i] = null;
     }
-    return values;
-  }
-
-  @Override
-  public boolean contains(CharSequence name) {
-    return get0(name) != null;
-  }
-
-  @Override
-  public VertxHttpHeaders add(CharSequence name, Iterable values) {
-    String n = name.toString();
-    for (Object seq: values) {
-      add(n, seq.toString());
-    }
+    head.before = head.after = head;
     return this;
-  }
-
-  @Override
-  public MultiMap set(CharSequence name, CharSequence value) {
-    return set(name.toString(), value.toString());
-  }
-
-  @Override
-  public VertxHttpHeaders set(CharSequence name, Iterable values) {
-    remove(name);
-    String n = name.toString();
-    for (Object seq: values) {
-      add(n, seq.toString());
-    }
-    return this;
-  }
-
-  @Override
-  public VertxHttpHeaders remove(CharSequence name) {
-    return remove(name.toString());
   }
 
   public String toString() {
@@ -379,11 +390,6 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public HttpHeaders add(String name, Object value) {
-    return add((CharSequence) name, (CharSequence) value);
-  }
-
-  @Override
   public HttpHeaders addInt(CharSequence name, int value) {
     throw new UnsupportedOperationException();
   }
@@ -391,11 +397,6 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   @Override
   public HttpHeaders addShort(CharSequence name, short value) {
     throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public HttpHeaders set(String name, Object value) {
-    return set0(name, (CharSequence) value);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -32,7 +32,7 @@ import static io.netty.util.AsciiString.*;
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
-public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
+public final class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
   @Override
   public MultiMap setAll(MultiMap headers) {

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -87,15 +87,12 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public VertxHttpHeaders add(final String name, final String strVal) {
-    int h = AsciiString.hashCode(name);
-    int i = index(h);
-    add0(h, i, name, strVal);
-    return this;
+  public VertxHttpHeaders add(String name, String strVal) {
+    return add((CharSequence) name, strVal);
   }
 
   @Override
-  public VertxHttpHeaders add(String name, Iterable values) {
+  public VertxHttpHeaders add(CharSequence name, Iterable values) {
     int h = AsciiString.hashCode(name);
     int i = index(h);
     for (Object vstr: values) {
@@ -105,32 +102,29 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public VertxHttpHeaders add(CharSequence name, Iterable values) {
-    String n = name.toString();
-    for (Object seq: values) {
-      add(n, seq.toString());
-    }
-    return this;
+  public VertxHttpHeaders add(String name, Iterable values) {
+    return add((CharSequence) name, values);
   }
 
   @Override
   public MultiMap addAll(MultiMap headers) {
-    for (Map.Entry<String, String> entry: headers.entries()) {
-      add(entry.getKey(), entry.getValue());
-    }
-    return this;
+    return addAll(headers.entries());
   }
 
   @Override
   public MultiMap addAll(Map<String, String> map) {
-    for (Map.Entry<String, String> entry: map.entrySet()) {
+    return addAll(map.entrySet());
+  }
+
+  private MultiMap addAll(Iterable<Map.Entry<String, String>> headers) {
+    for (Map.Entry<String, String> entry: headers) {
       add(entry.getKey(), entry.getValue());
     }
     return this;
   }
 
   @Override
-  public VertxHttpHeaders remove(final String name) {
+  public VertxHttpHeaders remove(CharSequence name) {
     Objects.requireNonNull(name, "name");
     int h = AsciiString.hashCode(name);
     int i = index(h);
@@ -139,27 +133,32 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public VertxHttpHeaders remove(CharSequence name) {
-    return remove(name.toString());
+  public VertxHttpHeaders remove(final String name) {
+    return remove((CharSequence) name);
   }
 
   @Override
-  public VertxHttpHeaders set(final String name, final String strVal) {
-    return set0(name, strVal);
+  public VertxHttpHeaders set(CharSequence name, CharSequence value) {
+    return set0(name, value);
   }
 
   @Override
-  public HttpHeaders set(String name, Object value) {
-    return set0(name, (CharSequence) value);
+  public VertxHttpHeaders set(String name, String value) {
+    return set((CharSequence)name, value);
   }
 
   @Override
-  public MultiMap set(CharSequence name, CharSequence value) {
-    return set(name.toString(), value.toString());
+  public VertxHttpHeaders set(String name, Object value) {
+    return set((CharSequence)name, (CharSequence) value);
   }
 
   @Override
-  public VertxHttpHeaders set(final String name, final Iterable values) {
+  public VertxHttpHeaders set(CharSequence name, Object value) {
+    return set(name, (CharSequence)value);
+  }
+
+  @Override
+  public VertxHttpHeaders set(CharSequence name, Iterable values) {
     Objects.requireNonNull(values, "values");
 
     int h = AsciiString.hashCode(name);
@@ -177,30 +176,8 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public VertxHttpHeaders set(CharSequence name, Iterable values) {
-    remove(name);
-    String n = name.toString();
-    for (Object seq: values) {
-      add(n, seq.toString());
-    }
-    return this;
-  }
-
-  @Override
-  public boolean contains(String name, String value, boolean ignoreCase) {
-    int h = AsciiString.hashCode(name);
-    int i = index(h);
-    VertxHttpHeaders.MapEntry e = entries[i];
-    HashingStrategy<CharSequence> strategy = ignoreCase ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER;
-    while (e != null) {
-      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        if (strategy.equals(value, e.getValue())) {
-          return true;
-        }
-      }
-      e = e.next;
-    }
-    return false;
+  public VertxHttpHeaders set(String name, Iterable values) {
+    return set((CharSequence) name, values);
   }
 
   @Override
@@ -221,8 +198,8 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public boolean contains(String name) {
-    return contains((CharSequence) name);
+  public boolean contains(String name, String value, boolean ignoreCase) {
+    return contains((CharSequence) name, value, ignoreCase);
   }
 
   @Override
@@ -231,10 +208,9 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public String get(String name) {
-    return get((CharSequence) name);
+  public boolean contains(String name) {
+    return contains((CharSequence) name);
   }
-
 
   @Override
   public String get(CharSequence name) {
@@ -244,8 +220,8 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   }
 
   @Override
-  public List<String> getAll(final String name) {
-    return getAll((CharSequence) name);
+  public String get(String name) {
+    return get((CharSequence) name);
   }
 
   @Override
@@ -264,6 +240,11 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
       e = e.next;
     }
     return values;
+  }
+
+  @Override
+  public List<String> getAll(String name) {
+    return getAll((CharSequence) name);
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
+++ b/src/main/java/io/vertx/core/http/impl/headers/VertxHttpHeaders.java
@@ -34,14 +34,6 @@ import static io.netty.util.AsciiString.*;
  */
 public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
 
-  private MultiMap set0(Iterable<Map.Entry<String, String>> map) {
-    clear();
-    for (Map.Entry<String, String> entry: map) {
-      add(entry.getKey(), entry.getValue());
-    }
-    return this;
-  }
-
   @Override
   public MultiMap setAll(MultiMap headers) {
     return set0(headers);
@@ -123,17 +115,6 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     return this;
   }
 
-  private void add0(int h, int i, final CharSequence name, final CharSequence value) {
-    // Update the hash table.
-    VertxHttpHeaders.MapEntry e = entries[i];
-    VertxHttpHeaders.MapEntry newEntry;
-    entries[i] = newEntry = new VertxHttpHeaders.MapEntry(h, name, value);
-    newEntry.next = e;
-
-    // Update the linked list.
-    newEntry.addBefore(head);
-  }
-
   @Override
   public VertxHttpHeaders remove(final String name) {
     Objects.requireNonNull(name, "name");
@@ -143,53 +124,9 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     return this;
   }
 
-  private void remove0(int h, int i, CharSequence name) {
-    VertxHttpHeaders.MapEntry e = entries[i];
-    if (e == null) {
-      return;
-    }
-
-    for (;;) {
-      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        e.remove();
-        VertxHttpHeaders.MapEntry next = e.next;
-        if (next != null) {
-          entries[i] = next;
-          e = next;
-        } else {
-          entries[i] = null;
-          return;
-        }
-      } else {
-        break;
-      }
-    }
-
-    for (;;) {
-      VertxHttpHeaders.MapEntry next = e.next;
-      if (next == null) {
-        break;
-      }
-      if (next.hash == h && AsciiString.contentEqualsIgnoreCase(name, next.key)) {
-        e.next = next.next;
-        next.remove();
-      } else {
-        e = next;
-      }
-    }
-  }
-
   @Override
   public VertxHttpHeaders set(final String name, final String strVal) {
     return set0(name, strVal);
-  }
-
-  private VertxHttpHeaders set0(final CharSequence name, final CharSequence strVal) {
-    int h = AsciiString.hashCode(name);
-    int i = index(h);
-    remove0(h, i, name);
-    add0(h, i, name, strVal);
-    return this;
   }
 
   @Override
@@ -256,19 +193,6 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
   @Override
   public String get(final String name) {
     return get((CharSequence) name);
-  }
-
-  private CharSequence get0(CharSequence name) {
-    int h = AsciiString.hashCode(name);
-    int i = index(h);
-    VertxHttpHeaders.MapEntry e = entries[i];
-    while (e != null) {
-      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
-        return e.getValue();
-      }
-      e = e.next;
-    }
-    return null;
   }
 
   @Override
@@ -531,5 +455,81 @@ public class VertxHttpHeaders extends HttpHeaders implements MultiMap {
     public String toString() {
       return getKey() + ": " + getValue();
     }
+  }
+
+  private void remove0(int h, int i, CharSequence name) {
+    VertxHttpHeaders.MapEntry e = entries[i];
+    if (e == null) {
+      return;
+    }
+
+    for (;;) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        e.remove();
+        VertxHttpHeaders.MapEntry next = e.next;
+        if (next != null) {
+          entries[i] = next;
+          e = next;
+        } else {
+          entries[i] = null;
+          return;
+        }
+      } else {
+        break;
+      }
+    }
+
+    for (;;) {
+      VertxHttpHeaders.MapEntry next = e.next;
+      if (next == null) {
+        break;
+      }
+      if (next.hash == h && AsciiString.contentEqualsIgnoreCase(name, next.key)) {
+        e.next = next.next;
+        next.remove();
+      } else {
+        e = next;
+      }
+    }
+  }
+
+  private void add0(int h, int i, final CharSequence name, final CharSequence value) {
+    // Update the hash table.
+    VertxHttpHeaders.MapEntry e = entries[i];
+    VertxHttpHeaders.MapEntry newEntry;
+    entries[i] = newEntry = new VertxHttpHeaders.MapEntry(h, name, value);
+    newEntry.next = e;
+
+    // Update the linked list.
+    newEntry.addBefore(head);
+  }
+
+  private VertxHttpHeaders set0(final CharSequence name, final CharSequence strVal) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    remove0(h, i, name);
+    add0(h, i, name, strVal);
+    return this;
+  }
+
+  private CharSequence get0(CharSequence name) {
+    int h = AsciiString.hashCode(name);
+    int i = index(h);
+    VertxHttpHeaders.MapEntry e = entries[i];
+    while (e != null) {
+      if (e.hash == h && AsciiString.contentEqualsIgnoreCase(name, e.key)) {
+        return e.getValue();
+      }
+      e = e.next;
+    }
+    return null;
+  }
+
+  private MultiMap set0(Iterable<Map.Entry<String, String>> map) {
+    clear();
+    for (Map.Entry<String, String> entry: map) {
+      add(entry.getKey(), entry.getValue());
+    }
+    return this;
   }
 }


### PR DESCRIPTION
Refactor to remove duplicate methods and use the optimal implementation that can possibly uses `AsciiString` optimised headers.