### PR TITLE
Use Http2Headers.contains instead of default MultiMap implementation

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/Http2HeadersAdaptor.java
@@ -101,6 +101,11 @@ public class Http2HeadersAdaptor implements MultiMap {
   }
 
   @Override
+  public boolean contains(String name, String value, boolean caseInsensitive) {
+    return headers.contains(toLowerCase(name), value, caseInsensitive);
+  }
+
+  @Override
   public boolean isEmpty() {
     return headers.isEmpty();
   }
@@ -226,6 +231,11 @@ public class Http2HeadersAdaptor implements MultiMap {
   @Override
   public boolean contains(CharSequence name) {
     return headers.contains(toLowerCase(name));
+  }
+
+  @Override
+  public boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
+    return headers.contains(toLowerCase(name), value, caseInsensitive);
   }
 
   @Override


### PR DESCRIPTION
In netty/netty#7633, a method was added to check if a HTTP/2 header is present and has a given value.

Now that Vert.x core requires Netty 4.1.22, we can use it instead of the slower default implementation.

See also #2258