### PR TITLE
Enable websocket compression

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1001,6 +1001,14 @@ Set the trust options in jks format, aka Java truststore
 +++
 Set whether compression is enabled
 +++
+|[[tryWebsocketDeflateFrameCompression]]`tryWebsocketDeflateFrameCompression`|`Boolean`|
++++
+Set option to offer Deflate Frame websocket compression
++++
+|[[tryWebsocketTryPermessageDefalteCompression]]`tryWebsocketTryPermessageDefalteCompression`|`Boolean`|
++++
+Set option to offer Permessage Deflate websocket compression
++++
 |[[useAlpn]]`useAlpn`|`Boolean`|
 +++
 Set the ALPN usage.
@@ -1012,6 +1020,22 @@ Set whether Netty pooled buffers are enabled
 |[[verifyHost]]`verifyHost`|`Boolean`|
 +++
 Set whether hostname verification is enabled
++++
+|[[websocketCompressionAllowClientNoContext]]`websocketCompressionAllowClientNoContext`|`Boolean`|
++++
+Set the websocket compression allow client no context option
++++
+|[[websocketCompressionDeflateUseWebkitName]]`websocketCompressionDeflateUseWebkitName`|`Boolean`|
++++
+Sets the option to use the webkit name with the deflate frame compression
++++
+|[[websocketCompressionLevel]]`websocketCompressionLevel`|`Number (int)`|
++++
+Set websocket compression level
++++
+|[[websocketCompressionRequestServerNoContext]]`websocketCompressionRequestServerNoContext`|`Boolean`|
++++
+Set the websocket compression server no context option
 +++
 |===
 
@@ -1242,6 +1266,30 @@ Set the ALPN usage.
 |[[usePooledBuffers]]`usePooledBuffers`|`Boolean`|
 +++
 Set whether Netty pooled buffers are enabled
++++
+|[[websocketAllowServerNoContext]]`websocketAllowServerNoContext`|`Boolean`|
++++
+Set the WebSocket Allow Server No Context option
++++
+|[[websocketCompressionLevel]]`websocketCompressionLevel`|`Number (int)`|
++++
+Set the WebSocket compression level
++++
+|[[websocketFrameDeflateCompressionSupported]]`websocketFrameDeflateCompressionSupported`|`Boolean`|
++++
+Enable or disable support for WebSocket Defalte Frame compression
++++
+|[[websocketPermessageDeflateCompressionIsSupported]]`websocketPermessageDeflateCompressionIsSupported`|`Boolean`|
++++
+Get whether WebSocket Permessage Deflate compression is supported
++++
+|[[websocketPermessageDeflateCompressionSupported]]`websocketPermessageDeflateCompressionSupported`|`Boolean`|
++++
+Enable or disable support for WebSocket Permessage Deflate compression
++++
+|[[websocketPreferredClientNoContext]]`websocketPreferredClientNoContext`|`Boolean`|
++++
+Set the WebSocket Preferred Client No Context setting
 +++
 |[[websocketSubProtocols]]`websocketSubProtocols`|`String`|
 +++

--- a/src/main/asciidocs/dataobjects.adoc
+++ b/src/main/asciidocs/dataobjects.adoc
@@ -839,6 +839,12 @@ Set the trust options in jks format, aka Java truststore
 |[[tryUseCompression]]`@tryUseCompression`|`Boolean`|+++
 Set whether compression is enabled
 +++
+|[[tryUsePerFrameWebsocketCompression]]`@tryUsePerFrameWebsocketCompression`|`Boolean`|+++
+Set option to offer Deflate Frame websocket compression
++++
+|[[tryUsePerMessageWebsocketCompression]]`@tryUsePerMessageWebsocketCompression`|`Boolean`|+++
+Set option to offer Permessage Deflate websocket compression
++++
 |[[useAlpn]]`@useAlpn`|`Boolean`|+++
 Set the ALPN usage.
 +++
@@ -847,6 +853,15 @@ Set whether Netty pooled buffers are enabled
 +++
 |[[verifyHost]]`@verifyHost`|`Boolean`|+++
 Set whether hostname verification is enabled
++++
+|[[websocketCompressionAllowClientNoContext]]`@websocketCompressionAllowClientNoContext`|`Boolean`|+++
+Set the websocket compression allow client no context option
++++
+|[[websocketCompressionLevel]]`@websocketCompressionLevel`|`Number (int)`|+++
+Set websocket compression level
++++
+|[[websocketCompressionRequestServerNoContext]]`@websocketCompressionRequestServerNoContext`|`Boolean`|+++
+Set the websocket compression server no context option
 +++
 |===
 
