### PR TITLE
EventBus local only delivery

### DIFF
--- a/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
+++ b/src/main/java/io/vertx/core/eventbus/DeliveryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -37,9 +37,15 @@ public class DeliveryOptions {
    */
   public static final long DEFAULT_TIMEOUT = 30 * 1000;
 
+  /**
+   * Whether the message should be delivered to local consumers only by default = false.
+   */
+  public static final boolean DEFAULT_LOCAL_ONLY = false;
+
   private long timeout = DEFAULT_TIMEOUT;
   private String codecName;
   private MultiMap headers;
+  private boolean localOnly = DEFAULT_LOCAL_ONLY;
 
   /**
    * Default constructor
@@ -56,6 +62,7 @@ public class DeliveryOptions {
     this.timeout = other.getSendTimeout();
     this.codecName = other.getCodecName();
     this.headers = other.getHeaders();
+    this.localOnly = other.localOnly;
   }
 
   /**
@@ -76,6 +83,7 @@ public class DeliveryOptions {
         headers.set(entry.getKey(), (String)entry.getValue());
       }
     }
+    this.localOnly = json.getBoolean("localOnly", DEFAULT_LOCAL_ONLY);
   }
 
   /**
@@ -92,6 +100,7 @@ public class DeliveryOptions {
       headers.entries().forEach(entry -> hJson.put(entry.getKey(), entry.getValue()));
       json.put("headers", hJson);
     }
+    json.put("localOnly", localOnly);
     return json;
   }
 
@@ -187,5 +196,26 @@ public class DeliveryOptions {
     if (headers == null) {
       headers = new CaseInsensitiveHeaders();
     }
+  }
+
+  /**
+   * @return whether the message should be delivered to local consumers only
+   */
+  public boolean isLocalOnly() {
+    return localOnly;
+  }
+
+  /**
+   * Whether a message should be delivered to local consumers only. Defaults to {@code false}.
+   *
+   * <p>
+   * <strong>This option is effective in clustered mode only and does not apply to reply messages</strong>.
+   *
+   * @param localOnly {@code true} to deliver to local consumers only, {@code false} otherwise
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DeliveryOptions setLocalOnly(boolean localOnly) {
+    this.localOnly = localOnly;
+    return this;
   }
 }

--- a/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
+++ b/src/main/java/io/vertx/core/eventbus/impl/clustered/ClusteredEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -11,13 +11,7 @@
 
 package io.vertx.core.eventbus.impl.clustered;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBusOptions;
 import io.vertx.core.eventbus.MessageCodec;
@@ -31,16 +25,7 @@ import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.NetServer;
-import io.vertx.core.net.NetServerOptions;
-import io.vertx.core.net.NetSocket;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
-import io.vertx.core.net.TCPSSLOptions;
-import io.vertx.core.net.TrustOptions;
+import io.vertx.core.net.*;
 import io.vertx.core.net.impl.ServerID;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
@@ -231,29 +216,34 @@ public class ClusteredEventBus extends EventBusImpl {
 
   @Override
   protected <T> void sendOrPub(SendContextImpl<T> sendContext) {
-    String address = sendContext.message.address();
-    Handler<AsyncResult<ChoosableIterable<ClusterNodeInfo>>> resultHandler = asyncResult -> {
-      if (asyncResult.succeeded()) {
-        ChoosableIterable<ClusterNodeInfo> serverIDs = asyncResult.result();
-        if (serverIDs != null && !serverIDs.isEmpty()) {
-          sendToSubs(serverIDs, sendContext);
-        } else {
-          if (metrics != null) {
-            metrics.messageSent(address, !sendContext.message.isSend(), true, false);
-          }
-          deliverMessageLocally(sendContext);
-        }
-      } else {
-        log.error("Failed to send message", asyncResult.cause());
+    if (sendContext.options.isLocalOnly()) {
+      if (metrics != null) {
+        metrics.messageSent(sendContext.message.address(), !sendContext.message.isSend(), true, false);
       }
-    };
-    if (Vertx.currentContext() == null) {
+      deliverMessageLocally(sendContext);
+    } else if (Vertx.currentContext() == null) {
       // Guarantees the order when there is no current context
       sendNoContext.runOnContext(v -> {
-        subs.get(address, resultHandler);
+        subs.get(sendContext.message.address(), ar -> onSubsReceived(ar, sendContext));
       });
     } else {
-      subs.get(address, resultHandler);
+      subs.get(sendContext.message.address(), ar -> onSubsReceived(ar, sendContext));
+    }
+  }
+
+  private <T> void onSubsReceived(AsyncResult<ChoosableIterable<ClusterNodeInfo>> asyncResult, SendContextImpl<T> sendContext) {
+    if (asyncResult.succeeded()) {
+      ChoosableIterable<ClusterNodeInfo> serverIDs = asyncResult.result();
+      if (serverIDs != null && !serverIDs.isEmpty()) {
+        sendToSubs(serverIDs, sendContext);
+      } else {
+        if (metrics != null) {
+          metrics.messageSent(sendContext.message.address(), !sendContext.message.isSend(), true, false);
+        }
+        deliverMessageLocally(sendContext);
+      }
+    } else {
+      log.error("Failed to send message", asyncResult.cause());
     }
   }
 

--- a/src/test/java/io/vertx/core/eventbus/DeliveryOptionsTest.java
+++ b/src/test/java/io/vertx/core/eventbus/DeliveryOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2018 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -14,7 +14,7 @@ package io.vertx.core.eventbus;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Thomas Segismont
@@ -23,17 +23,21 @@ public class DeliveryOptionsTest {
 
   @Test
   public void toJson() throws Exception {
-    JsonObject defaultJson = new JsonObject().put("timeout", DeliveryOptions.DEFAULT_TIMEOUT);
+    JsonObject defaultJson = new JsonObject()
+      .put("timeout", DeliveryOptions.DEFAULT_TIMEOUT)
+      .put("localOnly", DeliveryOptions.DEFAULT_LOCAL_ONLY);
     assertEquals(defaultJson, new DeliveryOptions().toJson());
 
     JsonObject fullJson = new JsonObject()
       .put("timeout", 15000)
+      .put("localOnly", true)
       .put("codecName", "pimpo")
       .put("headers", new JsonObject().put("marseille", "om").put("lyon", "ol").put("amsterdam", "ajax"));
 
     assertEquals(fullJson,
       new DeliveryOptions()
         .setSendTimeout(15000)
+        .setLocalOnly(true)
         .setCodecName("pimpo")
         .addHeader("marseille", "om").addHeader("lyon", "ol").addHeader("amsterdam", "ajax")
         .toJson());


### PR DESCRIPTION
When deploying verticles across the cluster, it can be useful to force delivery to a local consumer.

For example, you might deploy audit verticles on all nodes, with local consumers only.
Forcing local delivery avoids paying the price of a cluster manager lookup.

This fixes #1764