### PR TITLE
Add missing @Fluent annotations to HttpServerResponse methods

### DIFF
--- a/src/main/java/io/vertx/core/http/HttpServerResponse.java
+++ b/src/main/java/io/vertx/core/http/HttpServerResponse.java
@@ -400,11 +400,13 @@ public interface HttpServerResponse extends WriteStream<Buffer> {
   /**
    * Like {@link #push(HttpMethod, String, String, MultiMap, Handler)} with no headers.
    */
+  @Fluent
   HttpServerResponse push(HttpMethod method, String host, String path, Handler<AsyncResult<HttpServerResponse>> handler);
 
   /**
    * Like {@link #push(HttpMethod, String, String, MultiMap, Handler)} with the host copied from the current request.
    */
+  @Fluent
   HttpServerResponse push(HttpMethod method, String path, MultiMap headers, Handler<AsyncResult<HttpServerResponse>> handler);
 
   /**


### PR DESCRIPTION
Adds missing fluent annotations to some methods in HttpServerResponse. It seems like without these the methods have `MethodKind.OTHER` when they are processed by vertx-codegen due to the condition [here](https://github.com/vert-x3/vertx-codegen/blob/master/src/main/java/io/vertx/codegen/ClassModel.java#L868).