### PR TITLE
Invoke endHandler immediately when a webSocket connection is closed.

### DIFF
--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -424,14 +424,17 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   }
 
   void handleClosed() {
+    Handler<Void> endHandler;
     synchronized (conn) {
       cleanupHandlers();
-      if (endHandler != null) {
-        conn.getContext().runOnContext(endHandler);
-      }
+      endHandler = this.endHandler;
+      Handler<Void> closeHandler = this.closeHandler;
       if (closeHandler != null) {
         conn.getContext().runOnContext(closeHandler);
       }
+    }
+    if (endHandler != null) {
+      endHandler.handle(null);
     }
   }
 


### PR DESCRIPTION
For issue: #2461 
Recreate for pull request: #2462 