@@ -978,6 +993,12 @@ Set the key/cert store options in pem format.
 |[[pemTrustOptions]]`@pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|+++
 Set the trust options in pem format
 +++
+|[[perFrameWebsocketCompressionSupported]]`@perFrameWebsocketCompressionSupported`|`Boolean`|+++
+Enable or disable support for WebSocket Defalte Frame compression
++++
+|[[perMessageWebsocketCompressionSupported]]`@perMessageWebsocketCompressionSupported`|`Boolean`|+++
+Enable or disable support for WebSocket Permessage Deflate compression
++++
 |[[pfxKeyCertOptions]]`@pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|+++
 Set the key/cert options in pfx format.
 +++
@@ -1036,6 +1057,15 @@ Set the ALPN usage.
 +++
 |[[usePooledBuffers]]`@usePooledBuffers`|`Boolean`|+++
 Set whether Netty pooled buffers are enabled
++++
+|[[websocketAllowServerNoContext]]`@websocketAllowServerNoContext`|`Boolean`|+++
+Set the WebSocket Allow Server No Context option
++++
+|[[websocketCompressionLevel]]`@websocketCompressionLevel`|`Number (int)`|+++
+Set the WebSocket compression level
++++
+|[[websocketPreferredClientNoContext]]`@websocketPreferredClientNoContext`|`Boolean`|+++
+Set the WebSocket Preferred Client No Context setting
 +++
 |[[websocketSubProtocols]]`@websocketSubProtocols`|`String`|+++
 Set the websocket subprotocols supported by the server.

--- a/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpClientOptionsConverter.java
@@ -154,9 +154,34 @@ import java.time.format.DateTimeFormatter;
             obj.setTryUseCompression((Boolean)member.getValue());
           }
           break;
+        case "tryUsePerFrameWebsocketCompression":
+          if (member.getValue() instanceof Boolean) {
+            obj.setTryUsePerFrameWebsocketCompression((Boolean)member.getValue());
+          }
+          break;
+        case "tryUsePerMessageWebsocketCompression":
+          if (member.getValue() instanceof Boolean) {
+            obj.setTryUsePerMessageWebsocketCompression((Boolean)member.getValue());
+          }
+          break;
         case "verifyHost":
           if (member.getValue() instanceof Boolean) {
             obj.setVerifyHost((Boolean)member.getValue());
+          }
+          break;
+        case "websocketCompressionAllowClientNoContext":
+          if (member.getValue() instanceof Boolean) {
+            obj.setWebsocketCompressionAllowClientNoContext((Boolean)member.getValue());
+          }
+          break;
+        case "websocketCompressionLevel":
+          if (member.getValue() instanceof Number) {
+            obj.setWebsocketCompressionLevel(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "websocketCompressionRequestServerNoContext":
+          if (member.getValue() instanceof Boolean) {
+            obj.setWebsocketCompressionRequestServerNoContext((Boolean)member.getValue());
           }
           break;
       }
@@ -206,5 +231,7 @@ import java.time.format.DateTimeFormatter;
     json.put("sendUnmaskedFrames", obj.isSendUnmaskedFrames());
     json.put("tryUseCompression", obj.isTryUseCompression());
     json.put("verifyHost", obj.isVerifyHost());
+    json.put("websocketCompressionAllowClientNoContext", obj.getWebsocketCompressionAllowClientNoContext());
+    json.put("websocketCompressionRequestServerNoContext", obj.getWebsocketCompressionRequestServerNoContext());
   }
 }

--- a/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/core/http/HttpServerOptionsConverter.java
@@ -89,6 +89,31 @@ import java.time.format.DateTimeFormatter;
             obj.setMaxWebsocketMessageSize(((Number)member.getValue()).intValue());
           }
           break;
