### PR TITLE
Added helper method for merging json in object

### DIFF
--- a/src/main/java/io/vertx/core/json/JsonObject.java
+++ b/src/main/java/io/vertx/core/json/JsonObject.java
@@ -15,6 +15,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.Shareable;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
@@ -754,6 +755,22 @@ public class JsonObject implements Iterable<Map.Entry<String, Object>>, ClusterS
           return newVal;
         });
       }
+    }
+    return this;
+  }
+
+  /**
+   * Merge in already created object
+   * Copy properties from json to object
+   *
+   * @param object
+   * @return a reference to this, so the API can be used fluently
+   */
+  public <T> JsonObject mergeIn(T object) {
+    try {
+      Json.mapper.readerForUpdating(object).readValue(this.encode());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
     return this;
   }

--- a/src/test/java/io/vertx/test/core/JsonObjectMergeTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectMergeTest.java
@@ -1,0 +1,44 @@
+package io.vertx.test.core;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author <a href="https://github.com/mystdeim">Roman Novikov</a>
+ */
+public class JsonObjectMergeTest {
+
+  @Test
+  public void testSuccessful() {
+    Sample sample = new Sample();
+    JsonObject json = new JsonObject().put("id", "1").put("name", "Sam");
+
+    json.mergeIn(sample);
+    assertEquals("1", sample.id);
+    assertEquals("Sam", sample.name);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testFailed() {
+    Sample sample = new Sample();
+    JsonObject json = new JsonObject().put("id", "1").put("person", "Sam");
+
+    json.mergeIn(sample);
+  }
+
+  class Sample {
+    private String id;
+    private String name;
+    public Sample() {
+    }
+    public void setId(String id) {
+      this.id = id;
+    }
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+}

--- a/src/test/java/io/vertx/test/core/JsonObjectMergeTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectMergeTest.java
@@ -28,6 +28,9 @@ public class JsonObjectMergeTest {
     json.mergeIn(sample);
   }
 
+  /**
+   * Sample model
+   */
   class Sample {
     private String id;
     private String name;

--- a/src/test/java/io/vertx/test/core/JsonObjectMergeTest.java
+++ b/src/test/java/io/vertx/test/core/JsonObjectMergeTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- *
  * @author <a href="https://github.com/mystdeim">Roman Novikov</a>
  */
 public class JsonObjectMergeTest {


### PR DESCRIPTION
Method mergeIn(T object) can be helpfull when we pass json in the object constructor, for example:

```java
@DataObject
public class Account {

    UUID id;
    String person;

    public Account(JsonObject obj) {
        obj.mergeIn(this);
    }

    public JsonObject toJson() {
        return JsonObject.mapFrom(this);
    }

    //...
}
```