### PR TITLE
Remove deprecation warnings

### DIFF
--- a/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
+++ b/src/main/java/io/vertx/core/datagram/impl/DatagramSocketImpl.java
@@ -14,11 +14,11 @@ package io.vertx.core.datagram.impl;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.MaxMessagesRecvByteBufAllocator;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.util.NetUtil;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -39,7 +39,10 @@ import io.vertx.core.spi.metrics.NetworkMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.streams.WriteStream;
 
-import java.net.*;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
 import java.util.Objects;
 
 /**
@@ -70,7 +73,8 @@ public class DatagramSocketImpl implements DatagramSocket, MetricsProvider {
       throw new IllegalStateException("Cannot use DatagramSocket in a multi-threaded worker verticle");
     }
     channel.config().setOption(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-    channel.config().setMaxMessagesPerRead(1);
+    MaxMessagesRecvByteBufAllocator bufAllocator = channel.config().getRecvByteBufAllocator();
+    bufAllocator.maxMessagesPerRead(1);
     context.nettyEventLoop().register(channel);
     if (options.getLogActivity()) {
       channel.pipeline().addLast("logging", new LoggingHandler());

--- a/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
+++ b/src/main/java/io/vertx/core/dns/impl/DnsClientImpl.java
@@ -15,6 +15,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
+import io.netty.channel.MaxMessagesRecvByteBufAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
@@ -75,7 +76,7 @@ public final class DnsClientImpl implements DnsClient {
     Objects.requireNonNull(options.getHost(), "no null host accepted");
 
     this.options = new DnsClientOptions(options);
-    
+
     ContextInternal creatingContext = vertx.getContext();
     if (creatingContext != null && creatingContext.isMultiThreadedWorkerContext()) {
       throw new IllegalStateException("Cannot use DnsClient in a multi-threaded worker verticle");
@@ -91,7 +92,8 @@ public final class DnsClientImpl implements DnsClient {
     actualCtx = vertx.getOrCreateContext();
     channel = transport.datagramChannel(this.dnsServer.getAddress() instanceof Inet4Address ? InternetProtocolFamily.IPv4 : InternetProtocolFamily.IPv6);
     channel.config().setOption(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
-    channel.config().setMaxMessagesPerRead(1);
+    MaxMessagesRecvByteBufAllocator bufAllocator = channel.config().getRecvByteBufAllocator();
+    bufAllocator.maxMessagesPerRead(1);
     channel.config().setAllocator(PartialPooledByteBufAllocator.INSTANCE);
     actualCtx.nettyEventLoop().register(channel);
     if (options.getLogActivity()) {

--- a/src/main/java/io/vertx/core/http/impl/AssembledHttpRequest.java
+++ b/src/main/java/io/vertx/core/http/impl/AssembledHttpRequest.java
@@ -92,7 +92,7 @@ class AssembledHttpRequest implements HttpContent, HttpRequest {
 
   @Override
   public HttpMethod getMethod() {
-    return request.getMethod();
+    return request.method();
   }
 
   @Override
@@ -102,7 +102,7 @@ class AssembledHttpRequest implements HttpContent, HttpRequest {
 
   @Override
   public String getUri() {
-    return request.getUri();
+    return request.uri();
   }
 
   @Override
@@ -122,7 +122,7 @@ class AssembledHttpRequest implements HttpContent, HttpRequest {
 
   @Override
   public HttpVersion getProtocolVersion() {
-    return request.getProtocolVersion();
+    return request.protocolVersion();
   }
 
   @Override
@@ -142,7 +142,7 @@ class AssembledHttpRequest implements HttpContent, HttpRequest {
 
   @Override
   public DecoderResult getDecoderResult() {
-    return request.getDecoderResult();
+    return request.decoderResult();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
+++ b/src/main/java/io/vertx/core/http/impl/HeadersAdaptor.java
@@ -122,7 +122,7 @@ public class HeadersAdaptor implements MultiMap {
 
   @Override
   public Iterator<Map.Entry<String, String>> iterator() {
-    return headers.iterator();
+    return headers.iteratorAsString();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xClientConnection.java
@@ -12,17 +12,46 @@
 package io.vertx.core.http.impl;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.*;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DecoderResult;
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.websocketx.*;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import io.netty.util.ReferenceCountUtil;
-import io.vertx.core.*;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebsocketRejectedException;
+import io.vertx.core.http.WebsocketVersion;
 import io.vertx.core.http.impl.pool.ConnectionListener;
 import io.vertx.core.http.impl.ws.WebSocketFrameInternal;
 import io.vertx.core.impl.ContextInternal;
@@ -39,13 +68,7 @@ import java.util.Deque;
 import java.util.Map;
 import java.util.Queue;
 
-import static io.vertx.core.http.HttpHeaders.ACCEPT_ENCODING;
-import static io.vertx.core.http.HttpHeaders.CLOSE;
-import static io.vertx.core.http.HttpHeaders.CONNECTION;
-import static io.vertx.core.http.HttpHeaders.DEFLATE_GZIP;
-import static io.vertx.core.http.HttpHeaders.HOST;
-import static io.vertx.core.http.HttpHeaders.KEEP_ALIVE;
-import static io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING;
+import static io.vertx.core.http.HttpHeaders.*;
 
 /**
  *
@@ -378,10 +401,10 @@ class Http1xClientConnection extends Http1xConnectionBase implements HttpClientC
         HttpVersion protocolVersion = conn.options.getProtocolVersion();
         String requestConnectionHeader = request.headers().get(HttpHeaders.Names.CONNECTION);
         // We don't need to protect against concurrent changes on forceClose as it only goes from false -> true
-        if (HttpHeaders.Values.CLOSE.equalsIgnoreCase(responseConnectionHeader) || HttpHeaders.Values.CLOSE.equalsIgnoreCase(requestConnectionHeader)) {
+        if (HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(responseConnectionHeader) || HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(requestConnectionHeader)) {
           // In all cases, if we have a close connection option then we SHOULD NOT treat the connection as persistent
           close = true;
-        } else if (protocolVersion == HttpVersion.HTTP_1_0 && !HttpHeaders.Values.KEEP_ALIVE.equalsIgnoreCase(responseConnectionHeader)) {
+        } else if (protocolVersion == HttpVersion.HTTP_1_0 && !HttpHeaderValues.KEEP_ALIVE.contentEqualsIgnoreCase(responseConnectionHeader)) {
           // In the HTTP/1.0 case both request/response need a keep-alive connection header the connection to be persistent
           // currently Vertx forces the Connection header if keepalive is enabled for 1.0
           close = true;

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerHandler.java
@@ -25,8 +25,7 @@ import io.vertx.core.net.impl.HandlerHolder;
 import io.vertx.core.net.impl.SSLHelper;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
 
 /**
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
@@ -84,7 +83,7 @@ public class Http1xServerHandler extends VertxHttpHandler<Http1xServerConnection
       return null;
     }
 
-    if (request.getMethod() != HttpMethod.GET) {
+    if (request.method() != HttpMethod.GET) {
       HttpServerImpl.sendError(null, METHOD_NOT_ALLOWED, ch);
       return null;
     }

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -32,14 +32,23 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.codec.http.websocketx.*;
-import io.netty.handler.codec.http2.*;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
+import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http2.DefaultHttp2DataFrame;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
+import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedWriteHandler;
@@ -66,7 +75,15 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.SocketAddress;
-import io.vertx.core.net.impl.*;
+import io.vertx.core.net.impl.AsyncResolveConnectHelper;
+import io.vertx.core.net.impl.ConnectionBase;
+import io.vertx.core.net.impl.HandlerHolder;
+import io.vertx.core.net.impl.HandlerManager;
+import io.vertx.core.net.impl.SSLHelper;
+import io.vertx.core.net.impl.ServerID;
+import io.vertx.core.net.impl.VertxEventLoopGroup;
+import io.vertx.core.net.impl.VertxHandler;
+import io.vertx.core.net.impl.VertxSniHandler;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
@@ -86,7 +103,7 @@ import java.util.stream.Collectors;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
-import static io.vertx.core.spi.metrics.Metrics.METRICS_ENABLED;
+import static io.vertx.core.spi.metrics.Metrics.*;
 
 /**
  * This class is thread-safe
@@ -643,7 +660,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       if (msg instanceof HttpRequest) {
         final HttpRequest request = (HttpRequest) msg;
 
-        if (log.isTraceEnabled()) log.trace("Server received request: " + request.getUri());
+        if (log.isTraceEnabled()) log.trace("Server received request: " + request.uri());
 
         if (request.headers().contains(io.vertx.core.http.HttpHeaders.UPGRADE, io.vertx.core.http.HttpHeaders.WEBSOCKET, true)) {
 
@@ -657,7 +674,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             return;
           }
 
-          if (request.getMethod() != HttpMethod.GET) {
+          if (request.method() != HttpMethod.GET) {
             handshakeErrorStatus = METHOD_NOT_ALLOWED;
             sendError(null, METHOD_NOT_ALLOWED, ch);
             return;
@@ -667,7 +684,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
             if (request instanceof FullHttpRequest) {
               handshake(conn, (FullHttpRequest) request);
             } else {
-              wsRequest = new DefaultFullHttpRequest(request.getProtocolVersion(), request.getMethod(), request.getUri());
+              wsRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri());
               wsRequest.headers().set(request.headers());
             }
           }
@@ -739,9 +756,9 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
 
         URI theURI;
         try {
-          theURI = new URI(request.getUri());
+          theURI = new URI(request.uri());
         } catch (URISyntaxException e2) {
-          throw new IllegalArgumentException("Invalid uri " + request.getUri()); //Should never happen
+          throw new IllegalArgumentException("Invalid uri " + request.uri()); //Should never happen
         }
 
         if (metrics != null) {
@@ -793,9 +810,9 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     }
     if (err != null) {
       resp.content().writeBytes(err.toString().getBytes(CharsetUtil.UTF_8));
-      HttpHeaders.setContentLength(resp, err.length());
+      HttpUtil.setContentLength(resp, err.length());
     } else {
-      HttpHeaders.setContentLength(resp, 0);
+      HttpUtil.setContentLength(resp, 0);
     }
 
     ch.writeAndFlush(resp);
@@ -808,9 +825,9 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
     } else {
       prefix = "wss://";
     }
-    URI uri = new URI(req.getUri());
+    URI uri = new URI(req.uri());
     String path = uri.getRawPath();
-    String loc =  prefix + HttpHeaders.getHost(req) + path;
+    String loc = prefix + req.headers().get(HttpHeaderNames.HOST) + path;
     String query = uri.getRawQuery();
     if (query != null) {
       loc += "?" + query;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerResponseImpl.java
@@ -14,18 +14,21 @@ package io.vertx.core.http.impl;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
-import io.vertx.core.VertxException;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.impl.headers.VertxHttpHeaders;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
@@ -80,7 +83,7 @@ public class HttpServerResponseImpl implements HttpServerResponse {
   HttpServerResponseImpl(final VertxInternal vertx, Http1xServerConnection conn, HttpRequest request) {
     this.vertx = vertx;
     this.conn = conn;
-    this.version = request.getProtocolVersion();
+    this.version = request.protocolVersion();
     this.headers = new VertxHttpHeaders();
     this.status = HttpResponseStatus.OK;
     this.keepAlive = (version == HttpVersion.HTTP_1_1 && !request.headers().contains(io.vertx.core.http.HttpHeaders.CONNECTION, HttpHeaders.CLOSE, true))

--- a/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/VertxHttpHandler.java
@@ -18,7 +18,13 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
-import io.netty.handler.codec.http.websocketx.*;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.vertx.core.http.impl.ws.WebSocketFrameImpl;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.core.net.impl.VertxHandler;
@@ -41,7 +47,7 @@ public abstract class VertxHttpHandler<C extends ConnectionBase> extends VertxHa
         ByteBuf newBuf = safeBuffer(content, allocator);
         if (msg instanceof LastHttpContent) {
           LastHttpContent last = (LastHttpContent) msg;
-          return new AssembledLastHttpContent(newBuf, last.trailingHeaders(), last.getDecoderResult());
+          return new AssembledLastHttpContent(newBuf, last.trailingHeaders(), last.decoderResult());
         } else {
           return new DefaultHttpContent(newBuf);
         }

--- a/src/main/java/io/vertx/core/net/impl/PartialPooledByteBufAllocator.java
+++ b/src/main/java/io/vertx/core/net/impl/PartialPooledByteBufAllocator.java
@@ -162,7 +162,7 @@ public final class PartialPooledByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
-      return ctx.hasAttr(attributeKey);
+      return ctx.channel().hasAttr(attributeKey);
     }
 
     @Override
@@ -376,7 +376,7 @@ public final class PartialPooledByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public <T> Attribute<T> attr(AttributeKey<T> key) {
-      return ctx.attr(key);
+      return ctx.channel().attr(key);
     }
   }
 

--- a/src/test/java/io/vertx/test/core/Http1xTest.java
+++ b/src/test/java/io/vertx/test/core/Http1xTest.java
@@ -12,10 +12,29 @@
 package io.vertx.test.core;
 
 import io.netty.handler.codec.TooLongFrameException;
-import io.vertx.core.*;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.dns.AddressResolverOptions;
-import io.vertx.core.http.*;
+import io.vertx.core.http.ConnectionPoolTooBusyException;
+import io.vertx.core.http.Http2Settings;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.HttpClientRequestImpl;
 import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.impl.ContextInternal;
@@ -44,8 +63,24 @@ import io.vertx.core.streams.Pump;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -915,6 +950,7 @@ public class Http1xTest extends HttpTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testDefaultServerOptionsJson() {
     HttpServerOptions def = new HttpServerOptions();
     HttpServerOptions json = new HttpServerOptions(new JsonObject());

--- a/src/test/java/io/vertx/test/core/NetTest.java
+++ b/src/test/java/io/vertx/test/core/NetTest.java
@@ -41,7 +41,8 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.impl.*;
+import io.vertx.core.impl.ConcurrentHashSet;
+import io.vertx.core.impl.NetSocketInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -678,6 +679,7 @@ public class NetTest extends VertxTestBase {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testDefaultServerOptionsJson() {
     NetServerOptions def = new NetServerOptions();
     NetServerOptions json = new NetServerOptions(new JsonObject());

--- a/src/test/java/io/vertx/test/core/SSLHelperTest.java
+++ b/src/test/java/io/vertx/test/core/SSLHelperTest.java
@@ -54,7 +54,7 @@ public class SSLHelperTest extends VertxTestBase {
 
   @Test
   public void testUseOpenSSLCiphersWhenNotSpecified() throws Exception {
-    Set<String> expected = OpenSsl.availableCipherSuites();
+    Set<String> expected = OpenSsl.availableOpenSslCipherSuites();
     SSLHelper helper = new SSLHelper(
         new HttpClientOptions().setOpenSslEngineOptions(new OpenSSLEngineOptions()),
         Cert.CLIENT_PEM.get(),

--- a/src/test/java/io/vertx/test/core/StarterTest.java
+++ b/src/test/java/io/vertx/test/core/StarterTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@SuppressWarnings("deprecation")
 public class StarterTest extends VertxTestBase {
 
   Vertx vertx;


### PR DESCRIPTION
Removes Netty deprecation warnings mostly.

Does not modify Vert.x' HttpHeaders constants (still mixing lower and upper case letters)