+        case "perFrameWebsocketCompressionSupported":
+          if (member.getValue() instanceof Boolean) {
+            obj.setPerFrameWebsocketCompressionSupported((Boolean)member.getValue());
+          }
+          break;
+        case "perMessageWebsocketCompressionSupported":
+          if (member.getValue() instanceof Boolean) {
+            obj.setPerMessageWebsocketCompressionSupported((Boolean)member.getValue());
+          }
+          break;
+        case "websocketAllowServerNoContext":
+          if (member.getValue() instanceof Boolean) {
+            obj.setWebsocketAllowServerNoContext((Boolean)member.getValue());
+          }
+          break;
+        case "websocketCompressionLevel":
+          if (member.getValue() instanceof Number) {
+            obj.setWebsocketCompressionLevel(((Number)member.getValue()).intValue());
+          }
+          break;
+        case "websocketPreferredClientNoContext":
+          if (member.getValue() instanceof Boolean) {
+            obj.setWebsocketPreferredClientNoContext((Boolean)member.getValue());
+          }
+          break;
         case "websocketSubProtocols":
           if (member.getValue() instanceof String) {
             obj.setWebsocketSubProtocols((String)member.getValue());
@@ -123,6 +148,8 @@ import java.time.format.DateTimeFormatter;
     json.put("maxInitialLineLength", obj.getMaxInitialLineLength());
     json.put("maxWebsocketFrameSize", obj.getMaxWebsocketFrameSize());
     json.put("maxWebsocketMessageSize", obj.getMaxWebsocketMessageSize());
+    json.put("websocketAllowServerNoContext", obj.getWebsocketAllowServerNoContext());
+    json.put("websocketPreferredClientNoContext", obj.getWebsocketPreferredClientNoContext());
     if (obj.getWebsocketSubProtocols() != null) {
       json.put("websocketSubProtocols", obj.getWebsocketSubProtocols());
     }

--- a/src/main/java/io/vertx/core/http/HttpClientOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpClientOptions.java
@@ -163,6 +163,32 @@ public class HttpClientOptions extends ClientOptionsBase {
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
 
   /**
+   * Default offer WebSocket Deflate Frame compression = false
+   */
+  public static final boolean DEFAULT_TRY_USE_WEBSOCKET_DEFLATE_FRAME = false;
+
+  /**
+   * Default offer WebSocket Permessage Deflate Compression = false
+   */
+  public static final boolean DEFAULT_TRY_USE_WEBSOCKET_PERMESSAGE_DEFLATE = false;
+
+  /**
+   * Default WebSocket compression level = 6
+   */
+  public static final int DEFAULT_WEBSOCKET_COMPRESSION_LEVEL = 6;
+
+  /**
+   * Default WebSocket Compression client no context allowance = false
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_CLIENT_NO_CONTEXT = false;
+
+  /**
+   * Default WebSocket Compression server no context allowance = false
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_REQUEST_SERVER_NO_CONTEXT = false;
+
+
+  /**
    * Default pool cleaner period = 1000 ms (1 second)
    */
   public static final int DEFAULT_POOL_CLEANER_PERIOD = 1000;
@@ -196,6 +222,13 @@ public class HttpClientOptions extends ClientOptionsBase {
   private int maxRedirects;
   private boolean forceSni;
   private int decoderInitialBufferSize;
+
+  private boolean websocketTryUseDeflateFrame;
+  private boolean websocketTryUsePermessageDeflate;
+  private int websocketCompressionLevel;
+  private boolean websocketAllowClientNoContext;
+  private boolean websocketRequestServerNoContext;
+
 
   /**
    * Default constructor
@@ -240,6 +273,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     this.forceSni = other.forceSni;
     this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
     this.poolCleanerPeriod = other.getPoolCleanerPeriod();
+    this.websocketTryUseDeflateFrame = other.websocketTryUseDeflateFrame;
+    this.websocketTryUsePermessageDeflate = other.websocketTryUsePermessageDeflate;
+    this.websocketAllowClientNoContext = other.websocketAllowClientNoContext;
+    this.websocketCompressionLevel = other.websocketCompressionLevel;
+    this.websocketRequestServerNoContext = other.websocketRequestServerNoContext;
   }
 
   /**
@@ -292,6 +330,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     maxRedirects = DEFAULT_MAX_REDIRECTS;
     forceSni = DEFAULT_FORCE_SNI;
     decoderInitialBufferSize = DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
+    websocketTryUseDeflateFrame = DEFAULT_TRY_USE_WEBSOCKET_DEFLATE_FRAME;
+    websocketTryUsePermessageDeflate = DEFAULT_TRY_USE_WEBSOCKET_PERMESSAGE_DEFLATE;
+    websocketCompressionLevel = DEFAULT_WEBSOCKET_COMPRESSION_LEVEL;
+    websocketAllowClientNoContext = DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_CLIENT_NO_CONTEXT;
+    websocketRequestServerNoContext = DEFAULT_WEBSOCKET_COMPRESSION_REQUEST_SERVER_NO_CONTEXT;
     poolCleanerPeriod = DEFAULT_POOL_CLEANER_PERIOD;
   }
 
@@ -1048,6 +1091,106 @@ public class HttpClientOptions extends ClientOptionsBase {
   }
 
   /**
+   * Set option to offer Deflate Frame websocket compression
+   * @param tryDeflateFrame
+   * @return  a reference to this, so the API can be used fluently
+   */
+ public HttpClientOptions setTryUsePerFrameWebsocketCompression (boolean tryUsePerFrameWebsocketCompression )
+ {
+	 this.websocketTryUseDeflateFrame = tryUsePerFrameWebsocketCompression;
+	 return this;
+ }
+
+ /**
+  *
+  * @return Whether Deflate Frame websocket compression will be offered
+  */
+ public boolean tryWebsocketDeflateFrameCompression()
+ {
+	 return this.websocketTryUseDeflateFrame;
+ }
+
+/**
+ * Set option to offer Permessage Deflate websocket compression
+ * @param tryPermessageDeflate
+ * @return  a reference to this, so the API can be used fluently
+ */
+ public HttpClientOptions setTryUsePerMessageWebsocketCompression (boolean tryUsePerMessageWebsocketCompression )
+ {
+	 this.websocketTryUsePermessageDeflate = tryUsePerMessageWebsocketCompression;
+	 return this;
+ }
+
+ /**
+  *
+  * @return whether Permessage Deflate websocket compression will be offered
+  */
+ public boolean tryUsePerMessageWebsocketCompression ()
+ {
+	 return this.websocketTryUsePermessageDeflate;
+ }
+
+ /**
+  * Set websocket compression level
+  * @param compressionLevel
+  * @return a reference to this, so the API can be used fluently
+  */
+ public HttpClientOptions setWebsocketCompressionLevel (int websocketCompressionLevel)
+ {
+	 this.websocketCompressionLevel = websocketCompressionLevel;
+	 return this;
+ }
+
+ /**
+  *
+  * @return websocket compression level
+  */
+ public int websocketCompressionLevel()
+ {
+	 return this.websocketCompressionLevel;
+ }
+
+ /**
+  * Set the websocket compression allow client no context option
+  * @param allowClientNoContext
+  * @return a reference to this, so the API can be used fluently
+  */
+ public HttpClientOptions setWebsocketCompressionAllowClientNoContext(boolean allowClientNoContext)
+ {
+	 this.websocketAllowClientNoContext = allowClientNoContext;
+	 return this;
+ }
+
+ /**
+  *
+  * @return the current websocket compression client no context setting
+  */
+ public boolean getWebsocketCompressionAllowClientNoContext()
+ {
+	 return this.websocketAllowClientNoContext;
+ }
+
+ /**
+  * Set the websocket compression server no context option
+  * @param requestServerNoContext
+  * @return a reference to this, so the API can be used fluently
+  */
+ public HttpClientOptions setWebsocketCompressionRequestServerNoContext(boolean requestServerNoContext)
+ {
+	this.websocketRequestServerNoContext = requestServerNoContext;
+	return this;
+ }
+
+ /**
+  *
+  * @return current setting of the websocket compression server no context option
+  */
+ public boolean getWebsocketCompressionRequestServerNoContext()
+ {
+	 return this.websocketRequestServerNoContext;
+ }
+
+  /**
    * @return the initial buffer size for the HTTP decoder
    */
   public int getDecoderInitialBufferSize() { return decoderInitialBufferSize; }
@@ -1115,6 +1258,12 @@ public class HttpClientOptions extends ClientOptionsBase {
     if (http2KeepAliveTimeout != that.http2KeepAliveTimeout) return false;
     if (poolCleanerPeriod != that.poolCleanerPeriod) return false;
 
+    if (websocketTryUseDeflateFrame != that.websocketTryUseDeflateFrame) return false;
+    if (websocketTryUsePermessageDeflate != that.websocketTryUsePermessageDeflate) return false;
+    if (websocketCompressionLevel != that.websocketCompressionLevel) return false;
+    if (websocketAllowClientNoContext != that.websocketAllowClientNoContext) return false;
+    if (websocketRequestServerNoContext != that.websocketRequestServerNoContext) return false;
+
     return true;
   }
 
@@ -1145,6 +1294,11 @@ public class HttpClientOptions extends ClientOptionsBase {
     result = 31 * result + keepAliveTimeout;
     result = 31 * result + http2KeepAliveTimeout;
     result = 31 * result + poolCleanerPeriod;
+    result = 31 * result + (websocketTryUseDeflateFrame ? 1 : 0);
+    result = 31 * result + (websocketTryUsePermessageDeflate ? 1 : 0);
+    result = 31 * result + websocketCompressionLevel;
+    result = 31 * result + (websocketAllowClientNoContext ? 1 : 0);
+    result = 31 * result + (websocketRequestServerNoContext ? 1: 0);
     return result;
   }
 

--- a/src/main/java/io/vertx/core/http/HttpServerOptions.java
+++ b/src/main/java/io/vertx/core/http/HttpServerOptions.java
@@ -104,6 +104,31 @@ public class HttpServerOptions extends NetServerOptions {
    * Default initial buffer size for HttpObjectDecoder = 128 bytes
    */
   public static final int DEFAULT_DECODER_INITIAL_BUFFER_SIZE = 128;
+  
+  /**
+   * Default support for WebSockets deflate frame compression
+   */
+  public static final boolean DEFAULT_WEBSOCKET_SUPPORT_DEFLATE_FRAME_COMPRESSION = true;
+  
+  /**
+   * Default support for WebSockets Permessage Deflate compression
+   */
+  public static final boolean DEFAULT_WEBSOCKET_SUPPORT_PERMESSAGE_DEFLATE_COMPRESSION = true;
+  
+  /**
+   * Default WebSocket compression level
+   */
+  public static final int DEFAULT_WEBSOCKET_COMPRESSION_LEVEL = 6;
+  
+  /**
+   * Default Websocket compression server no context
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_SERVER_NO_CONTEXT = false;
+  
+  /**
+   * Default WebSocket compression client no context
+   */
+  public static final boolean DEFAULT_WEBSOCKET_COMPRESSION_PREFERRED_CLIENT_NO_CONTEXT = false;
 
   private boolean compressionSupported;
   private int compressionLevel;
@@ -120,6 +145,11 @@ public class HttpServerOptions extends NetServerOptions {
   private boolean decompressionSupported;
   private boolean acceptUnmaskedFrames;
   private int decoderInitialBufferSize;
+  private boolean websocketDeflateFrameCompressionSupported;
+  private boolean websocketPermessageDeflateCompressionSupported;
+  private int websocketCompressionLevel;
+  private boolean websocketCompressionAllowServerNoContext;
+  private boolean websocketCompressionPreferredClientNoContext;
 
   /**
    * Default constructor
@@ -152,6 +182,11 @@ public class HttpServerOptions extends NetServerOptions {
     this.decompressionSupported = other.isDecompressionSupported();
     this.acceptUnmaskedFrames = other.isAcceptUnmaskedFrames();
     this.decoderInitialBufferSize = other.getDecoderInitialBufferSize();
+    this.websocketDeflateFrameCompressionSupported = other.websocketDeflateFrameCompressionSupported;
+    this.websocketPermessageDeflateCompressionSupported = other.websocketPermessageDeflateCompressionSupported;
+    this.websocketCompressionLevel = other.websocketCompressionLevel;
+    this.websocketCompressionPreferredClientNoContext = other.websocketCompressionPreferredClientNoContext;
+    this.websocketCompressionAllowServerNoContext = other.websocketCompressionAllowServerNoContext;
   }
 
   /**
@@ -192,6 +227,11 @@ public class HttpServerOptions extends NetServerOptions {
     decompressionSupported = DEFAULT_DECOMPRESSION_SUPPORTED;
     acceptUnmaskedFrames = DEFAULT_ACCEPT_UNMASKED_FRAMES;
     decoderInitialBufferSize = DEFAULT_DECODER_INITIAL_BUFFER_SIZE;
+    websocketDeflateFrameCompressionSupported = DEFAULT_WEBSOCKET_SUPPORT_DEFLATE_FRAME_COMPRESSION;
+    websocketPermessageDeflateCompressionSupported = DEFAULT_WEBSOCKET_SUPPORT_PERMESSAGE_DEFLATE_COMPRESSION;
+    websocketCompressionLevel = DEFAULT_WEBSOCKET_COMPRESSION_LEVEL;
+    websocketCompressionPreferredClientNoContext = DEFAULT_WEBSOCKET_COMPRESSION_PREFERRED_CLIENT_NO_CONTEXT;
+    websocketCompressionAllowServerNoContext = DEFAULT_WEBSOCKET_COMPRESSION_ALLOW_SERVER_NO_CONTEXT;
   }
 
   @Override
@@ -712,6 +752,96 @@ public class HttpServerOptions extends NetServerOptions {
     return this;
   }
 
+  /**
+   * Enable or disable support for WebSocket Defalte Frame compression
+   * @param deflateCompressionSupported
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setPerFrameWebsocketCompressionSupported  (boolean perFrameWebsocketCompressionSupported ) {
+	  this.websocketDeflateFrameCompressionSupported = perFrameWebsocketCompressionSupported;
+	  return this;
+  }
+  
+  /** 
+   * Get whether WebSocket Deflate Frame compression is supported
+   * @return true if the http server will accept Deflate Frame compression 
+   */
+  public boolean perFrameWebsocketCompressionSupported  () {
+	  return this.websocketDeflateFrameCompressionSupported;
+  }
+  
+  /**
+   * Enable or disable support for WebSocket Permessage Deflate compression
+   * @param permessageDeflateSupported
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setPerMessageWebsocketCompressionSupported  (boolean perMessageWebsocketCompressionSupported ) {
+	  this.websocketPermessageDeflateCompressionSupported = perMessageWebsocketCompressionSupported;
+	  return this;
+  }
+  
+  /**
+   * Get whether WebSocket Permessage Deflate compression is supported
+   * @return true if the http server will accept Permessage Deflate compression
+   */
+  public boolean perMessageWebsocketCompressionSupported  () {
+	  return this.websocketPermessageDeflateCompressionSupported;
+  }
+  
+  /**
+   * Set the WebSocket compression level 
+   * @param compressionLevel
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setWebsocketCompressionLevel (int websocketCompressionLevel) {
+	  this.websocketCompressionLevel = compressionLevel;
+	  return this;
+  }
+  
+  /**
+   * Get the WebSocket compression level
+   * @return the current WebSocket compression level
+   */
+  public int websocketCompressionLevel () {
+	  return this.websocketCompressionLevel;
+  }
+  
+  /**
+   * Set the WebSocket Allow Server No Context option
+   * @param allowServerNoContext 
+   * @return  a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setWebsocketAllowServerNoContext (boolean allowServerNoContext) {
+	  this.websocketCompressionAllowServerNoContext = allowServerNoContext;
+	  return this;
+  }
+  
+  /**
+   * Get current setting to allow server no context for WebSocket compression
+   * @return
+   */
+  public boolean getWebsocketAllowServerNoContext () {
+	  return this.websocketCompressionAllowServerNoContext;
+  }
+  
+  /**
+   * Set the WebSocket Preferred Client No Context setting
+   * @param preferredClientNoContext
+   * @return  a reference to this, so the API can be used fluently
+   */
+  public HttpServerOptions setWebsocketPreferredClientNoContext (boolean preferredClientNoContext) {
+	  this.websocketCompressionPreferredClientNoContext = preferredClientNoContext;
+	  return this;
+  }
+  
+  /**
+   * Get the current setting of the WebSocket Compression Preferred Client no Context setting
+   * @return
+   */
+  public boolean getWebsocketPreferredClientNoContext () {
+	  return this.websocketCompressionPreferredClientNoContext;
+  }
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -733,6 +863,11 @@ public class HttpServerOptions extends NetServerOptions {
     if (decompressionSupported != that.decompressionSupported) return false;
     if (acceptUnmaskedFrames != that.acceptUnmaskedFrames) return false;
     if (decoderInitialBufferSize != that.decoderInitialBufferSize) return false;
+    if (websocketDeflateFrameCompressionSupported != that.websocketDeflateFrameCompressionSupported) return false;
+    if (websocketPermessageDeflateCompressionSupported != that.websocketPermessageDeflateCompressionSupported) return false;
+    if (websocketCompressionLevel != that.websocketCompressionLevel) return false;
+    if (websocketCompressionAllowServerNoContext != that.websocketCompressionAllowServerNoContext) return false;
+    if (websocketCompressionPreferredClientNoContext != that.websocketCompressionPreferredClientNoContext) return false;
 
     return !(websocketSubProtocols != null ? !websocketSubProtocols.equals(that.websocketSubProtocols) : that.websocketSubProtocols != null);
 
@@ -755,6 +890,11 @@ public class HttpServerOptions extends NetServerOptions {
     result = 31 * result + (decompressionSupported ? 1 : 0);
     result = 31 * result + (acceptUnmaskedFrames ? 1 : 0);
     result = 31 * result + decoderInitialBufferSize;
+    result = 31 * result + (websocketDeflateFrameCompressionSupported ? 1 : 0);
+    result = 31 * result + (websocketPermessageDeflateCompressionSupported ? 1 : 0);
+    result = 31 * result + websocketCompressionLevel;
+    result = 31 * result + (websocketCompressionAllowServerNoContext ? 1 : 0);
+    result = 31 * result + (websocketCompressionPreferredClientNoContext ? 1 : 0);
     return result;
   }
 }

--- a/src/main/java/io/vertx/core/http/impl/Http1xServerHandler.java
+++ b/src/main/java/io/vertx/core/http/impl/Http1xServerHandler.java
@@ -92,8 +92,11 @@ public class Http1xServerHandler extends VertxHttpHandler<Http1xServerConnection
     try {
 
       WebSocketServerHandshakerFactory factory =
-        new WebSocketServerHandshakerFactory(HttpServerImpl.getWebSocketLocation(ch.pipeline(), request), conn.options.getWebsocketSubProtocols(), false,
+        new WebSocketServerHandshakerFactory(HttpServerImpl.getWebSocketLocation(ch.pipeline(), request),
+          conn.options.getWebsocketSubProtocols(),
+          conn.options.perMessageWebsocketCompressionSupported () || conn.options.perFrameWebsocketCompressionSupported (),
           conn.options.getMaxWebsocketFrameSize(), conn.options.isAcceptUnmaskedFrames());
+
       WebSocketServerHandshaker shake = factory.newHandshaker(request);
 
       if (shake == null) {

--- a/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpClientImpl.java
@@ -11,6 +11,14 @@
 
 package io.vertx.core.http.impl;
 
+import com.sun.scenario.effect.impl.sw.sse.SSEBlend_SRC_OUTPeer;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandshaker;
+import io.vertx.core.Closeable;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.VertxException;
 import io.vertx.core.*;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -38,6 +46,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -1091,7 +1100,6 @@ public class HttpClientImpl implements HttpClient, MetricsProvider {
       if (this.handler == null && handler != null) {
         this.handler = handler;
         checkClosed();
-        ContextInternal context = vertx.getOrCreateContext();
         Handler<Throwable> connectionExceptionHandler;
         if (exceptionHandler == null) {
           connectionExceptionHandler = log::error;

--- a/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
+++ b/src/main/java/io/vertx/core/http/impl/HttpServerImpl.java
@@ -22,6 +22,20 @@ import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.websocketx.*;
 import io.netty.handler.codec.http2.*;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
+import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.WebSocketServerExtensionHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.DeflateFrameServerExtensionHandshaker;
+import io.netty.handler.codec.http.websocketx.extensions.compression.PerMessageDeflateServerExtensionHandshaker;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
@@ -51,12 +65,14 @@ import io.vertx.core.spi.metrics.Metrics;
 import io.vertx.core.spi.metrics.MetricsProvider;
 import io.vertx.core.spi.metrics.VertxMetrics;
 import io.vertx.core.streams.ReadStream;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -93,6 +109,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
   private final HttpStreamHandler<ServerWebSocket> wsStream = new HttpStreamHandler<>();
   private final HttpStreamHandler<HttpServerRequest> requestStream = new HttpStreamHandler<>();
   private Handler<HttpConnection> connectionHandler;
+  private final String subProtocols;
   private String serverOrigin;
 
   private ChannelGroup serverChannelGroup;
@@ -117,6 +134,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       creatingContext.addCloseHook(this);
     }
     this.sslHelper = new SSLHelper(options, options.getKeyCertOptions(), options.getTrustOptions());
+    this.subProtocols = options.getWebsocketSubProtocols();
     this.logEnabled = options.getLogActivity();
   }
 
@@ -430,6 +448,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       // some casting and a header check
       handler = new Http1xServerHandler(sslHelper, options, serverOrigin, holder, metrics);
     } else {
+      initializeWebsocketExtensions (pipeline);
       handler = new ServerHandlerWithWebSockets(sslHelper, options, serverOrigin, holder, metrics);
     }
     handler.addHandler(conn -> {
@@ -439,6 +458,28 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
       connectionMap.remove(pipeline.channel());
     });
     pipeline.addLast("handler", handler);
+
+  }
+
+  void initializeWebsocketExtensions (ChannelPipeline pipeline) {
+	  ArrayList<WebSocketServerExtensionHandshaker> extensionHandshakers = new ArrayList<WebSocketServerExtensionHandshaker>();
+
+	  if (options.perFrameWebsocketCompressionSupported ()) {
+		  extensionHandshakers.add(new DeflateFrameServerExtensionHandshaker(options.websocketCompressionLevel()));
+	  }
+
+	  if (options.perMessageWebsocketCompressionSupported ()) {
+		  extensionHandshakers.add(new PerMessageDeflateServerExtensionHandshaker(options.websocketCompressionLevel(),
+				  ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(), PerMessageDeflateServerExtensionHandshaker.MAX_WINDOW_SIZE,
+				  options.getWebsocketAllowServerNoContext(), options.getWebsocketPreferredClientNoContext()));
+	  }
+
+	  if (!extensionHandshakers.isEmpty()) {
+		  WebSocketServerExtensionHandler extensionHandler = new WebSocketServerExtensionHandler(
+			  extensionHandshakers.toArray(new WebSocketServerExtensionHandshaker[extensionHandshakers.size()]));
+		  pipeline.addLast("websocketExtensionHandler", extensionHandler);
+	  }
+
   }
 
   private void handleHttp1(Channel ch) {
@@ -673,6 +714,7 @@ public class HttpServerImpl implements HttpServer, Closeable, MetricsProvider {
               // Echo back close frame and close the connection once it was written.
               // This is specified in the WebSockets RFC 6455 Section  5.4.1
               CloseWebSocketFrame closeFrame = new CloseWebSocketFrame(wsFrame.closeStatusCode(), wsFrame.closeReason());
+              //TODO check if .replace(wsFrame.getBinaryData()) is really needed
               ch.writeAndFlush(closeFrame).addListener(ChannelFutureListener.CLOSE);
               closeFrameSent = true;
             }

--- a/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
+++ b/src/main/java/io/vertx/core/http/impl/WebSocketImplBase.java
@@ -27,6 +27,7 @@ import io.vertx.core.net.SocketAddress;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**

--- a/src/test/java/io/vertx/test/core/WebsocketTest.java
+++ b/src/test/java/io/vertx/test/core/WebsocketTest.java
@@ -964,6 +964,121 @@ public class WebsocketTest extends VertxTestBase {
     await();
   }
 
+  @Test
+  // Test normal negotiation of websocket compression
+  public void testNormalWSDeflateFrameCompressionNegotiation() throws Exception {
+    String path = "/some/path";
+    Buffer buff = Buffer.buffer("AAA");
+
+    // Server should have basic compression enabled by default,
+    // client needs to ask for it
+    server = vertx.createHttpServer(new HttpServerOptions().setPort(HttpTestBase.DEFAULT_HTTP_PORT))
+        .websocketHandler(ws -> {
+          assertEquals("upgrade", ws.headers().get("Connection"));
+          assertEquals("deflate-frame", ws.headers().get("sec-websocket-extensions"));
+          ws.writeFrame(WebSocketFrame.binaryFrame(buff, true));
+        });
+
+    server.listen(ar -> {
+      assertTrue(ar.succeeded());
+
+      HttpClientOptions options = new HttpClientOptions();
+      options.setTryUsePerFrameWebsocketCompression(true);
+      client = vertx.createHttpClient(options);
+      client.websocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path, ws -> {
+        final Buffer received = Buffer.buffer();
+        ws.handler(data -> {
+          received.appendBuffer(data);
+          if (received.length() == buff.length()) {
+            assertEquals(buff, received);
+            ws.close();
+            testComplete();
+          }
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  // Test normal negotiation of websocket compression
+  public void testNormalWSPermessageDeflateCompressionNegotiation() throws Exception {
+	  String path = "/some/path";
+	  Buffer buff = Buffer.buffer("AAA");
+
+	  // Server should have basic compression enabled by default,
+	  // client needs to ask for it
+	  server = vertx.createHttpServer(new HttpServerOptions().setPort(DEFAULT_HTTP_PORT)).websocketHandler(ws -> {
+		  assertEquals("upgrade", ws.headers().get("Connection"));
+		  assertEquals("permessage-deflate;client_max_window_bits", ws.headers().get("sec-websocket-extensions"));
+		  ws.writeFrame(WebSocketFrame.binaryFrame(buff,  true));
+	  });
+
+	  server.listen(ar -> {
+		  assertTrue(ar.succeeded());
+
+		  HttpClientOptions options = new HttpClientOptions();
+	      options.setTryUsePerMessageWebsocketCompression(true);
+	      client = vertx.createHttpClient(options);
+		  client.websocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path, ws -> {
+			  final Buffer received = Buffer.buffer();
+			  ws.handler(data -> {
+				  received.appendBuffer(data);
+		          if (received.length() == buff.length()) {
+		            assertEquals(buff, received);
+		            ws.close();
+		            testComplete();
+		          }
+			  });
+		  });
+	  });
+	  await();
+  }
+
+  @Test
+  // Test server accepting no compression
+  public void testConnectWithWebsocketComressionDisabled() throws Exception {
+	  String path = "/some/path";
+	  Buffer buff = Buffer.buffer("AAA");
+
+	  // Server should have basic compression enabled by default,
+	  // client needs to ask for it
+	  server = vertx.createHttpServer(new HttpServerOptions()
+			  .setPort(DEFAULT_HTTP_PORT)
+			  .setPerFrameWebsocketCompressionSupported(false)
+			  .setPerMessageWebsocketCompressionSupported(false)
+			  ).websocketHandler(ws -> {
+
+		  assertEquals("upgrade", ws.headers().get("Connection"));
+		  assertNull(ws.headers().get("sec-websocket-extensions"));
+
+		  ws.writeFrame(WebSocketFrame.binaryFrame(buff,  true));
+	  });
+
+
+	  server.listen(ar -> {
+		  assertTrue(ar.succeeded());
+
+		  HttpClientOptions options = new HttpClientOptions();
+
+	      client = vertx.createHttpClient(options);
+
+		  client.websocket(DEFAULT_HTTP_PORT, DEFAULT_HTTP_HOST, path, ws -> {
+
+			  final Buffer received = Buffer.buffer();
+			  ws.handler(data -> {
+				  received.appendBuffer(data);
+		          if (received.length() == buff.length()) {
+		            assertEquals(buff, received);
+		            ws.close();
+		            testComplete();
+		          }
+			  });
+		  });
+	  });
+	  await();
+  }
+
   private void testValidSubProtocol(WebsocketVersion version) throws Exception {
     String path = "/some/path";
     String clientSubProtocols = "clientproto,commonproto";


### PR DESCRIPTION
Server support is enabled by default (but the client must request it).
Client side must be specifically enabled in options.