### PR TITLE
Add VertxOption to specify worker pool queue capacity

### DIFF
--- a/src/main/generated/io/vertx/core/VertxOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/VertxOptionsConverter.java
@@ -137,6 +137,11 @@ import io.vertx.core.json.JsonArray;
             obj.setWarningExceptionTimeUnit(java.util.concurrent.TimeUnit.valueOf((String)member.getValue()));
           }
           break;
+        case "workerPoolQueueCapacity":
+          if (member.getValue() instanceof Number) {
+            obj.setWorkerPoolQueueCapacity(((Number)member.getValue()).intValue());
+          }
+          break;
         case "workerPoolSize":
           if (member.getValue() instanceof Number) {
             obj.setWorkerPoolSize(((Number)member.getValue()).intValue());
@@ -196,6 +201,7 @@ import io.vertx.core.json.JsonArray;
     if (obj.getWarningExceptionTimeUnit() != null) {
       json.put("warningExceptionTimeUnit", obj.getWarningExceptionTimeUnit().name());
     }
+    json.put("workerPoolQueueCapacity", obj.getWorkerPoolQueueCapacity());
     json.put("workerPoolSize", obj.getWorkerPoolSize());
   }
 }

--- a/src/main/java/io/vertx/core/VertxOptions.java
+++ b/src/main/java/io/vertx/core/VertxOptions.java
@@ -38,6 +38,11 @@ public class VertxOptions {
   public static final int DEFAULT_EVENT_LOOP_POOL_SIZE = 2 * CpuCoreSensor.availableProcessors();
 
   /**
+   * The default capacity for the queue into the worker pool executor service
+   */
+  public static final int DEFAULT_WORKER_POOL_QUEUE_CAPACITY = Integer.MAX_VALUE;
+
+  /**
    * The default number of threads in the worker pool = 20
    */
   public static final int DEFAULT_WORKER_POOL_SIZE = 20;
@@ -151,6 +156,7 @@ public class VertxOptions {
 
   private int eventLoopPoolSize = DEFAULT_EVENT_LOOP_POOL_SIZE;
   private int workerPoolSize = DEFAULT_WORKER_POOL_SIZE;
+  private int workerPoolQueueCapacity = DEFAULT_WORKER_POOL_QUEUE_CAPACITY;
   private int internalBlockingPoolSize = DEFAULT_INTERNAL_BLOCKING_POOL_SIZE;
   private long blockedThreadCheckInterval = DEFAULT_BLOCKED_THREAD_CHECK_INTERVAL;
   private long maxEventLoopExecuteTime = DEFAULT_MAX_EVENT_LOOP_EXECUTE_TIME;
@@ -184,6 +190,7 @@ public class VertxOptions {
   public VertxOptions(VertxOptions other) {
     this.eventLoopPoolSize = other.getEventLoopPoolSize();
     this.workerPoolSize = other.getWorkerPoolSize();
+    this.workerPoolQueueCapacity = other.getWorkerPoolQueueCapacity();
     this.blockedThreadCheckInterval = other.getBlockedThreadCheckInterval();
     this.maxEventLoopExecuteTime = other.getMaxEventLoopExecuteTime();
     this.maxWorkerExecuteTime = other.getMaxWorkerExecuteTime();
@@ -260,6 +267,30 @@ public class VertxOptions {
     this.workerPoolSize = workerPoolSize;
     return this;
   }
+
+  /**
+   * Get the capacity of the queue in front of the worker pool.
+   * Tasks for the worker pool will queue up to this number after which tasks will be rejected.
+   *
+   * @return the capacity of the worker pool queue
+   */
+  public int getWorkerPoolQueueCapacity() {
+    return workerPoolQueueCapacity;
+  }
+
+  /**
+   * Set the capacity of the worker pool used by the Vert.x instance
+   * @param workerPoolQueueCapacity the capacity of the queue
+   * @return a reference to this, so this API can be used fluently
+   */
+  public VertxOptions setWorkerPoolQueueCapacity(int workerPoolQueueCapacity) {
+    if (workerPoolQueueCapacity < 1) {
+      throw new IllegalArgumentException("workerPoolQueueCapacity must be > 0");
+    }
+    this.workerPoolQueueCapacity = workerPoolQueueCapacity;
+    return this;
+  }
+
 
   /**
    * Is the Vert.x instance clustered?
@@ -818,6 +849,7 @@ public class VertxOptions {
 
     if (eventLoopPoolSize != that.eventLoopPoolSize) return false;
     if (workerPoolSize != that.workerPoolSize) return false;
+    if (workerPoolQueueCapacity != that.workerPoolQueueCapacity) return false;
     if (internalBlockingPoolSize != that.internalBlockingPoolSize) return false;
     if (blockedThreadCheckInterval != that.blockedThreadCheckInterval) return false;
     if (blockedThreadCheckIntervalUnit != that.blockedThreadCheckIntervalUnit) return false;
@@ -845,6 +877,7 @@ public class VertxOptions {
   public int hashCode() {
     int result = eventLoopPoolSize;
     result = 31 * result + workerPoolSize;
+    result = 31 * result + workerPoolQueueCapacity;
     result = 31 * result + internalBlockingPoolSize;
     result = 31 * result + (int) (blockedThreadCheckInterval ^ (blockedThreadCheckInterval >>> 32));
     result = 31 * result + (int) (maxEventLoopExecuteTime ^ (maxEventLoopExecuteTime >>> 32));
@@ -871,6 +904,7 @@ public class VertxOptions {
     return "VertxOptions{" +
         "eventLoopPoolSize=" + eventLoopPoolSize +
         ", workerPoolSize=" + workerPoolSize +
+        ", workerPoolQueueCapacity=" + workerPoolQueueCapacity +
         ", internalBlockingPoolSize=" + internalBlockingPoolSize +
         ", blockedThreadCheckIntervalUnit=" + blockedThreadCheckIntervalUnit +
         ", blockedThreadCheckInterval=" + blockedThreadCheckInterval +

--- a/src/main/java/io/vertx/core/impl/VertxImpl.java
+++ b/src/main/java/io/vertx/core/impl/VertxImpl.java
@@ -83,7 +83,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -173,8 +175,9 @@ public class VertxImpl implements VertxInternal, MetricsProvider {
 
     metrics = initialiseMetrics(options);
 
-    ExecutorService workerExec = Executors.newFixedThreadPool(options.getWorkerPoolSize(),
-        new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
+    ExecutorService workerExec = new ThreadPoolExecutor(options.getWorkerPoolSize(), options.getWorkerPoolSize(), 0L, TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<Runnable>(options.getWorkerPoolQueueCapacity()),
+      new VertxThreadFactory("vert.x-worker-thread-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));
     PoolMetrics workerPoolMetrics = metrics != null ? metrics.createPoolMetrics("worker", "vert.x-worker-thread", options.getWorkerPoolSize()) : null;
     ExecutorService internalBlockingExec = Executors.newFixedThreadPool(options.getInternalBlockingPoolSize(),
         new VertxThreadFactory("vert.x-internal-blocking-", checker, true, options.getMaxWorkerExecuteTime(), options.getMaxWorkerExecuteTimeUnit()));

--- a/src/test/java/io/vertx/test/core/VertxOptionsTest.java
+++ b/src/test/java/io/vertx/test/core/VertxOptionsTest.java
@@ -49,6 +49,15 @@ public class VertxOptionsTest extends VertxTestBase {
     } catch (IllegalArgumentException e) {
       // OK
     }
+    rand = TestUtils.randomPositiveInt();
+    assertEquals(options, options.setWorkerPoolQueueCapacity(rand));
+    assertEquals(rand, options.getWorkerPoolQueueCapacity());
+    try {
+      options.setWorkerPoolQueueCapacity(0);
+      fail("Should throw exception");
+    } catch (IllegalArgumentException e) {
+      // OK
+    }
     assertEquals(20, options.getInternalBlockingPoolSize());
     rand = TestUtils.randomPositiveInt();
     assertEquals(options, options.setInternalBlockingPoolSize(rand));
@@ -214,6 +223,7 @@ public class VertxOptionsTest extends VertxTestBase {
     int eventLoopPoolSize = TestUtils.randomPositiveInt();
     int internalBlockingPoolSize = TestUtils.randomPositiveInt();
     int workerPoolSize = TestUtils.randomPositiveInt();
+    int workerPoolQueueCapacity = TestUtils.randomPositiveInt();
     int blockedThreadCheckInterval = TestUtils.randomPositiveInt();
     String clusterHost = TestUtils.randomAlphaString(100);
     String clusterPublicHost = TestUtils.randomAlphaString(100);
@@ -237,6 +247,7 @@ public class VertxOptionsTest extends VertxTestBase {
     options.setEventLoopPoolSize(eventLoopPoolSize);
     options.setInternalBlockingPoolSize(internalBlockingPoolSize);
     options.setWorkerPoolSize(workerPoolSize);
+    options.setWorkerPoolQueueCapacity(workerPoolQueueCapacity);
     options.setBlockedThreadCheckInterval(blockedThreadCheckInterval);
     options.setClusterHost(clusterHost);
     options.setClusterPublicHost(clusterPublicHost);
@@ -265,6 +276,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(eventLoopPoolSize, options.getEventLoopPoolSize());
     assertEquals(internalBlockingPoolSize, options.getInternalBlockingPoolSize());
     assertEquals(workerPoolSize, options.getWorkerPoolSize());
+    assertEquals(workerPoolQueueCapacity, options.getWorkerPoolQueueCapacity());
     assertEquals(blockedThreadCheckInterval, options.getBlockedThreadCheckInterval());
     assertEquals(clusterHost, options.getClusterHost());
     assertEquals(clusterPublicHost, options.getClusterPublicHost());
@@ -290,6 +302,7 @@ public class VertxOptionsTest extends VertxTestBase {
     VertxOptions json = new VertxOptions(new JsonObject());
     assertEquals(def.getEventLoopPoolSize(), json.getEventLoopPoolSize());
     assertEquals(def.getWorkerPoolSize(), json.getWorkerPoolSize());
+    assertEquals(def.getWorkerPoolQueueCapacity(), json.getWorkerPoolQueueCapacity());
     assertEquals(def.isClustered(), json.isClustered());
     assertEquals(def.getClusterHost(), json.getClusterHost());
     assertEquals(def.getClusterPublicHost(), json.getClusterPublicHost());
@@ -322,6 +335,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(2 * Runtime.getRuntime().availableProcessors(), options.getEventLoopPoolSize());
     assertEquals(20, options.getInternalBlockingPoolSize());
     assertEquals(20, options.getWorkerPoolSize());
+    assertEquals(Integer.MAX_VALUE, options.getWorkerPoolQueueCapacity());
     assertEquals(1000, options.getBlockedThreadCheckInterval());
     assertEquals("localhost", options.getClusterHost());
     assertNull(options.getClusterPublicHost());
@@ -342,6 +356,7 @@ public class VertxOptionsTest extends VertxTestBase {
     int eventLoopPoolSize = TestUtils.randomPositiveInt();
     int internalBlockingPoolSize = TestUtils.randomPositiveInt();
     int workerPoolSize = TestUtils.randomPositiveInt();
+    int workerPoolQueueCapacity = TestUtils.randomPositiveInt();
     int blockedThreadCheckInterval = TestUtils.randomPositiveInt();
     String clusterHost = TestUtils.randomAlphaString(100);
     String clusterPublicHost = TestUtils.randomAlphaString(100);
@@ -369,6 +384,7 @@ public class VertxOptionsTest extends VertxTestBase {
         put("eventLoopPoolSize", eventLoopPoolSize).
         put("internalBlockingPoolSize", internalBlockingPoolSize).
         put("workerPoolSize", workerPoolSize).
+        put("workerPoolQueueCapacity", workerPoolQueueCapacity).
         put("blockedThreadCheckInterval", blockedThreadCheckInterval).
         put("clusterHost", clusterHost).
         put("clusterPublicHost", clusterPublicHost).
@@ -399,6 +415,7 @@ public class VertxOptionsTest extends VertxTestBase {
     assertEquals(eventLoopPoolSize, options.getEventLoopPoolSize());
     assertEquals(internalBlockingPoolSize, options.getInternalBlockingPoolSize());
     assertEquals(workerPoolSize, options.getWorkerPoolSize());
+    assertEquals(workerPoolQueueCapacity, options.getWorkerPoolQueueCapacity());
     assertEquals(blockedThreadCheckInterval, options.getBlockedThreadCheckInterval());
     assertEquals(clusterHost, options.getClusterHost());
     assertEquals(null, options.getClusterManager());


### PR DESCRIPTION
Add the ability to set the maximum capacity for the worker pool queue at
which point trying to enqueue additional tasks when its full will result
in a RejectedExecutionException

Previously the capacity of the queue was Integer.MAX_VALUE (unbounded)
which can result in a death-spiral for systems (i.e. http services) that
are processing more requests than they can handle.

For instance, as work tasks begin to queue for the workerPool, clients
that have yet to be serviced start retrying their operations. The queue
then continues to grow with clients continuing to retry their operation.
Death spiral.

Fixes #2465 

Signed-off-by: Farid Zakaria <farid.m.zakaria@gmail.com>