### PR TITLE
Fix BlockedThreadChecker intervals for benchmarks

### DIFF
--- a/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
+++ b/src/test/benchmarks/io/vertx/core/impl/VertxExecutorService.java
@@ -24,6 +24,6 @@ public class VertxExecutorService extends ThreadPoolExecutor {
     super(maxThreads, maxThreads,
         0L, TimeUnit.MILLISECONDS,
         new LinkedBlockingQueue<>(),
-        new VertxThreadFactory(prefix, new BlockedThreadChecker(10000, TimeUnit.NANOSECONDS, 10000, TimeUnit.NANOSECONDS), false, 10000, TimeUnit.NANOSECONDS));
+        new VertxThreadFactory(prefix, new BlockedThreadChecker(10000, TimeUnit.MILLISECONDS, 10000, TimeUnit.MILLISECONDS), false, 10000, TimeUnit.NANOSECONDS));
   }
 }


### PR DESCRIPTION
The following exception is thrown when benchmarks are run:

```
Caused by: java.lang.IllegalArgumentException: Non-positive period.
	at java.base/java.util.Timer.schedule(Timer.java:248)
	at io.vertx.core.impl.BlockedThreadChecker.<init>(BlockedThreadChecker.java:37)
	at io.vertx.core.impl.VertxExecutorService.<init>(VertxExecutorService.java:24)
```

The reason is that when `TimeUnit`s were added (2f61422f1d664e9c5d7f9778badacac36329005f), the values changed from 10000 milliseconds to 10000 nanoseconds (which are less than 1 ms, thus the exception). This PR changes the intervals back to their original values of 10000 ms.
