### PR TITLE
Add discriminator to internal eventbus addresses

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/EventBusImpl.java
@@ -407,7 +407,7 @@ public class EventBusImpl implements EventBus, MetricsProvider {
   }
 
   protected String generateReplyAddress() {
-    return Long.toString(replySequence.incrementAndGet());
+    return "__vertx.reply." + Long.toString(replySequence.incrementAndGet());
   }
 
   private <T> HandlerRegistration<T> createReplyHandlerRegistration(MessageImpl message,

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -260,7 +260,7 @@ public class ClusteredEventBus extends EventBusImpl {
   @Override
   protected String generateReplyAddress() {
     // The address is a cryptographically secure id that can't be guessed
-    return UUID.randomUUID().toString();
+    return "__vertx.reply." + UUID.randomUUID().toString();
   }
 
   @Override

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -63,8 +63,8 @@ public abstract class WebSocketImplBase<S extends WebSocketBase> implements WebS
   WebSocketImplBase(VertxInternal vertx, Http1xConnectionBase conn, boolean supportsContinuation,
                               int maxWebSocketFrameSize, int maxWebSocketMessageSize) {
     this.supportsContinuation = supportsContinuation;
-    this.textHandlerID = UUID.randomUUID().toString();
-    this.binaryHandlerID = UUID.randomUUID().toString();
+    this.textHandlerID = "__vertx.ws." + UUID.randomUUID().toString();
+    this.binaryHandlerID = "__vertx.ws." + UUID.randomUUID().toString();
     this.conn = conn;
     this.maxWebSocketFrameSize = maxWebSocketFrameSize;
     this.maxWebSocketMessageSize = maxWebSocketMessageSize;

--- a/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
+++ b/src/main/java/io/vertx/core/net/impl/NetSocketImpl.java
@@ -84,7 +84,7 @@ public class NetSocketImpl extends ConnectionBase implements NetSocketInternal {
                        SSLHelper helper, TCPMetrics metrics) {
     super(vertx, channel, context);
     this.helper = helper;
-    this.writeHandlerID = UUID.randomUUID().toString();
+    this.writeHandlerID = "__vertx.net." + UUID.randomUUID().toString();
     this.remoteAddress = remoteAddress;
     this.metrics = metrics;
   }


### PR DESCRIPTION
Addresses are now like: "__vertx.[net|ws|reply].randomUUID"

Fixes #1240 