### PR TITLE
Missing @Nullable in AsyncMap, Context, Vertx and WorkerExecutor

### DIFF
--- a/src/main/java/io/vertx/core/Context.java
+++ b/src/main/java/io/vertx/core/Context.java
@@ -116,7 +116,7 @@ public interface Context {
    *                 guarantees
    * @param <T> the type of the result
    */
-  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler);
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
    * Invoke {@link #executeBlocking(Handler, boolean, Handler)} with order = true.
@@ -124,7 +124,7 @@ public interface Context {
    * @param resultHandler  handler that will be called when the blocking code is complete
    * @param <T> the type of the result
    */
-  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> resultHandler);
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
    * If the context is associated with a Verticle deployment, this returns the deployment ID of that deployment.

--- a/src/main/java/io/vertx/core/Vertx.java
+++ b/src/main/java/io/vertx/core/Vertx.java
@@ -12,11 +12,7 @@
 package io.vertx.core;
 
 import io.netty.channel.EventLoopGroup;
-import io.vertx.codegen.annotations.CacheReturn;
-import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
-import io.vertx.codegen.annotations.Nullable;
-import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.annotations.*;
 import io.vertx.core.datagram.DatagramSocket;
 import io.vertx.core.datagram.DatagramSocketOptions;
 import io.vertx.core.dns.DnsClient;
@@ -520,12 +516,12 @@ public interface Vertx extends Measured {
    *                 guarantees
    * @param <T> the type of the result
    */
-  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler);
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
    */
-  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> resultHandler);
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
    * Return the Netty EventLoopGroup used by Vert.x

--- a/src/main/java/io/vertx/core/WorkerExecutor.java
+++ b/src/main/java/io/vertx/core/WorkerExecutor.java
@@ -11,6 +11,7 @@
 
 package io.vertx.core;
 
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.metrics.Measured;
 
@@ -47,12 +48,12 @@ public interface WorkerExecutor extends Measured {
    *                 guarantees
    * @param <T> the type of the result
    */
-  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<T>> resultHandler);
+  <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, boolean ordered, Handler<AsyncResult<@Nullable T>> resultHandler);
 
   /**
    * Like {@link #executeBlocking(Handler, boolean, Handler)} called with ordered = true.
    */
-  default <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<T>> resultHandler) {
+  default <T> void executeBlocking(Handler<Future<T>> blockingCodeHandler, Handler<AsyncResult<@Nullable T>> resultHandler) {
     executeBlocking(blockingCodeHandler, true, resultHandler);
   }
 

--- a/src/main/java/io/vertx/core/shareddata/AsyncMap.java
+++ b/src/main/java/io/vertx/core/shareddata/AsyncMap.java
@@ -12,6 +12,7 @@
 package io.vertx.core.shareddata;
 
 import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.Nullable;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -40,7 +41,7 @@ public interface AsyncMap<K, V> {
    * @param k  the key
    * @param resultHandler - this will be called some time later with the async result.
    */
-  void get(K k, Handler<AsyncResult<V>> resultHandler);
+  void get(K k, Handler<AsyncResult<@Nullable V>> resultHandler);
 
   /**
    * Put a value in the map, asynchronously.
@@ -70,7 +71,7 @@ public interface AsyncMap<K, V> {
    * @param v  the value
    * @param completionHandler  the handler
    */
-  void putIfAbsent(K k, V v, Handler<AsyncResult<V>> completionHandler);
+  void putIfAbsent(K k, V v, Handler<AsyncResult<@Nullable V>> completionHandler);
 
   /**
    * Link {@link #putIfAbsent} but specifying a time to live for the entry. Entry will expire and get evicted
@@ -81,7 +82,7 @@ public interface AsyncMap<K, V> {
    * @param ttl  The time to live (in ms) for the entry
    * @param completionHandler  the handler
    */
-  void putIfAbsent(K k, V v, long ttl, Handler<AsyncResult<V>> completionHandler);
+  void putIfAbsent(K k, V v, long ttl, Handler<AsyncResult<@Nullable V>> completionHandler);
 
   /**
    * Remove a value from the map, asynchronously.
@@ -89,7 +90,7 @@ public interface AsyncMap<K, V> {
    * @param k  the key
    * @param resultHandler - this will be called some time later to signify the value has been removed
    */
-  void remove(K k, Handler<AsyncResult<V>> resultHandler);
+  void remove(K k, Handler<AsyncResult<@Nullable V>> resultHandler);
 
   /**
    * Remove a value from the map, only if entry already exists with same value.
@@ -108,7 +109,7 @@ public interface AsyncMap<K, V> {
    * @param v  the new value
    * @param resultHandler  the result handler will be passed the previous value
    */
-  void replace(K k, V v, Handler<AsyncResult<V>> resultHandler);
+  void replace(K k, V v, Handler<AsyncResult<@Nullable V>> resultHandler);
 
   /**
    * Replace the entry only if it is currently mapped to a specific value

--- a/src/main/java/io/vertx/core/shareddata/AsyncMap.java
+++ b/src/main/java/io/vertx/core/shareddata/AsyncMap.java
@@ -23,14 +23,13 @@ import java.util.Set;
 
 
 /**
- *
  * An asynchronous map.
  * <p>
+ * {@link AsyncMap} does <em>not</em> allow {@code null} to be used as a key or value.
+ *
  * @implSpec Implementations of the interface must handle {@link io.vertx.core.shareddata.impl.ClusterSerializable}
- *           implementing objects.
- *
+ * implementing objects.
  * @author <a href="http://tfox.org">Tim Fox</a>
- *
  */
 @VertxGen
 public interface AsyncMap<K, V> {

--- a/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
+++ b/src/main/java/io/vertx/core/shareddata/impl/SharedDataImpl.java
@@ -221,11 +221,16 @@ public class SharedDataImpl implements SharedData {
 
     @Override
     public void replace(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+      checkType(k);
+      checkType(v);
       delegate.replace(k, v, resultHandler);
     }
 
     @Override
     public void replaceIfPresent(K k, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
+      checkType(k);
+      checkType(oldValue);
+      checkType(newValue);
       delegate.replaceIfPresent(k, oldValue, newValue, resultHandler);
     }
 


### PR DESCRIPTION
Fixes #2434

Improves Vert.x RxJava2 API (returns Maybe instead of Single)

With executeBlocking, the future provided to the blocking handler could be completed with null.

In AsyncMap, there are a few cases (get, remove, replace, putIfAbsent) when the result can be null as well.